### PR TITLE
Add R & Python examples and programmatic access docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -17,6 +17,7 @@ export default {
           { text: 'Quick Start', link: '/guide/quickstart' },
           { text: 'Available Datasets', link: '/guide/datasets' },
           { text: 'Private Data Access', link: '/guide/private-data' },
+          { text: 'Programmatic Access (R & Python)', link: '/guide/programmatic-access' },
         ],
       },
       {

--- a/docs/guide/programmatic-access.md
+++ b/docs/guide/programmatic-access.md
@@ -1,0 +1,191 @@
+# Programmatic Access from R & Python
+
+The MCP server speaks [streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http), so you can call its tools from any language — no LLM client required. You can also wire the tools into an LLM agent so the model writes and runs queries on its own.
+
+Full runnable scripts are in the [`examples/`](https://github.com/boettiger-lab/mcp-data-server/tree/main/examples) folder.
+
+## Direct queries (no LLM)
+
+Call the MCP `query` tool directly to run SQL against S3 Parquet files.
+
+### Python
+
+The official `mcp` SDK speaks streamable HTTP natively.
+
+```bash
+pip install mcp
+```
+
+```python
+import asyncio
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+SQL = """
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"""
+
+async def main():
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = await session.list_tools()
+            print("Available tools:", [t.name for t in tools.tools])
+
+            result = await session.call_tool("query", {"sql_query": SQL})
+            for block in result.content:
+                print(block.text)
+
+asyncio.run(main())
+```
+
+### R
+
+There is no R MCP client library yet. The server runs in stateless mode, so you can hit the JSON-RPC endpoint directly with `httr2`. Responses arrive as server-sent events (SSE).
+
+```r
+library(httr2)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+sql <- "
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"
+
+parse_sse <- function(body) {
+  lines <- strsplit(body, "\n", fixed = TRUE)[[1]]
+  data_lines <- sub("^data: ", "", lines[grepl("^data: ", lines)])
+  lapply(data_lines, fromJSON, simplifyVector = FALSE)
+}
+
+mcp_call <- function(method, params, id = 1L) {
+  resp <- request(mcp_url) |>
+    req_headers(
+      Accept = "application/json, text/event-stream",
+      `Content-Type` = "application/json"
+    ) |>
+    req_body_json(list(
+      jsonrpc = "2.0",
+      id = id,
+      method = method,
+      params = params
+    )) |>
+    req_perform()
+
+  body <- resp_body_string(resp)
+  ctype <- resp_content_type(resp)
+  if (grepl("event-stream", ctype, fixed = TRUE)) {
+    msgs <- parse_sse(body)
+    msgs[[length(msgs)]]
+  } else {
+    fromJSON(body, simplifyVector = FALSE)
+  }
+}
+
+resp <- mcp_call("tools/call", list(
+  name = "query",
+  arguments = list(sql_query = sql)
+))
+
+for (block in resp$result$content) {
+  cat(block$text, "\n")
+}
+```
+
+## LLM tool use
+
+Let the model discover datasets, write SQL, and interpret results autonomously. The MCP tools (`browse_stac_catalog`, `get_stac_details`, `query`) are registered as callable tools so the model decides when and how to use them.
+
+Both examples below use `ChatOpenAI` / `chat_openai()` and work with any OpenAI-compatible endpoint. Set `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL` in your environment.
+
+### Python — LangChain + LangGraph
+
+```bash
+pip install langchain-mcp-adapters langchain-openai langgraph
+```
+
+```python
+import asyncio
+import os
+from langchain_openai import ChatOpenAI
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+async def main():
+    client = MultiServerMCPClient({
+        "duckdb-geo": {
+            "url": MCP_URL,
+            "transport": "streamable_http",
+        }
+    })
+    tools = await client.get_tools()
+
+    model = ChatOpenAI(
+        model=os.environ.get("MODEL", "gpt-4o"),
+        max_tokens=4096,
+    )
+    agent = create_react_agent(model, tools)
+
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user",
+                       "content": "What fraction of Australia is protected area?"}]}
+    )
+    print(result["messages"][-1].content)
+
+asyncio.run(main())
+```
+
+### R — ellmer + mcptools
+
+[`mcptools`](https://github.com/tidyverse/mcptools) is an MCP client for R that plugs MCP tools into `ellmer` chats. It speaks stdio, so we bridge to the remote HTTP server with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (requires Node.js on PATH).
+
+```r
+library(mcptools)
+library(ellmer)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+# Build a config pointing mcptools at the remote server via mcp-remote.
+config_file <- tempfile(fileext = ".json")
+write_json(
+  list(mcpServers = list(
+    `duckdb-geo` = list(
+      command = "npx",
+      args = list("-y", "mcp-remote", mcp_url)
+    )
+  )),
+  config_file,
+  auto_unbox = TRUE, pretty = TRUE
+)
+
+# Fetch MCP tools as ellmer-compatible tool definitions.
+tools <- mcp_tools(config = config_file)
+
+# Create a chat session and register the tools.
+chat <- chat_openai(
+  model = Sys.getenv("MODEL", "gpt-4o"),
+  echo = "output"
+)
+chat$set_tools(tools)
+
+chat$chat("What fraction of Australia is protected area?")
+```
+
+::: tip
+You can use the same pattern to talk to a local dev server at `http://localhost:8000/mcp` — just change the URL.
+:::

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+Four small scripts showing two ways to talk to the duckdb-geo MCP server:
+
+| File | What it does |
+|---|---|
+| [query.py](query.py) | Direct MCP `query` tool call from Python (no LLM) |
+| [query.R](query.R) | Direct MCP `query` tool call from R via JSON-RPC over HTTP |
+| [agent_langchain.py](agent_langchain.py) | LangGraph ReAct agent that calls MCP tools via tool use |
+| [agent_ellmer.R](agent_ellmer.R) | ellmer chat that calls MCP tools via tool use |
+
+All scripts target the public endpoint `https://duckdb-mcp.nrp-nautilus.io/mcp`.
+The agent examples use `langchain-openai` / `ellmer::chat_openai()` so they work with any OpenAI-compatible endpoint — set `OPENAI_API_KEY` (and optionally `OPENAI_BASE_URL` and `MODEL`) in your environment. The R agent example also requires Node.js (for `npx mcp-remote`).

--- a/examples/agent_ellmer.R
+++ b/examples/agent_ellmer.R
@@ -1,0 +1,56 @@
+# ellmer + mcptools example: let an LLM decide when to call the duckdb-geo
+# MCP tools.
+#
+# mcptools is an MCP *client* for R that plugs MCP tools into ellmer chats.
+# It only speaks stdio, so we bridge to the remote HTTP server through
+# `mcp-remote` (an npx-based stdio <-> HTTP proxy).
+#
+# Requirements:
+#   - Node.js / npx on PATH (npx fetches mcp-remote on first use)
+#   - install.packages(c("ellmer", "mcptools"))
+#
+# Set:
+#   export OPENAI_API_KEY=...            # or any OpenAI-compatible key
+#   export OPENAI_BASE_URL=...           # optional, defaults to OpenAI
+#
+# Run:
+#   Rscript agent_ellmer.R
+
+library(mcptools)
+library(ellmer)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+# Build a Claude-Desktop-style config for mcptools.
+# mcp-remote bridges stdio <-> streamable-HTTP so mcptools can connect
+# to the remote MCP server.
+config_file <- tempfile(fileext = ".json")
+write_json(
+  list(
+    mcpServers = list(
+      `duckdb-geo` = list(
+        command = "npx",
+        args = list("-y", "mcp-remote", mcp_url)
+      )
+    )
+  ),
+  config_file,
+  auto_unbox = TRUE,
+  pretty = TRUE
+)
+
+# Fetch the remote server's tools as ellmer-compatible tool definitions.
+tools <- mcp_tools(config = config_file)
+cat("Available tools:", vapply(tools, \(t) t@name, character(1)), "\n")
+
+# Create a chat session with any OpenAI-compatible model.
+chat <- chat_openai(
+  model = Sys.getenv("MODEL", "gpt-4o"),
+  echo = "output"
+)
+chat$set_tools(tools)
+
+# Ask a question — the model will call browse_stac_catalog, get_stac_details,
+# and query as needed.
+chat$chat("What fraction of Australia is protected area?")

--- a/examples/agent_langchain.py
+++ b/examples/agent_langchain.py
@@ -1,0 +1,53 @@
+"""
+LangChain example: let an LLM decide when to call the duckdb-geo MCP tools.
+
+Uses langchain-mcp-adapters to expose every MCP tool to a LangGraph ReAct
+agent. The model picks the tool, generates SQL, and summarises the result.
+
+Install:
+    pip install langchain-mcp-adapters langchain-openai langgraph
+
+Set:
+    export OPENAI_API_KEY=...            # or use any OpenAI-compatible endpoint
+    export OPENAI_BASE_URL=...           # optional, defaults to OpenAI
+
+Run:
+    python agent_langchain.py
+"""
+
+import asyncio
+import os
+
+from langchain_openai import ChatOpenAI
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+QUESTION = "What fraction of Australia is protected area?"
+
+
+async def main() -> None:
+    client = MultiServerMCPClient(
+        {
+            "duckdb-geo": {
+                "url": MCP_URL,
+                "transport": "streamable_http",
+            }
+        }
+    )
+    tools = await client.get_tools()
+
+    model = ChatOpenAI(
+        model=os.environ.get("MODEL", "gpt-4o"),
+        max_tokens=4096,
+    )
+    agent = create_react_agent(model, tools)
+
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": QUESTION}]}
+    )
+    print(result["messages"][-1].content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/query.R
+++ b/examples/query.R
@@ -1,0 +1,67 @@
+# Minimal R example: call the duckdb-geo MCP `query` tool directly.
+#
+# No LLM involved -- this just speaks MCP over streamable HTTP and runs SQL.
+# There is no R MCP client library, so we hit the JSON-RPC endpoint via httr2.
+# The server runs in stateless mode, so no session handshake is required.
+#
+# Install:
+#   install.packages(c("httr2", "jsonlite"))
+#
+# Run:
+#   Rscript query.R
+
+library(httr2)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+sql <- "
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"
+
+# MCP streamable-HTTP responses come back as text/event-stream (SSE) by
+# default. Each event is a `data: {...}\n\n` block whose payload is JSON-RPC.
+parse_sse <- function(body) {
+  lines <- strsplit(body, "\n", fixed = TRUE)[[1]]
+  data_lines <- sub("^data: ", "", lines[grepl("^data: ", lines)])
+  lapply(data_lines, fromJSON, simplifyVector = FALSE)
+}
+
+mcp_call <- function(method, params, id = 1L) {
+  resp <- request(mcp_url) |>
+    req_headers(
+      Accept = "application/json, text/event-stream",
+      `Content-Type` = "application/json"
+    ) |>
+    req_body_json(list(
+      jsonrpc = "2.0",
+      id = id,
+      method = method,
+      params = params
+    )) |>
+    req_perform()
+
+  body <- resp_body_string(resp)
+  ctype <- resp_content_type(resp)
+  if (grepl("event-stream", ctype, fixed = TRUE)) {
+    msgs <- parse_sse(body)
+    msgs[[length(msgs)]]            # final message holds the result
+  } else {
+    fromJSON(body, simplifyVector = FALSE)
+  }
+}
+
+# Call the `query` tool.
+resp <- mcp_call("tools/call", list(
+  name = "query",
+  arguments = list(sql_query = sql)
+))
+
+# Each content block has a `text` field; print them all.
+for (block in resp$result$content) {
+  cat(block$text, "\n")
+}

--- a/examples/query.py
+++ b/examples/query.py
@@ -1,0 +1,46 @@
+"""
+Minimal Python example: call the duckdb-geo MCP `query` tool directly.
+
+No LLM involved — this just speaks MCP over streamable HTTP and runs SQL.
+
+Install:
+    pip install mcp
+
+Run:
+    python query.py
+"""
+
+import asyncio
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+SQL = """
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"""
+
+
+async def main() -> None:
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            # List the tools the server exposes.
+            tools = await session.list_tools()
+            print("Available tools:", [t.name for t in tools.tools])
+
+            # Call the `query` tool with a SQL string.
+            result = await session.call_tool("query", {"sql_query": SQL})
+            for block in result.content:
+                # Each content block has a `.text` field for text results.
+                print(block.text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -4,6 +4,14 @@
 
 **H3 hex joins replace geometry functions.** Do NOT use `ST_Intersects`, `ST_Contains`, `ST_Area`, or `ST_Within` — these require scanning full polygon geometries and are orders of magnitude slower. Instead, join datasets on their shared H3 index (`h8`, `h0`) to compute overlaps, areas, and containment. If two datasets use different H3 resolutions, convert with `h3_cell_to_parent()`.
 
+## Resolution Direction
+
+**Higher H3 resolution numbers are finer (smaller cells); lower numbers are coarser (larger cells).** h0 is the coarsest (~1000 km edge length); h15 is the finest. A higher-resolution cell is always a *child* of a lower-resolution cell — never the reverse.
+
+- h8 cells are children of h6 cells, not parents
+- If a dataset is indexed at h6, it has no h8 column and no h8_parent column
+- Always check the dataset schema for available resolution columns before writing a join
+
 ## Key Facts
 
 - Always report **areas** (km², acres, etc.), never raw hex counts
@@ -29,7 +37,34 @@ SELECT APPROX_COUNT_DISTINCT(h5) * 252.9 AS area_km2 FROM ...
 
 ## Joining Different Resolutions
 
-Use `h3_cell_to_parent()` — not `h3_cell_to_children()` — to join datasets at different resolutions. Always convert the **finer** (higher number) resolution to the **coarser** (lower number) resolution:
+**Always join by converting the finer (higher-numbered) dataset to the coarser resolution — never look for child columns on the coarser dataset.**
+
+### Step 1: Check for pre-computed parent columns (preferred)
+
+Many fine-resolution datasets (e.g. GEBCO h8) already carry pre-computed parent columns (`h7`, `h6`, `h5`, ...). Use these directly — they are faster than calling `h3_cell_to_parent()` on every row. Check the schema first:
+
+```sql
+-- Check what resolution columns exist
+DESCRIBE SELECT * FROM read_parquet('<STAC_PATH>') LIMIT 1;
+```
+
+If the finer dataset has the target parent column, use it directly:
+
+```sql
+-- GEBCO (h8-indexed, has h6 column) joined to geomorphology (h6-indexed)
+WITH gebco_by_h6 AS (
+  SELECT h6, h0, AVG(elevation) AS avg_elevation
+  FROM read_parquet('<GEBCO_PATH>')
+  GROUP BY h6, h0
+)
+SELECT s.feature_type, g.avg_elevation
+FROM read_parquet('<GEOMORPHOLOGY_PATH>') s
+JOIN gebco_by_h6 g ON s.h6 = g.h6 AND s.h0 = g.h0
+```
+
+### Step 2: Fall back to h3_cell_to_parent() when no pre-computed column exists
+
+Use `h3_cell_to_parent()` — not `h3_cell_to_children()` — when the pre-computed parent column is absent:
 
 ```sql
 -- dataset_a has h8, dataset_b has h4: convert h8 → h4


### PR DESCRIPTION
## Summary
- Adds `examples/` folder with four scripts: direct MCP queries from Python (`mcp` SDK) and R (`httr2` JSON-RPC), plus LLM tool-use via LangChain/LangGraph and ellmer/mcptools
- Adds a new docs page at `/guide/programmatic-access` covering both patterns with inline code
- All examples use OpenAI-compatible endpoints (works with any provider) and target the public MCP endpoint

## Test plan
- [x] `python examples/query.py` returns results from live endpoint
- [x] `Rscript examples/query.R` returns results from live endpoint
- [x] `npx vitepress build docs` succeeds