### PR TITLE
Add instructions://system MCP resource

### DIFF
--- a/server.py
+++ b/server.py
@@ -90,6 +90,10 @@ if CATALOG_RAW:
         clean_key = re.sub(r'[\*\d\.]', '', header).strip().lower().split('(')[0].strip().replace(' ', '_')
         DATA_CATALOG[clean_key] = header + "\n" + body.strip()
 
+@mcp.resource("instructions://system")
+def system_instructions() -> str:
+    return ROLE_RAW
+
 @mcp.resource("catalog://list")
 def list_datasets() -> str:
     return CATALOG_RAW


### PR DESCRIPTION
## Summary
- Registers `instructions://system` resource in `server.py` to expose `assistant-role.md` contents to MCP clients
- Mirrors the same change from mcp-private-data-server — enables geo-agent (and any MCP client) to read server-provided behavioral guidance into its system prompt
- No `assistant-role.md` file exists yet in this repo; the resource will return empty string until one is created

## Test plan
- [ ] Verify server starts without errors (graceful fallback when assistant-role.md is missing)
- [ ] Once an `assistant-role.md` is added, verify `instructions://system` resource returns its content

🤖 Generated with [Claude Code](https://claude.com/claude-code)