### PR TITLE
Slim geospatial-analyst prompt to role only

### DIFF
--- a/server.py
+++ b/server.py
@@ -90,10 +90,6 @@ if CATALOG_RAW:
         clean_key = re.sub(r'[\*\d\.]', '', header).strip().lower().split('(')[0].strip().replace(' ', '_')
         DATA_CATALOG[clean_key] = header + "\n" + body.strip()
 
-@mcp.resource("instructions://system")
-def system_instructions() -> str:
-    return ROLE_RAW
-
 @mcp.resource("catalog://list")
 def list_datasets() -> str:
     return CATALOG_RAW
@@ -110,13 +106,7 @@ def get_dataset_details(name: str) -> str:
 # -------------------------------------------------------------------------
 @mcp.prompt("geospatial-analyst")
 def analyst_persona() -> str:
-    return f"""
-    {ROLE_RAW}
-    DATASETS:
-    {CATALOG_RAW}
-    RULES:
-    {OPTIM_RAW}
-    """
+    return ROLE_RAW
 
 # -------------------------------------------------------------------------
 # 7. TOOL DEFINITION & MANUAL REGISTRATION


### PR DESCRIPTION
## Summary
- `geospatial-analyst` prompt now returns only `ROLE_RAW` (assistant-role.md)
- Previously bundled role + full catalog + optimization rules, duplicating content already in the tool description
- Mirrors the same change in mcp-private-data-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)