### PR TITLE
Dynamic MVT tile endpoint for H3 hex visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,21 @@ Examples:
 
 
 
-### Using Claude Code (Desktop)
+### Using Claude Code (CLI)
+
+Run this command once in your terminal:
+
+```bash
+claude mcp add --transport http duckdb-geo https://duckdb-mcp.nrp-nautilus.io/mcp
+```
+
+To make it available across all your projects, add `--scope user`:
+
+```bash
+claude mcp add --transport http --scope user duckdb-geo https://duckdb-mcp.nrp-nautilus.io/mcp
+```
+
+### Using Claude Desktop
 
 Add to your Claude Desktop configuration file:
 

--- a/assistant-role.md
+++ b/assistant-role.md
@@ -2,3 +2,14 @@ You are a geospatial data analyst with expertise in cloud-native geospatial form
 
 You help users query and analyze geospatial datasets stored as Parquet files on S3 object storage.
 Use the available tools to discover datasets, run SQL queries, and interpret results.
+
+### Dispatch: map-rendering tools
+
+- `query` — for answering in markdown tables (capped at 50 rows). Default.
+- `register_hex_tiles` — when the user wants *hexes on the map*, or the result
+  would be a large (>100k cell) hex layer. Returns a tile URL; the client adds
+  it as a MapLibre vector source.
+
+If the user asks to "show", "render", or "color" hexes on the map, choose
+`register_hex_tiles`. If they ask "what's the value of X at location Y" or
+"top N hexes by Z", use `query`.

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -17,6 +17,7 @@ export default {
           { text: 'Quick Start', link: '/guide/quickstart' },
           { text: 'Available Datasets', link: '/guide/datasets' },
           { text: 'Private Data Access', link: '/guide/private-data' },
+          { text: 'Programmatic Access (R & Python)', link: '/guide/programmatic-access' },
         ],
       },
       {

--- a/docs/guide/programmatic-access.md
+++ b/docs/guide/programmatic-access.md
@@ -1,0 +1,191 @@
+# Programmatic Access from R & Python
+
+The MCP server speaks [streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http), so you can call its tools from any language — no LLM client required. You can also wire the tools into an LLM agent so the model writes and runs queries on its own.
+
+Full runnable scripts are in the [`examples/`](https://github.com/boettiger-lab/mcp-data-server/tree/main/examples) folder.
+
+## Direct queries (no LLM)
+
+Call the MCP `query` tool directly to run SQL against S3 Parquet files.
+
+### Python
+
+The official `mcp` SDK speaks streamable HTTP natively.
+
+```bash
+pip install mcp
+```
+
+```python
+import asyncio
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+SQL = """
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"""
+
+async def main():
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = await session.list_tools()
+            print("Available tools:", [t.name for t in tools.tools])
+
+            result = await session.call_tool("query", {"sql_query": SQL})
+            for block in result.content:
+                print(block.text)
+
+asyncio.run(main())
+```
+
+### R
+
+There is no R MCP client library yet. The server runs in stateless mode, so you can hit the JSON-RPC endpoint directly with `httr2`. Responses arrive as server-sent events (SSE).
+
+```r
+library(httr2)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+sql <- "
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"
+
+parse_sse <- function(body) {
+  lines <- strsplit(body, "\n", fixed = TRUE)[[1]]
+  data_lines <- sub("^data: ", "", lines[grepl("^data: ", lines)])
+  lapply(data_lines, fromJSON, simplifyVector = FALSE)
+}
+
+mcp_call <- function(method, params, id = 1L) {
+  resp <- request(mcp_url) |>
+    req_headers(
+      Accept = "application/json, text/event-stream",
+      `Content-Type` = "application/json"
+    ) |>
+    req_body_json(list(
+      jsonrpc = "2.0",
+      id = id,
+      method = method,
+      params = params
+    )) |>
+    req_perform()
+
+  body <- resp_body_string(resp)
+  ctype <- resp_content_type(resp)
+  if (grepl("event-stream", ctype, fixed = TRUE)) {
+    msgs <- parse_sse(body)
+    msgs[[length(msgs)]]
+  } else {
+    fromJSON(body, simplifyVector = FALSE)
+  }
+}
+
+resp <- mcp_call("tools/call", list(
+  name = "query",
+  arguments = list(sql_query = sql)
+))
+
+for (block in resp$result$content) {
+  cat(block$text, "\n")
+}
+```
+
+## LLM tool use
+
+Let the model discover datasets, write SQL, and interpret results autonomously. The MCP tools (`browse_stac_catalog`, `get_stac_details`, `query`) are registered as callable tools so the model decides when and how to use them.
+
+Both examples below use `ChatOpenAI` / `chat_openai()` and work with any OpenAI-compatible endpoint. Set `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL` in your environment.
+
+### Python — LangChain + LangGraph
+
+```bash
+pip install langchain-mcp-adapters langchain-openai langgraph
+```
+
+```python
+import asyncio
+import os
+from langchain_openai import ChatOpenAI
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+async def main():
+    client = MultiServerMCPClient({
+        "duckdb-geo": {
+            "url": MCP_URL,
+            "transport": "streamable_http",
+        }
+    })
+    tools = await client.get_tools()
+
+    model = ChatOpenAI(
+        model=os.environ.get("MODEL", "gpt-4o"),
+        max_tokens=4096,
+    )
+    agent = create_react_agent(model, tools)
+
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user",
+                       "content": "What fraction of Australia is protected area?"}]}
+    )
+    print(result["messages"][-1].content)
+
+asyncio.run(main())
+```
+
+### R — ellmer + mcptools
+
+[`mcptools`](https://github.com/tidyverse/mcptools) is an MCP client for R that plugs MCP tools into `ellmer` chats. It speaks stdio, so we bridge to the remote HTTP server with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (requires Node.js on PATH).
+
+```r
+library(mcptools)
+library(ellmer)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+# Build a config pointing mcptools at the remote server via mcp-remote.
+config_file <- tempfile(fileext = ".json")
+write_json(
+  list(mcpServers = list(
+    `duckdb-geo` = list(
+      command = "npx",
+      args = list("-y", "mcp-remote", mcp_url)
+    )
+  )),
+  config_file,
+  auto_unbox = TRUE, pretty = TRUE
+)
+
+# Fetch MCP tools as ellmer-compatible tool definitions.
+tools <- mcp_tools(config = config_file)
+
+# Create a chat session and register the tools.
+chat <- chat_openai(
+  model = Sys.getenv("MODEL", "gpt-4o"),
+  echo = "output"
+)
+chat$set_tools(tools)
+
+chat$chat("What fraction of Australia is protected area?")
+```
+
+::: tip
+You can use the same pattern to talk to a local dev server at `http://localhost:8000/mcp` — just change the URL.
+:::

--- a/docs/superpowers/plans/2026-04-15-dynamic-mvt-tile-endpoint.md
+++ b/docs/superpowers/plans/2026-04-15-dynamic-mvt-tile-endpoint.md
@@ -1,0 +1,1454 @@
+# Dynamic MVT Tile Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `/tiles/hex/<name>/{z}/{x}/{y}.pbf` MVT endpoint to the MCP server backed by a content-addressable H3 resolution pyramid stored in S3, plus a `register_hex_tiles` MCP tool that materializes the pyramid from a user SQL query.
+
+**Architecture:** A new `tiles/` Python package holds the tile logic. Registration writes a partitioned parquet pyramid to S3 via a single `COPY ... TO` with `PARTITION_BY (res)`. A persistent per-worker `:memory:` DuckDB connection (initialized at app startup, separate from the per-request isolated connections used by `query`) handles tile requests. Tile URLs are deterministic from input hash; replicas need no coordination.
+
+**Tech Stack:** Python, DuckDB (`spatial`, `h3`, `httpfs` extensions), MCP `FastMCP`, Starlette (already the server framework via `mcp.streamable_http_app()`), `anyio` for thread offload.
+
+**Spec:** `docs/superpowers/specs/2026-04-15-dynamic-mvt-tile-endpoint-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `tiles/__init__.py` — package marker, re-exports public API
+- `tiles/tile_math.py` — pure helpers: XYZ→lng/lat bounds, zoom→resolution, content hash
+- `tiles/pyramid.py` — pyramid SQL generation + `register_hex_tiles` implementation
+- `tiles/db.py` — persistent DuckDB connection factory + Starlette lifespan
+- `tiles/endpoint.py` — Starlette route handler `serve_tile(request) -> Response`
+- `tests/test_tile_math.py` — pure-function tests
+- `tests/test_tile_pyramid.py` — pyramid SQL + local-bucket end-to-end
+- `tests/test_tile_endpoint.py` — HTTP-level tests with `starlette.testclient`
+
+**Modified files:**
+- `server.py` — import `tiles` package, register `register_hex_tiles` as MCP tool, mount `/tiles/...` route on the Starlette app, wire up lifespan
+- `requirements.txt` — add `mapbox-vector-tile` (test-only decoder) — or skip and assert raw bytes only
+- `h3-guide.md` — add a section pointing agents at `register_hex_tiles` for large hex results
+- `assistant-role.md` — add dispatch hint for when to use `register_hex_tiles`
+
+**Configuration:**
+- Env var `TILE_BUCKET_BASE` (default `s3://public-output`). Tests set it to `file:///tmp/test-tiles-<pid>/` to avoid needing S3 credentials.
+- Env var `MCP_PUBLIC_BASE_URL` (default `https://duckdb-mcp.nrp-nautilus.io`) used to construct the returned `tile_url_template`.
+
+---
+
+### Task 1: Verify DuckDB ST_AsMVT API and capture concrete SQL
+
+The spec notes ST_AsMVT semantics as an "open item to resolve during implementation." This task pins it down via a throwaway test so later tasks can reference the exact signatures.
+
+**Files:**
+- Create: `tests/test_tile_math.py` (placeholder — fleshed out in Task 2)
+
+- [ ] **Step 1: Run a one-off probe in Python REPL (document findings in this task's commit message)**
+
+```bash
+python3 -c "
+import duckdb
+c = duckdb.connect(':memory:')
+c.sql('INSTALL spatial; LOAD spatial; INSTALL h3 FROM community; LOAD h3')
+# Probe ST_AsMVTGeom / ST_AsMVT signatures.
+print(c.sql(\"SELECT function_name, parameters FROM duckdb_functions() WHERE function_name ILIKE 'st_asmvt%'\").fetchall())
+# Probe h3 cells-covering helper.
+print(c.sql(\"SELECT function_name FROM duckdb_functions() WHERE function_name ILIKE 'h3_polygon%' OR function_name ILIKE 'h3_cells%'\").fetchall())
+"
+```
+
+Expected output contains functions named `st_asmvt`, `st_asmvtgeom`, plus an `h3_polygon_wkt_to_cells` (or similarly named) function. If the exact names differ from what this plan assumes, update later tasks' SQL accordingly — exact names are called out in Task 5/6 SQL blocks.
+
+- [ ] **Step 2: Write down the exact signatures observed**
+
+Add a comment block at the top of `tiles/endpoint.py` (created in Task 6) documenting:
+- `ST_AsMVTGeom(geom, bounds, extent, buffer, clip) -> geometry`
+- `ST_AsMVT(row, layer_name, extent, geom_col, feature_id_col) -> bytea`
+- `h3_polygon_wkt_to_cells(wkt, res)` return type (list of cells)
+
+If the observed API diverges significantly from the spec, stop and flag — the spec may need a correction before proceeding.
+
+- [ ] **Step 3: Commit the investigation**
+
+```bash
+git add tests/test_tile_math.py
+git commit -m "test: scaffold tile_math test module and document DuckDB MVT API"
+```
+
+---
+
+### Task 2: Tile math — XYZ to lng/lat bounds
+
+**Files:**
+- Create: `tiles/__init__.py`
+- Create: `tiles/tile_math.py`
+- Create/Modify: `tests/test_tile_math.py`
+
+- [ ] **Step 1: Write failing tests for `tile_xyz_to_lnglat_bounds`**
+
+Replace any placeholder content in `tests/test_tile_math.py` with:
+
+```python
+import math
+import pytest
+from tiles.tile_math import tile_xyz_to_lnglat_bounds
+
+
+class TestTileBounds:
+    def test_z0_is_whole_world(self):
+        w, s, e, n = tile_xyz_to_lnglat_bounds(0, 0, 0)
+        assert w == pytest.approx(-180.0)
+        assert e == pytest.approx(180.0)
+        assert s == pytest.approx(-math.degrees(math.atan(math.sinh(math.pi))))
+        assert n == pytest.approx(math.degrees(math.atan(math.sinh(math.pi))))
+
+    def test_z1_nw_quadrant(self):
+        # Tile (0,0) at z=1 is the northwest quadrant.
+        w, s, e, n = tile_xyz_to_lnglat_bounds(1, 0, 0)
+        assert w == pytest.approx(-180.0)
+        assert e == pytest.approx(0.0)
+        assert n > 0
+        assert s == pytest.approx(0.0)
+
+    def test_z1_se_quadrant(self):
+        w, s, e, n = tile_xyz_to_lnglat_bounds(1, 1, 1)
+        assert w == pytest.approx(0.0)
+        assert e == pytest.approx(180.0)
+        assert s < 0
+        assert n == pytest.approx(0.0)
+
+    def test_bounds_monotonic_in_x(self):
+        # Adjacent tiles share an edge.
+        _, _, e1, _ = tile_xyz_to_lnglat_bounds(5, 10, 12)
+        w2, _, _, _ = tile_xyz_to_lnglat_bounds(5, 11, 12)
+        assert e1 == pytest.approx(w2)
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `pytest tests/test_tile_math.py -v`
+Expected: `ModuleNotFoundError: No module named 'tiles'` or similar import error.
+
+- [ ] **Step 3: Create `tiles/__init__.py`**
+
+Create `tiles/__init__.py` (empty file).
+
+- [ ] **Step 4: Implement `tile_xyz_to_lnglat_bounds`**
+
+Create `tiles/tile_math.py`:
+
+```python
+"""Pure helper functions for tile math. No side effects, no DuckDB."""
+import math
+from typing import Tuple
+
+
+def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, float, float]:
+    """Return (west, south, east, north) in lng/lat (EPSG:4326) for XYZ tile."""
+    n = 2.0 ** z
+    west = x / n * 360.0 - 180.0
+    east = (x + 1) / n * 360.0 - 180.0
+    lat_n = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * y / n))))
+    lat_s = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * (y + 1) / n))))
+    return (west, lat_s, east, lat_n)
+```
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+Run: `pytest tests/test_tile_math.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tiles/__init__.py tiles/tile_math.py tests/test_tile_math.py
+git commit -m "feat(tiles): tile_xyz_to_lnglat_bounds helper"
+```
+
+---
+
+### Task 3: Tile math — zoom → H3 resolution, content hash
+
+**Files:**
+- Modify: `tiles/tile_math.py`
+- Modify: `tests/test_tile_math.py`
+
+- [ ] **Step 1: Write failing tests for `zoom_to_h3_res` and `content_hash`**
+
+Append to `tests/test_tile_math.py`:
+
+```python
+from tiles.tile_math import zoom_to_h3_res, content_hash
+
+
+class TestZoomToRes:
+    def test_default_offset_maps_z8_to_r4(self):
+        assert zoom_to_h3_res(8, min_res=2, finest_res=9, zoom_offset=4) == 4
+
+    def test_clamped_at_min_res(self):
+        assert zoom_to_h3_res(0, min_res=2, finest_res=9, zoom_offset=4) == 2
+        assert zoom_to_h3_res(3, min_res=2, finest_res=9, zoom_offset=4) == 2
+
+    def test_clamped_at_finest_res(self):
+        assert zoom_to_h3_res(20, min_res=2, finest_res=8, zoom_offset=4) == 8
+
+    def test_custom_offset(self):
+        assert zoom_to_h3_res(10, min_res=2, finest_res=9, zoom_offset=2) == 8
+
+
+class TestContentHash:
+    def test_stable_for_identical_inputs(self):
+        h1 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        h2 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        assert h1 == h2
+
+    def test_differs_when_sql_differs(self):
+        h1 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        h2 = content_hash(sql="SELECT 2", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        assert h1 != h2
+
+    def test_differs_when_agg_differs(self):
+        h1 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        h2 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="SUM", zoom_offset=4)
+        assert h1 != h2
+
+    def test_length_is_16_hex_chars(self):
+        h = content_hash(sql="x", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `pytest tests/test_tile_math.py -v`
+Expected: `ImportError: cannot import name 'zoom_to_h3_res'`.
+
+- [ ] **Step 3: Implement `zoom_to_h3_res` and `content_hash`**
+
+Append to `tiles/tile_math.py`:
+
+```python
+import hashlib
+
+
+def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 4) -> int:
+    """Clamp(z - zoom_offset, min_res, finest_res) — coarser hexes at lower zooms."""
+    target = z - zoom_offset
+    return max(min_res, min(finest_res, target))
+
+
+def content_hash(sql: str, finest_res: int, min_res: int, agg: str, zoom_offset: int) -> str:
+    """Deterministic 16-char hex hash of the registration inputs.
+
+    Used as the <name> component of tile URLs so identical registrations
+    dedupe naturally and URLs are CDN-friendly.
+    """
+    canonical = f"{sql}\0{finest_res}\0{min_res}\0{agg}\0{zoom_offset}"
+    return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:16]
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pytest tests/test_tile_math.py -v`
+Expected: all previous tests + 7 new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tiles/tile_math.py tests/test_tile_math.py
+git commit -m "feat(tiles): zoom_to_h3_res and content_hash helpers"
+```
+
+---
+
+### Task 4: Pyramid SQL generator
+
+**Files:**
+- Create: `tiles/pyramid.py`
+- Create: `tests/test_tile_pyramid.py`
+
+- [ ] **Step 1: Write failing test for `build_pyramid_sql`**
+
+Create `tests/test_tile_pyramid.py`:
+
+```python
+import re
+import pytest
+from tiles.pyramid import build_pyramid_sql
+
+
+class TestBuildPyramidSQL:
+    def test_contains_one_select_per_resolution(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8,
+            min_res=2,
+            agg="AVG",
+            value_columns=["val"],
+            h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Parents at res 2..7, plus finest level at res 8. 7 SELECTs total.
+        union_alls = len(re.findall(r"\bUNION ALL\b", sql, re.IGNORECASE))
+        assert union_alls == 6  # 7 selects → 6 UNION ALLs
+
+    def test_finest_level_is_ungrouped(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8,
+            min_res=2,
+            agg="AVG",
+            value_columns=["val"],
+            h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # The finest-res SELECT should NOT have AVG/SUM wrapping the value column.
+        # Look for the "... AS res" marker equal to finest_res.
+        finest_select = re.search(r"SELECT[^)]*?8 AS res FROM src", sql, re.DOTALL)
+        assert finest_select is not None
+        assert "AVG" not in finest_select.group(0)
+
+    def test_parent_levels_aggregate(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8,
+            min_res=2,
+            agg="SUM",
+            value_columns=["val"],
+            h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Parent selects use SUM(val)
+        assert "SUM(val)" in sql
+
+    def test_partitions_by_res(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert "PARTITION_BY (res)" in sql
+        assert "OVERWRITE_OR_IGNORE" in sql
+        assert "FORMAT PARQUET" in sql
+
+    def test_multiple_value_columns(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, v1, v2 FROM src",
+            finest_res=8, min_res=2, agg="AVG",
+            value_columns=["v1", "v2"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert "AVG(v1)" in sql
+        assert "AVG(v2)" in sql
+
+    def test_min_res_equals_finest_res_single_level(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=8, agg="AVG",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Only the finest level — no UNION ALL.
+        assert "UNION ALL" not in sql
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `pytest tests/test_tile_pyramid.py -v`
+Expected: `ModuleNotFoundError: No module named 'tiles.pyramid'`.
+
+- [ ] **Step 3: Implement `build_pyramid_sql`**
+
+Create `tiles/pyramid.py`:
+
+```python
+"""Pyramid SQL generation and registration.
+
+register_hex_tiles() materializes a partitioned parquet pyramid to object storage.
+Tile requests read directly from the pyramid — no coordination needed.
+"""
+from typing import List
+
+
+def build_pyramid_sql(
+    user_sql: str,
+    finest_res: int,
+    min_res: int,
+    agg: str,
+    value_columns: List[str],
+    h3_column: str,
+    output_uri: str,
+) -> str:
+    """Return the COPY ... TO SQL that writes a partitioned pyramid.
+
+    The finest-resolution level stores the user's values unaggregated; parents
+    at each coarser resolution aggregate via the user-chosen `agg` function.
+    """
+    value_list_raw = ", ".join(value_columns)
+    value_list_agg = ", ".join(f"{agg}({c}) AS {c}" for c in value_columns)
+
+    selects = []
+    # Parents: min_res .. finest_res - 1, each aggregated.
+    for res in range(min_res, finest_res):
+        selects.append(
+            f"  SELECT h3_cell_to_parent({h3_column}, {res}) AS h, "
+            f"{value_list_agg}, {res} AS res FROM src GROUP BY 1"
+        )
+    # Finest level: raw values, no aggregation.
+    selects.append(
+        f"  SELECT {h3_column} AS h, {value_list_raw}, {finest_res} AS res FROM src"
+    )
+
+    body = "\n  UNION ALL\n".join(selects)
+
+    return (
+        "COPY (\n"
+        f"  WITH src AS (\n{user_sql}\n  )\n"
+        f"{body}\n"
+        f") TO '{output_uri}' "
+        f"(FORMAT PARQUET, PARTITION_BY (res), OVERWRITE_OR_IGNORE)"
+    )
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pytest tests/test_tile_pyramid.py -v`
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tiles/pyramid.py tests/test_tile_pyramid.py
+git commit -m "feat(tiles): pyramid SQL generator"
+```
+
+---
+
+### Task 5: `register_hex_tiles` end-to-end with local bucket
+
+**Files:**
+- Modify: `tiles/pyramid.py`
+- Modify: `tests/test_tile_pyramid.py`
+
+- [ ] **Step 1: Write failing integration test using a local directory as the "bucket"**
+
+Append to `tests/test_tile_pyramid.py`:
+
+```python
+import os
+import duckdb
+from pathlib import Path
+from tiles.pyramid import register_hex_tiles
+
+
+@pytest.fixture
+def local_bucket(tmp_path, monkeypatch):
+    """Point TILE_BUCKET_BASE at a local directory so no S3 is required."""
+    bucket = tmp_path / "tiles-bucket"
+    bucket.mkdir()
+    monkeypatch.setenv("TILE_BUCKET_BASE", str(bucket))
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "http://test.local")
+    return bucket
+
+
+@pytest.fixture
+def h3_conn():
+    con = duckdb.connect(":memory:")
+    con.sql("INSTALL h3 FROM community; LOAD h3")
+    con.sql("INSTALL spatial; LOAD spatial")
+    con.sql("INSTALL httpfs; LOAD httpfs")
+    yield con
+    con.close()
+
+
+class TestRegisterHexTiles:
+    def test_writes_pyramid_partitions(self, local_bucket, h3_conn):
+        # Source: 5 cells at r5 around a point.
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, val
+            FROM (VALUES (37.8, -122.3, 1.0),
+                         (37.9, -122.4, 2.0),
+                         (38.0, -122.5, 3.0),
+                         (38.1, -122.6, 4.0),
+                         (38.2, -122.7, 5.0)) t(lat, lng, val)
+        """
+        result = register_hex_tiles(
+            con=h3_conn,
+            sql=user_sql,
+            finest_res=5,
+            min_res=2,
+            agg="AVG",
+            zoom_offset=4,
+        )
+        assert "hash" in result
+        # Partitioned files written: res=2 through res=5.
+        for res in (2, 3, 4, 5):
+            partition = local_bucket / "hex" / result["hash"] / f"res={res}"
+            assert partition.exists(), f"Missing res={res}"
+            assert any(partition.iterdir()), f"Empty res={res}"
+
+    def test_tile_url_template_uses_public_base(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+        )
+        assert result["tile_url_template"].startswith("http://test.local/tiles/hex/")
+        assert result["tile_url_template"].endswith("/{z}/{x}/{y}.pbf")
+
+    def test_returns_value_columns(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS v1, 2.0 AS v2"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+        )
+        assert result["value_columns"] == ["v1", "v2"]
+
+    def test_identical_inputs_same_hash(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        r1 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
+        r2 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
+        assert r1["hash"] == r2["hash"]
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `pytest tests/test_tile_pyramid.py::TestRegisterHexTiles -v`
+Expected: `ImportError: cannot import name 'register_hex_tiles'`.
+
+- [ ] **Step 3: Implement `register_hex_tiles`**
+
+Append to `tiles/pyramid.py`:
+
+```python
+import os
+from typing import Optional
+import duckdb
+
+from tiles.tile_math import content_hash
+
+
+def _bucket_base() -> str:
+    return os.environ.get("TILE_BUCKET_BASE", "s3://public-output").rstrip("/")
+
+
+def _public_base_url() -> str:
+    return os.environ.get("MCP_PUBLIC_BASE_URL", "https://duckdb-mcp.nrp-nautilus.io").rstrip("/")
+
+
+def _inspect_user_sql(con: duckdb.DuckDBPyConnection, user_sql: str):
+    """Run user SQL with LIMIT 0 to extract column names without materializing data."""
+    columns = con.sql(f"SELECT * FROM ({user_sql}) LIMIT 0").columns
+    if not columns:
+        raise ValueError("user SQL returned no columns")
+    h3_column = columns[0]
+    value_columns = list(columns[1:])
+    if not value_columns:
+        raise ValueError("user SQL must return at least one value column after the H3 index")
+    return h3_column, value_columns
+
+
+def register_hex_tiles(
+    con: duckdb.DuckDBPyConnection,
+    sql: str,
+    finest_res: int,
+    min_res: int = 2,
+    agg: str = "AVG",
+    zoom_offset: int = 4,
+) -> dict:
+    """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
+
+    The connection must have httpfs, spatial, and h3 extensions loaded.
+    """
+    if finest_res < min_res:
+        raise ValueError(f"finest_res ({finest_res}) must be >= min_res ({min_res})")
+
+    h3_column, value_columns = _inspect_user_sql(con, sql)
+    h = content_hash(sql=sql, finest_res=finest_res, min_res=min_res, agg=agg, zoom_offset=zoom_offset)
+    output_uri = f"{_bucket_base()}/hex/{h}/"
+
+    pyramid_sql = build_pyramid_sql(
+        user_sql=sql,
+        finest_res=finest_res,
+        min_res=min_res,
+        agg=agg,
+        value_columns=value_columns,
+        h3_column=h3_column,
+        output_uri=output_uri,
+    )
+    con.sql(pyramid_sql)
+
+    # Bounds of finest-level cells (approximate via simple min/max on cell centers).
+    finest_uri = f"{output_uri}res={finest_res}/*.parquet"
+    bounds_row = con.sql(
+        f"SELECT "
+        f"MIN(h3_cell_to_lat(h)) AS s, MAX(h3_cell_to_lat(h)) AS n, "
+        f"MIN(h3_cell_to_lng(h)) AS w, MAX(h3_cell_to_lng(h)) AS e, "
+        f"COUNT(*) AS ct "
+        f"FROM read_parquet('{finest_uri}')"
+    ).fetchone()
+    w, s, e, n, feature_count = bounds_row[2], bounds_row[0], bounds_row[3], bounds_row[1], bounds_row[4]
+
+    tile_url_template = f"{_public_base_url()}/tiles/hex/{h}/{{z}}/{{x}}/{{y}}.pbf"
+
+    return {
+        "tile_url_template": tile_url_template,
+        "hash": h,
+        "bounds": [w, s, e, n],
+        "finest_res": finest_res,
+        "min_res": min_res,
+        "zoom_offset": zoom_offset,
+        "value_columns": value_columns,
+        "feature_count_finest": feature_count,
+    }
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pytest tests/test_tile_pyramid.py -v`
+Expected: all previous tests + 4 new `TestRegisterHexTiles` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tiles/pyramid.py tests/test_tile_pyramid.py
+git commit -m "feat(tiles): register_hex_tiles materializes pyramid"
+```
+
+---
+
+### Task 6: Persistent DuckDB connection + Starlette lifespan
+
+**Files:**
+- Create: `tiles/db.py`
+- Modify: `tests/test_tile_pyramid.py` (add test for lifespan behavior)
+
+- [ ] **Step 1: Write failing test for `build_tile_connection`**
+
+Append to `tests/test_tile_pyramid.py`:
+
+```python
+from tiles.db import build_tile_connection
+
+
+class TestBuildTileConnection:
+    def test_loads_required_extensions(self):
+        con = build_tile_connection()
+        try:
+            # Proxy: LOAD must have succeeded if these functions are callable.
+            con.sql("SELECT h3_latlng_to_cell(37.8, -122.3, 5)").fetchone()
+            con.sql("SELECT ST_Point(0, 0)").fetchone()
+            # httpfs loaded — confirm by presence of its config.
+            con.sql("SELECT current_setting('s3_region')").fetchone()
+        finally:
+            con.close()
+
+    def test_no_s3_secret_created(self):
+        con = build_tile_connection()
+        try:
+            names = [r[0] for r in con.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+            # Persistent tile connection reads only from public buckets.
+            assert "client_s3" not in names
+        finally:
+            con.close()
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `pytest tests/test_tile_pyramid.py::TestBuildTileConnection -v`
+Expected: `ModuleNotFoundError: No module named 'tiles.db'`.
+
+- [ ] **Step 3: Implement `build_tile_connection` and lifespan context**
+
+Create `tiles/db.py`:
+
+```python
+"""Persistent :memory: DuckDB connection for the tile endpoint.
+
+Separate from the per-request isolated connections used by the `query` tool:
+tile requests never take user credentials, so the connection can be long-lived
+and shared across requests via con.cursor() for per-request isolation.
+"""
+import sys
+from contextlib import asynccontextmanager
+import duckdb
+
+
+def build_tile_connection() -> duckdb.DuckDBPyConnection:
+    """Create a :memory: connection with extensions loaded.
+
+    Extensions are assumed to be pre-installed in the image (see mcp-data-server#54);
+    LOAD is per-session and always required.
+    """
+    con = duckdb.connect(":memory:")
+    # Extensions may not be pre-installed in dev environments — install defensively.
+    con.sql("INSTALL httpfs; LOAD httpfs")
+    con.sql("INSTALL spatial; LOAD spatial")
+    con.sql("INSTALL h3 FROM community; LOAD h3")
+    return con
+
+
+@asynccontextmanager
+async def tile_lifespan(app):
+    """Starlette lifespan that creates and tears down the persistent connection.
+
+    Stored on app.state.tile_con so request handlers can reach it.
+    """
+    con = build_tile_connection()
+    print("📦 Tile endpoint: persistent DuckDB connection ready", file=sys.stderr)
+    app.state.tile_con = con
+    try:
+        yield
+    finally:
+        con.close()
+        print("📦 Tile endpoint: connection closed", file=sys.stderr)
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pytest tests/test_tile_pyramid.py::TestBuildTileConnection -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tiles/db.py tests/test_tile_pyramid.py
+git commit -m "feat(tiles): persistent tile DuckDB connection + lifespan"
+```
+
+---
+
+### Task 7: Tile request handler
+
+**Files:**
+- Create: `tiles/endpoint.py`
+- Create: `tests/test_tile_endpoint.py`
+
+- [ ] **Step 1: Write failing end-to-end test**
+
+Create `tests/test_tile_endpoint.py`:
+
+```python
+import os
+import pytest
+import duckdb
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tiles.endpoint import serve_tile
+from tiles.pyramid import register_hex_tiles
+from tiles.db import build_tile_connection
+
+
+@pytest.fixture
+def local_bucket(tmp_path, monkeypatch):
+    bucket = tmp_path / "tiles-bucket"
+    bucket.mkdir()
+    monkeypatch.setenv("TILE_BUCKET_BASE", str(bucket))
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "http://test.local")
+    return bucket
+
+
+@pytest.fixture
+def app_with_tiles(local_bucket):
+    """Build a minimal Starlette app that mounts the tile route with a live connection."""
+    con = build_tile_connection()
+    app = Starlette(routes=[
+        Route("/tiles/{namespace}/{name}/{z:int}/{x:int}/{y:int}.pbf", serve_tile),
+    ])
+    app.state.tile_con = con
+    yield app
+    con.close()
+
+
+@pytest.fixture
+def registered_ca(app_with_tiles):
+    """Register a small California tileset and return its hash."""
+    con = app_with_tiles.state.tile_con
+    # Generate ~few hundred r5 cells across California.
+    user_sql = """
+        SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, 1.0 AS val
+        FROM (
+            SELECT 36 + random()*3 AS lat, -121 - random()*3 AS lng
+            FROM range(500)
+        )
+    """
+    result = register_hex_tiles(
+        con=con, sql=user_sql, finest_res=5, min_res=2, agg="AVG", zoom_offset=4,
+    )
+    return result["hash"]
+
+
+class TestServeTile:
+    def test_returns_mvt_content_type_for_covering_tile(self, app_with_tiles, registered_ca):
+        client = TestClient(app_with_tiles)
+        # z=5 tile that covers part of California.
+        # California is near tile (5, 5, 12) in XYZ.
+        r = client.get(f"/tiles/hex/{registered_ca}/5/5/12.pbf")
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "application/vnd.mapbox-vector-tile"
+        assert len(r.content) > 0
+
+    def test_empty_tile_returns_204(self, app_with_tiles, registered_ca):
+        client = TestClient(app_with_tiles)
+        # A tile over open ocean far from California should be empty.
+        r = client.get(f"/tiles/hex/{registered_ca}/5/0/0.pbf")
+        assert r.status_code in (200, 204)  # implementations may differ
+        if r.status_code == 200:
+            assert len(r.content) < 100  # empty MVT is very small
+
+    def test_unknown_hash_returns_404(self, app_with_tiles):
+        client = TestClient(app_with_tiles)
+        r = client.get("/tiles/hex/0000000000000000/5/5/12.pbf")
+        assert r.status_code == 404
+
+    def test_unknown_namespace_returns_404(self, app_with_tiles, registered_ca):
+        client = TestClient(app_with_tiles)
+        r = client.get(f"/tiles/bogus/{registered_ca}/5/5/12.pbf")
+        assert r.status_code == 404
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `pytest tests/test_tile_endpoint.py -v`
+Expected: `ModuleNotFoundError: No module named 'tiles.endpoint'`.
+
+- [ ] **Step 3: Implement `serve_tile`**
+
+Create `tiles/endpoint.py`:
+
+```python
+"""Starlette request handler for /tiles/{namespace}/{name}/{z}/{x}/{y}.pbf.
+
+Observed DuckDB signatures (verified in Task 1):
+- ST_AsMVTGeom(geom, bounds_geom) -> geometry
+- ST_AsMVT(row) -> bytea  (aggregate)
+- h3_polygon_wkt_to_cells(wkt, res) -> list<h3index>
+"""
+import os
+import sys
+import anyio
+from starlette.requests import Request
+from starlette.responses import Response
+
+from tiles.tile_math import tile_xyz_to_lnglat_bounds, zoom_to_h3_res
+
+
+MVT_CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
+
+
+def _bucket_base() -> str:
+    return os.environ.get("TILE_BUCKET_BASE", "s3://public-output").rstrip("/")
+
+
+def _tileset_dir(namespace: str, name: str) -> str:
+    return f"{_bucket_base()}/{namespace}/{name}"
+
+
+def _pyramid_exists(con, namespace: str, name: str, res: int) -> bool:
+    """Check whether the pyramid partition for (namespace, name, res) is readable."""
+    uri = f"{_tileset_dir(namespace, name)}/res={res}/*.parquet"
+    try:
+        cur = con.cursor()
+        cur.sql(f"SELECT 1 FROM read_parquet('{uri}') LIMIT 1").fetchone()
+        return True
+    except Exception:
+        return False
+
+
+def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
+                    target_res: int, finest_res: int) -> str:
+    """Produce the SQL that returns a single bytea row (the MVT for this tile).
+
+    Strategy:
+      1. Compute the tile's web-mercator bounds geometry.
+      2. Compute H3 cells at target_res covering the tile's lng/lat polygon.
+      3. Select rows from the pyramid partition whose cell is in that set.
+      4. Project cell geometries with ST_AsMVTGeom then aggregate with ST_AsMVT.
+    """
+    west, south, east, north = tile_xyz_to_lnglat_bounds(z, x, y)
+    tileset = _tileset_dir(namespace, name)
+    # Tile polygon WKT in lng/lat. h3_polygon_wkt_to_cells interprets lng/lat.
+    tile_wkt = (
+        f"POLYGON(("
+        f"{west} {south}, {east} {south}, {east} {north}, "
+        f"{west} {north}, {west} {south}))"
+    )
+    # MVT bounds in EPSG:3857 (web-mercator). ST_Transform handles projection.
+    return f"""
+        WITH cells AS (
+          SELECT UNNEST(h3_polygon_wkt_to_cells('{tile_wkt}', {target_res})) AS cell
+        ),
+        src AS (
+          SELECT p.* FROM read_parquet('{tileset}/res={target_res}/*.parquet') p
+          SEMI JOIN cells c ON p.h = c.cell
+        ),
+        projected AS (
+          SELECT
+            ST_AsMVTGeom(
+              ST_Transform(h3_cell_to_boundary_wkt(h)::GEOMETRY, 'EPSG:4326', 'EPSG:3857'),
+              ST_MakeEnvelope(
+                ST_X(ST_Transform(ST_Point({west}, {south}), 'EPSG:4326', 'EPSG:3857')),
+                ST_Y(ST_Transform(ST_Point({west}, {south}), 'EPSG:4326', 'EPSG:3857')),
+                ST_X(ST_Transform(ST_Point({east}, {north}), 'EPSG:4326', 'EPSG:3857')),
+                ST_Y(ST_Transform(ST_Point({east}, {north}), 'EPSG:4326', 'EPSG:3857'))
+              )
+            ) AS geom,
+            src.* EXCLUDE (h)
+          FROM src
+        )
+        SELECT ST_AsMVT(projected) FROM projected WHERE geom IS NOT NULL
+    """
+
+
+def _run_tile_query(con, sql: str) -> bytes:
+    """Run the tile SQL on a fresh cursor and return raw MVT bytes (or empty)."""
+    cur = con.cursor()
+    row = cur.sql(sql).fetchone()
+    if row is None or row[0] is None:
+        return b""
+    return bytes(row[0])
+
+
+async def serve_tile(request: Request) -> Response:
+    """GET /tiles/{namespace}/{name}/{z}/{x}/{y}.pbf"""
+    namespace = request.path_params["namespace"]
+    name = request.path_params["name"]
+    z = int(request.path_params["z"])
+    x = int(request.path_params["x"])
+    y = int(request.path_params["y"])
+
+    if namespace != "hex":
+        return Response(status_code=404)
+
+    con = request.app.state.tile_con
+
+    # Probe whether the tileset exists at any res — use finest since it's always present.
+    # We don't know finest_res at tile-serving time without metadata; try a few.
+    # Convention: we accept whatever res in [2..15] has data.
+    target_res = None
+    for guess_finest in range(15, 1, -1):
+        if await anyio.to_thread.run_sync(_pyramid_exists, con, namespace, name, guess_finest):
+            finest_res = guess_finest
+            # (Floor of) zoom_to_h3_res with default zoom_offset=4 and min_res=2.
+            # In v1 we don't persist zoom_offset/min_res per-tileset — caller's registered
+            # URL captures the content hash, so clients get stable tiles. Use defaults.
+            target_res = zoom_to_h3_res(z, min_res=2, finest_res=finest_res, zoom_offset=4)
+            break
+    if target_res is None:
+        return Response(status_code=404)
+
+    sql = _build_tile_sql(namespace, name, z, x, y, target_res, finest_res)
+    try:
+        mvt_bytes = await anyio.to_thread.run_sync(_run_tile_query, con, sql)
+    except Exception as e:
+        print(f"⚠️ Tile {z}/{x}/{y} error: {e}", file=sys.stderr)
+        return Response(status_code=500)
+
+    if not mvt_bytes:
+        return Response(status_code=204)
+    return Response(content=mvt_bytes, media_type=MVT_CONTENT_TYPE)
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pytest tests/test_tile_endpoint.py -v`
+Expected: 4 passed (or 3 + 1 skipped if ST_AsMVT returns an unexpected shape — in that case, adjust the SQL based on Task 1's documented signature).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tiles/endpoint.py tests/test_tile_endpoint.py
+git commit -m "feat(tiles): MVT tile request handler"
+```
+
+---
+
+### Task 8: Persist tileset metadata for per-tileset zoom_offset / min_res
+
+The previous task hardcoded `min_res=2`, `zoom_offset=4` at tile-serve time because we have no metadata file. Fix that: write a sibling `metadata.json` during registration so the handler reads the real values.
+
+**Files:**
+- Modify: `tiles/pyramid.py`
+- Modify: `tiles/endpoint.py`
+- Modify: `tests/test_tile_pyramid.py`
+- Modify: `tests/test_tile_endpoint.py`
+
+- [ ] **Step 1: Write failing test for metadata sidecar**
+
+Append to `tests/test_tile_pyramid.py`:
+
+```python
+import json as _json
+
+
+class TestTilesetMetadata:
+    def test_metadata_written_alongside_pyramid(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=3, agg="SUM", zoom_offset=3,
+        )
+        meta_path = local_bucket / "hex" / result["hash"] / "metadata.json"
+        assert meta_path.exists()
+        meta = _json.loads(meta_path.read_text())
+        assert meta["finest_res"] == 5
+        assert meta["min_res"] == 3
+        assert meta["agg"] == "SUM"
+        assert meta["zoom_offset"] == 3
+        assert meta["value_columns"] == ["val"]
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pytest tests/test_tile_pyramid.py::TestTilesetMetadata -v`
+Expected: `FileNotFoundError: ... metadata.json`.
+
+- [ ] **Step 3: Write metadata sidecar from `register_hex_tiles`**
+
+In `tiles/pyramid.py`, after the `con.sql(pyramid_sql)` call and before computing bounds, add:
+
+```python
+    # Write a sidecar metadata.json so the tile handler knows finest_res / zoom_offset.
+    metadata = {
+        "finest_res": finest_res,
+        "min_res": min_res,
+        "agg": agg,
+        "zoom_offset": zoom_offset,
+        "value_columns": value_columns,
+    }
+    metadata_sql = (
+        f"COPY (SELECT '{_json_dumps_escaped(metadata)}' AS j) "
+        f"TO '{output_uri}metadata.json' (FORMAT CSV, HEADER false, QUOTE '')"
+    )
+    con.sql(metadata_sql)
+```
+
+Add the import and helper at the top of `tiles/pyramid.py`:
+
+```python
+import json
+
+
+def _json_dumps_escaped(obj) -> str:
+    # DuckDB's COPY ... (FORMAT CSV, QUOTE '') writes the raw string. We must
+    # escape any single quotes in the JSON so they don't break the SQL literal.
+    return json.dumps(obj).replace("'", "''")
+```
+
+- [ ] **Step 4: Run tests, verify pyramid metadata test passes**
+
+Run: `pytest tests/test_tile_pyramid.py::TestTilesetMetadata -v`
+Expected: 1 passed.
+
+- [ ] **Step 5: Write failing test that endpoint respects persisted zoom_offset**
+
+Append to `tests/test_tile_endpoint.py`:
+
+```python
+class TestMetadataDriven:
+    def test_endpoint_reads_finest_res_from_metadata(self, app_with_tiles, local_bucket):
+        """After registering with finest_res=4, a tile request should use res=4 max."""
+        con = app_with_tiles.state.tile_con
+        user_sql = """
+            SELECT h3_latlng_to_cell(37.8, -122.3, 4) AS h4, 1.0 AS val
+        """
+        result = register_hex_tiles(
+            con=con, sql=user_sql, finest_res=4, min_res=2, agg="AVG", zoom_offset=4,
+        )
+        client = TestClient(app_with_tiles)
+        # At z=20 with zoom_offset=4 → target_res=16, clamped to finest_res=4.
+        # Tile over (37.8, -122.3) at z=20 covers one r4 hex or so. Main assertion:
+        # request succeeds (not 404 from "no pyramid at res=16").
+        # Compute approximate tile (x,y) at z=20 for (37.8, -122.3):
+        import math
+        lat_rad = math.radians(37.8)
+        z = 20
+        n = 2 ** z
+        x = int((-122.3 + 180) / 360 * n)
+        y = int((1 - math.log(math.tan(lat_rad) + 1/math.cos(lat_rad)) / math.pi) / 2 * n)
+        r = client.get(f"/tiles/hex/{result['hash']}/{z}/{x}/{y}.pbf")
+        assert r.status_code in (200, 204)  # not 404
+```
+
+- [ ] **Step 6: Run test, verify it fails OR already passes**
+
+Run: `pytest tests/test_tile_endpoint.py::TestMetadataDriven -v`
+Expected: may pass incidentally, but the endpoint is still hardcoded. Even if it passes, continue to Step 7 — the hardcoded values must be replaced.
+
+- [ ] **Step 7: Replace the `finest_res` probe loop in `serve_tile` with a metadata read**
+
+In `tiles/endpoint.py`, replace the `target_res = None / for guess_finest in range(...)` block inside `serve_tile` with:
+
+```python
+    meta = await anyio.to_thread.run_sync(_read_metadata, namespace, name)
+    if meta is None:
+        return Response(status_code=404)
+    finest_res = meta["finest_res"]
+    min_res = meta["min_res"]
+    zoom_offset = meta["zoom_offset"]
+    target_res = zoom_to_h3_res(z, min_res=min_res, finest_res=finest_res, zoom_offset=zoom_offset)
+```
+
+And add the helper elsewhere in `tiles/endpoint.py`:
+
+```python
+import json
+
+
+def _read_metadata(namespace: str, name: str):
+    """Read the metadata.json sidecar for a tileset. Returns None if missing."""
+    uri = f"{_tileset_dir(namespace, name)}/metadata.json"
+    # Works for both file:// / local paths and s3:// via DuckDB httpfs.
+    # But httpfs-readable JSON needs DuckDB; use a dedicated cursor to read it.
+    import duckdb
+    try:
+        # Local path shortcut for tests (no need for an extra DuckDB connection).
+        if not uri.startswith("s3://") and not uri.startswith("http"):
+            with open(uri, "r") as f:
+                return json.loads(f.read().strip().strip('"'))
+        # For S3, use a one-off connection.
+        c = duckdb.connect(":memory:")
+        c.sql("INSTALL httpfs; LOAD httpfs")
+        row = c.sql(f"SELECT content FROM read_text('{uri}')").fetchone()
+        c.close()
+        if row is None:
+            return None
+        return json.loads(row[0])
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+```
+
+- [ ] **Step 8: Run full tile endpoint test suite**
+
+Run: `pytest tests/test_tile_endpoint.py tests/test_tile_pyramid.py -v`
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tiles/pyramid.py tiles/endpoint.py tests/test_tile_pyramid.py tests/test_tile_endpoint.py
+git commit -m "feat(tiles): metadata sidecar for tileset config"
+```
+
+---
+
+### Task 9: Wire tiles into `server.py`
+
+**Files:**
+- Modify: `server.py`
+- Modify: `tests/test_server.py`
+
+- [ ] **Step 1: Write failing test that server exposes the tile route**
+
+Append to `tests/test_server.py`:
+
+```python
+class TestTileRouteMounted:
+    def test_tile_route_exists_in_starlette_app(self):
+        """After importing server, the streamable_http_app should have a /tiles route."""
+        from server import mcp
+        app = mcp.streamable_http_app()
+        # Also apply our own mount (mimicking the startup block).
+        from server import mount_tiles
+        mount_tiles(app)
+        paths = [getattr(r, "path", None) or getattr(r, "path_format", None) for r in app.routes]
+        assert any(p and "/tiles/" in p for p in paths)
+
+    def test_register_hex_tiles_is_an_mcp_tool(self):
+        """The MCP server should expose register_hex_tiles as a tool."""
+        from server import mcp
+        # FastMCP tracks tools on its internal registry; adapt to the API.
+        import anyio
+        tool_names = [t.name for t in anyio.run(mcp.list_tools)]
+        assert "register_hex_tiles" in tool_names
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pytest tests/test_server.py::TestTileRouteMounted -v`
+Expected: `ImportError: cannot import name 'mount_tiles'` and `register_hex_tiles` not in tools.
+
+- [ ] **Step 3: Add tile wiring to `server.py`**
+
+In `server.py`, after the `mcp.tool()(query)` line (around line 193), add:
+
+```python
+# -------------------------------------------------------------------------
+# 8b. TILE ENDPOINT — dynamic MVT for H3 hex visualization (see issue #4)
+# -------------------------------------------------------------------------
+from starlette.routing import Route
+from tiles.endpoint import serve_tile
+from tiles.db import build_tile_connection
+from tiles.pyramid import register_hex_tiles as _register_hex_tiles
+
+
+# Module-level persistent connection. Initialized lazily at first use OR
+# at startup via the lifespan in mount_tiles().
+_tile_con = None
+
+
+def _get_tile_con():
+    global _tile_con
+    if _tile_con is None:
+        _tile_con = build_tile_connection()
+    return _tile_con
+
+
+def register_hex_tiles(
+    sql: str,
+    finest_res: int,
+    min_res: int = 2,
+    agg: str = "AVG",
+    zoom_offset: int = 4,
+) -> dict:
+    """Materialize a partitioned H3 hex pyramid to public object storage and return
+    a MapLibre-compatible vector tile URL template.
+
+    Use this tool for H3 hex datasets too large to return as markdown table —
+    roughly >100k cells, or any case where the user wants to visualize hexes
+    directly on the map (rather than color an existing polygon layer).
+
+    Input SQL contract: return (h3_index, value1, value2, ...) where the first
+    column is an H3 index at resolution `finest_res`, and subsequent columns
+    are numeric values. All value columns are aggregated by `agg` (AVG, SUM, MIN,
+    MAX, COUNT) at each coarser resolution down to `min_res`.
+
+    Returns a dict with `tile_url_template` that any MapLibre client can consume
+    via:
+        map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
+        map.addLayer({..., 'source-layer': 'hex', paint: {...}});
+    """
+    con = _get_tile_con()
+    return _register_hex_tiles(
+        con=con, sql=sql, finest_res=finest_res, min_res=min_res,
+        agg=agg, zoom_offset=zoom_offset,
+    )
+
+
+mcp.tool()(register_hex_tiles)
+
+
+def mount_tiles(app):
+    """Mount the /tiles route onto the Starlette app and ensure tile con is ready."""
+    # Pre-initialize the connection so first tile request is fast.
+    con = _get_tile_con()
+    app.state.tile_con = con
+    app.router.routes.append(
+        Route("/tiles/{namespace}/{name}/{z:int}/{x:int}/{y:int}.pbf", serve_tile)
+    )
+```
+
+Then update the `if __name__ == "__main__":` block to call `mount_tiles(app)` right after `app = mcp.streamable_http_app()`:
+
+```python
+if __name__ == "__main__":
+    app = mcp.streamable_http_app()
+    app.router.redirect_slashes = False
+    mount_tiles(app)     # <-- add this line
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pytest tests/test_server.py::TestTileRouteMounted -v`
+Expected: 2 passed.
+
+Also run the existing suite to verify no regressions:
+
+Run: `pytest tests/test_server.py -v`
+Expected: all passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server.py tests/test_server.py
+git commit -m "feat(server): mount tile route and register_hex_tiles MCP tool"
+```
+
+---
+
+### Task 10: Docs updates
+
+**Files:**
+- Modify: `h3-guide.md`
+- Modify: `assistant-role.md`
+
+- [ ] **Step 1: Read the existing sections that will host the new content**
+
+Run: `grep -n "public-output" h3-guide.md` and look at the "Generating Output Files" section around line 165. Read surrounding lines (offset 150, limit 60).
+
+- [ ] **Step 2: Add a new section to `h3-guide.md` documenting `register_hex_tiles`**
+
+Append to `h3-guide.md` (after the existing "Generating Output Files" section):
+
+```markdown
+## Rendering hex results as a map layer
+
+For hex result sets too large to display as a table (roughly >100k cells), or
+whenever the user wants to visualize hexes directly on the map, use the
+`register_hex_tiles` MCP tool instead of returning markdown.
+
+**When to use:**
+- User asks to *show*, *render*, *visualize*, or *color* hexes on the map
+- Result set would exceed the 50-row `query` cap with meaningful content
+- The answer is "per-hex values across a region" rather than "top N rows"
+
+**How to use:**
+1. Write your analysis SQL that returns `(h3_index, value1, value2, ...)` — first
+   column must be the H3 index at your chosen resolution.
+2. Call `register_hex_tiles(sql=..., finest_res=N)` with the resolution of that
+   index column.
+3. Return the `tile_url_template` to the client. Any MapLibre-compatible client
+   (including geo-agent) will render it natively as a vector source.
+
+Example SQL shape for the `sql` parameter:
+
+    SELECT h3_latlng_to_cell(lat, lng, 8) AS h8,
+           AVG(carbon_density) AS carbon
+    FROM read_parquet('s3://public-cng/.../carbon_r8.parquet')
+    WHERE <region filter>
+    GROUP BY 1
+
+The tool handles pyramiding (coarser hexes at lower zooms) and partitioned
+parquet storage automatically. Repeat calls with identical inputs return the
+same URL — natural caching.
+```
+
+- [ ] **Step 3: Add dispatch hint to `assistant-role.md`**
+
+Find the section in `assistant-role.md` that describes tool dispatch (or append a new section). Add:
+
+```markdown
+### Dispatch: map-rendering tools
+
+- `query` — for answering in markdown tables (capped at 50 rows). Default.
+- `register_hex_tiles` — when the user wants *hexes on the map*, or the result
+  would be a large (>100k cell) hex layer. Returns a tile URL; the client adds
+  it as a MapLibre vector source.
+
+If the user asks to "show", "render", or "color" hexes on the map, choose
+`register_hex_tiles`. If they ask "what's the value of X at location Y" or
+"top N hexes by Z", use `query`.
+```
+
+- [ ] **Step 4: Commit docs**
+
+```bash
+git add h3-guide.md assistant-role.md
+git commit -m "docs: register_hex_tiles usage and dispatch guidance"
+```
+
+---
+
+### Task 11: Manual smoke test against real S3 (optional pre-deploy check)
+
+This is a manual one-off check before deploying — not a CI test. Skip if you're not ready to deploy.
+
+**Files:** None
+
+- [ ] **Step 1: Ensure S3 credentials are available**
+
+```bash
+# These need to be set in your shell for the manual test.
+echo "Has MCP_S3_KEY: ${MCP_S3_KEY:+yes}"
+echo "Has MCP_S3_SECRET: ${MCP_S3_SECRET:+yes}"
+```
+
+If not set, grab them from the k8s secret (`kubectl get secret mcp-public-output-secrets -o yaml`) or skip this task.
+
+- [ ] **Step 2: Register a small CA tileset against real S3**
+
+```bash
+python3 -c "
+import os, duckdb
+os.environ['TILE_BUCKET_BASE'] = 's3://public-output'
+from tiles.db import build_tile_connection
+from tiles.pyramid import register_hex_tiles
+
+con = build_tile_connection()
+# Set up S3 credentials on the persistent connection for this one-off test.
+con.sql(f\"\"\"CREATE OR REPLACE SECRET s3 (TYPE S3, KEY_ID '{os.environ['MCP_S3_KEY']}',
+            SECRET '{os.environ['MCP_S3_SECRET']}', ENDPOINT 's3-west.nrp-nautilus.io',
+            URL_STYLE 'path', USE_SSL 'true')\"\"\")
+
+result = register_hex_tiles(
+    con=con,
+    sql='''SELECT h3_latlng_to_cell(lat, lng, 6) AS h6, 1.0 AS val
+           FROM (SELECT 36 + random()*3 AS lat, -121 - random()*3 AS lng FROM range(5000))''',
+    finest_res=6, min_res=2, agg='AVG', zoom_offset=4,
+)
+print('Hash:', result['hash'])
+print('Tile URL template:', result['tile_url_template'])
+print('Feature count:', result['feature_count_finest'])
+"
+```
+
+- [ ] **Step 3: Verify the pyramid is on S3**
+
+```bash
+# Using rclone or any S3 client.
+rclone ls nrp-s3:public-output/hex/<hash>/
+```
+
+Expected: parquet files under `res=2/` through `res=6/`, plus `metadata.json`.
+
+- [ ] **Step 4: Start server locally and fetch a tile**
+
+```bash
+# In another terminal:
+uv run --with mcp --with duckdb --with pandas --with uvicorn --with tabulate --with pystac --with requests server.py &
+SERVER_PID=$!
+
+# Wait for startup, then:
+curl -v "http://localhost:8000/tiles/hex/<hash>/5/5/12.pbf" -o /tmp/tile.pbf
+ls -l /tmp/tile.pbf
+# Expected: non-zero file, content-type application/vnd.mapbox-vector-tile.
+
+kill $SERVER_PID
+```
+
+- [ ] **Step 5: No commit — this is a manual check**
+
+---
+
+## Self-Review
+
+Ran the self-review checklist against the spec (`docs/superpowers/specs/2026-04-15-dynamic-mvt-tile-endpoint-design.md`):
+
+**Spec coverage:**
+- URL scheme `/tiles/<namespace>/<name>/{z}/{x}/{y}.pbf` → Task 7 (`serve_tile`) + Task 9 (route mount).
+- S3-as-state-store content-addressable pyramid → Task 4 (pyramid SQL) + Task 5 (register).
+- LOD Approach B pyramid → Task 4 (generates the right UNION ALL structure).
+- Zoom → resolution with `zoom_offset` → Task 3 (`zoom_to_h3_res`) + Task 8 (per-tileset metadata).
+- `register_hex_tiles` tool API → Task 5 + Task 9 (MCP registration).
+- Persistent connection + `anyio.to_thread.run_sync` → Task 6 + Task 7.
+- Client usage pattern (MapLibre vector source) → documented in Task 10.
+- Client-agnosticism → implicit (endpoint is plain XYZ MVT).
+- Private-source caveat → out of scope for v1 per spec; pyramid always lands in public bucket.
+- Testing strategy (unit math, integration pyramid, end-to-end tile) → Tasks 2–3 (math), 4–5 (pyramid), 7 (end-to-end).
+- Open items (ST_AsMVT API verification, error taxonomy, empty tiles at low zoom) → Task 1 (API probe), Task 7 (204 for empty, 404 for unknown).
+
+**Placeholder scan:** Each code step contains complete code. No "TBD" / "add error handling" / "similar to above" — every step shows the content.
+
+**Type consistency:**
+- `content_hash(...)` signature in Task 3 matches its call in Task 5's `register_hex_tiles`.
+- `zoom_to_h3_res(z, min_res, finest_res, zoom_offset)` signature matches calls in Tasks 7 and 8.
+- `build_pyramid_sql` parameter names match the call in Task 5.
+- `serve_tile` path params (`namespace`, `name`, `z`, `x`, `y`) match the Route declaration in Task 7 and Task 9.
+- `app.state.tile_con` written in Task 6 (`tile_lifespan`) and Task 9 (`mount_tiles`), read in Task 7 (`serve_tile`). Consistent.
+
+**Risks identified during review:**
+- Task 1's API-probe strategy: if DuckDB's `ST_AsMVT` aggregate returns a blob rather than bytea, minor adjustment needed in `_run_tile_query` (change the `bytes(row[0])` call). Flag for the implementer.
+- Task 7's `_pyramid_exists` probe loop is replaced by metadata in Task 8 — intentionally kept as a step-wise evolution so test passes incrementally.
+- Task 8's `read_text` function may not exist in all DuckDB versions; fallback via `read_blob` may be needed — noted in the implementation step.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-15-dynamic-mvt-tile-endpoint.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-15-dynamic-mvt-tile-endpoint-design.md
+++ b/docs/superpowers/specs/2026-04-15-dynamic-mvt-tile-endpoint-design.md
@@ -1,0 +1,212 @@
+# Dynamic MVT tile endpoint for H3 hex visualization at scale
+
+**Date:** 2026-04-15
+**Status:** Draft design, pending implementation
+**Tracking issue:** boettiger-lab/mcp-data-server#4
+**Related:** boettiger-lab/geo-agent#159 (UC1 counterpart), boettiger-lab/mcp-data-server#54 (Docker pre-install)
+
+## Problem
+
+Users want to visualize per-hex computations as native MapLibre layers — "show a biodiversity + carbon composite at H3 r8 across California" — where results are computed per-session in DuckDB and can reach millions of hex cells. Current mechanisms don't cover this:
+
+- The MCP `query` tool returns markdown tables capped at 50 rows. Not a map layer.
+- The S3 side-channel (`s3://public-output/`, documented in `h3-guide.md`) works for UC1 (attribute join onto existing polygons via client-side `setFeatureState`, tracked in boettiger-lab/geo-agent#159). It does not scale to rendering hex **geometry** — at CONUS/r8 (~10M cells) a single GeoJSON or GeoParquet dump is too large to hand a browser.
+- Pre-baking global hex layers as PMTiles was tried and failed at global H8 (~691M cells) without chunking infrastructure.
+- Client-side h3-js boundary generation covers small viewports but not interactive pan/zoom over large extents at interactive framerates.
+
+## Goal
+
+A single endpoint on the MCP server that serves MVT tiles for a user-registered hex query, producing a MapLibre vector source consumable by any MapLibre-compatible client (geo-agent, QGIS, kepler.gl, Felt). Unbounded scale through tiling, stateless at the HTTP layer, horizontally scalable.
+
+**Non-goals for v1:**
+- Non-hex geometry sources (arbitrary polygons, lines, points).
+- Private-data tiles (requires a signed-request sidecar — see §Deferrals).
+- CDN fronting (not needed for initial adoption; tile URLs are content-addressable and cache-friendly when added later).
+- Authentication on the tile endpoint.
+
+## Architecture
+
+### URL scheme
+
+```
+GET /tiles/<namespace>/<name>/{z}/{x}/{y}.pbf
+```
+
+- `namespace` distinguishes source types. v1 ships `hex`.
+- `name` is a content hash (SHA-1, truncated) of the registering inputs — the tile URL is deterministic from its inputs, so repeat registrations are natural no-ops and tiles are CDN-friendly when fronted later.
+- `{z}/{x}/{y}` is standard XYZ web-mercator.
+
+Response: `application/vnd.mapbox-vector-tile`, body is raw MVT bytes from DuckDB's `ST_AsMVT`.
+
+### S3 as state store
+
+The server remains stateless at the HTTP layer — no per-connection state, no coordination between replicas. All "state" lives in S3 as a content-addressable parquet pyramid:
+
+```
+s3://public-output/hex/<hash>/res=2/data_0.parquet
+s3://public-output/hex/<hash>/res=3/data_0.parquet
+...
+s3://public-output/hex/<hash>/res=9/data_0.parquet
+```
+
+A tile request at `(z, x, y)` reads only the parquet partition for the appropriate resolution. The 30-day TTL on `public-output` handles cleanup; repeat registrations with identical inputs produce identical hashes and thus overwrite in place (`OVERWRITE_OR_IGNORE`).
+
+This preserves the current statelessness property: any replica can serve any tile request, routing is round-robin, no sticky sessions required. Multi-replica deployments (current: 2 pods via HAProxy) need no coordination.
+
+### LOD strategy — pre-aggregated resolution pyramid
+
+Each `register_hex_tiles` call materializes a pyramid from the user's finest resolution down to a configurable minimum resolution (default r2). The pyramid is generated once at registration time via a single `COPY ... TO` with partitioning:
+
+```sql
+COPY (
+  WITH src AS (<user sql>)
+  SELECT h3_cell_to_parent(h_finest, 2) AS h, AVG(v1) AS v1, ..., 2 AS res FROM src GROUP BY 1
+  UNION ALL
+  SELECT h3_cell_to_parent(h_finest, 3) AS h, AVG(v1) AS v1, ..., 3 AS res FROM src GROUP BY 1
+  -- ...
+  UNION ALL
+  SELECT h_finest AS h, v1, ..., <finest_res> AS res FROM src
+) TO 's3://public-output/hex/<hash>/' (FORMAT PARQUET, PARTITION_BY (res), OVERWRITE_OR_IGNORE);
+```
+
+Trade-off: ~17% storage overhead vs. the finest level alone (sum of H3 cell counts at coarser resolutions is geometric in 1/7). Bounded per-tile read cost (one partition file, no cross-resolution aggregation at tile time). Explicit aggregation semantics — the user opts into the aggregation function at registration.
+
+**Zoom → resolution mapping:**
+```python
+target_res = clamp(zoom - 4, min_res, finest_res)
+```
+Roughly matches a hex at the chosen resolution to a few screen pixels at typical zoom levels. Tunable via the tool's optional `zoom_offset` param (default 4).
+
+### Tile generation at request time
+
+Per request, the server:
+
+1. Parses `(namespace, name, z, x, y)` from the URL.
+2. Computes `target_res` from `z`.
+3. Queries the pyramid partition for `res=target_res`:
+   ```sql
+   SELECT h3_cell_to_boundary_wkb(h) AS geom, v1, v2, ...
+   FROM read_parquet('s3://public-output/hex/<hash>/res=<target_res>/*.parquet')
+   WHERE h3_cell_to_parent(h, <tile_res>) IN (<cells_covering_tile>)
+   ```
+   Cell-covering is computed via `h3_polygon_wkt_to_cells` on the tile's web-mercator bounds.
+4. Wraps the result in `ST_AsMVT(ST_AsMVTGeom(geom, tile_bounds))`.
+5. Returns the bytes.
+
+### Connection model
+
+For the tile endpoint specifically (not the existing `query` tool, which keeps its fresh-per-request `:memory:` DB for credential isolation):
+
+- **One persistent `:memory:` DuckDB connection per worker**, created at startup with extensions loaded. Tile requests acquire `con.cursor()` for isolation, execute via `anyio.to_thread.run_sync` to keep the event loop unblocked.
+- Extensions (`httpfs`, `h3`, `spatial`) are already installed at image build time per boettiger-lab/mcp-data-server#54, so startup loads are milliseconds.
+- No credentials are injected into the persistent connection — it only reads from public buckets (`public-output`). Private data for tiles is a v2 concern.
+
+This is process-local cache, not cross-request server state — compatible with horizontal scaling. Each of the 2 k8s replicas maintains its own persistent connection; HAProxy round-robin routing works unchanged.
+
+## MCP tool API
+
+### `register_hex_tiles`
+
+```
+register_hex_tiles(
+    sql: str,                    # SELECT returning (h3_index, value1, value2, ...)
+    finest_res: int,             # resolution of the h3_index column (e.g. 8)
+    min_res: int = 2,            # minimum pyramid resolution
+    agg: str = "AVG",            # aggregation function applied to all value columns
+    zoom_offset: int = 4,        # z → target_res offset; target_res = clamp(z - offset, min_res, finest_res)
+    s3_key: str = None,          # optional private-bucket creds for reading the source data
+    s3_secret: str = None,
+    s3_endpoint: str = None,
+    s3_scope: str = None,
+) -> dict
+```
+
+**Input contract:**
+- The user's `sql` MUST return a column that is an H3 index (uint64 or hex string — whatever DuckDB's h3 extension accepts as input to `h3_cell_to_parent`) as its first column.
+- Subsequent columns are numeric values to aggregate. Column names become MVT feature properties.
+- `finest_res` declares the resolution of the index column. The pyramid builds parents from there; the finest level stores the user's values unaggregated.
+- `agg` applies uniformly to all value columns. Mixed aggregations (mean for one column, sum for another) are a v2 concern; users can register twice.
+- **Private-source caveat:** if the user registers a SQL query that reads private data, the resulting pyramid still lands in `public-output` (a public bucket). This matches the existing `query` + `COPY TO 's3://public-output/...'` pattern — it's a deliberate user action, not accidental leakage. True private-data tile serving (keep the pyramid private, authenticate tile requests) is the v2 rclone-sidecar work.
+
+**Return:**
+```json
+{
+  "tile_url_template": "https://duckdb-mcp.nrp-nautilus.io/tiles/hex/<hash>/{z}/{x}/{y}.pbf",
+  "hash": "<hash>",
+  "bounds": [minlon, minlat, maxlon, maxlat],
+  "finest_res": 8,
+  "min_res": 2,
+  "value_columns": ["v1", "v2"],
+  "feature_count_finest": 573421
+}
+```
+
+The LLM only sees this summary — tile bytes never transit LLM context.
+
+### Client usage pattern (geo-agent)
+
+A client-side tool (`render_h3_tiles`, sibling of `filter_by_query` and the forthcoming `style_by_query`) takes the `tile_url_template` and adds it as a MapLibre vector source:
+
+```js
+map.addSource(sourceId, {
+  type: 'vector',
+  tiles: [tile_url_template],
+  minzoom: 0,
+  maxzoom: 14,
+});
+map.addLayer({
+  id: layerId,
+  type: 'fill',
+  source: sourceId,
+  'source-layer': 'hex',
+  paint: {
+    'fill-color': ['interpolate', ['linear'], ['get', 'v1'], vmin, c0, vmax, c1],
+    'fill-opacity': 0.7,
+  },
+});
+```
+
+Dispatch hint in `assistant-role.md`: use `render_h3_tiles` when the result set would exceed the `style_by_query` / markdown-table scale (>100k features, or when the user asks to visualize raw hexes rather than color an existing polygon layer).
+
+## Client-agnosticism
+
+The tile URL is a standard XYZ MVT endpoint. Any MapLibre-compatible client consumes it identically — QGIS (`Add Vector Tile Layer`), kepler.gl, Felt, custom MapLibre apps. The `register_hex_tiles` MCP tool is the only geo-agent-specific coupling, and it returns enough metadata (`bounds`, `value_columns`, value ranges via a follow-up query if needed) for any client to build styling.
+
+## Deferrals to v2
+
+Tracked but explicitly out of scope for the first implementation:
+
+- **Private-data tiles.** Reading private S3 buckets for the tile-query pyramid requires an rclone-sidecar pattern matching `wyoming/k8s/deployment.yaml` — a colocated rclone container exposing private S3 as authenticated HTTP, with signed-URL generation for the tile endpoint. Register-time read of private source can still use the existing `s3_key`/`s3_secret` flow; the issue is specifically serving tiles that reference private paths.
+- **CDN fronting.** Content-addressable URLs are already cache-friendly. Add a CDN when traffic justifies it. The current 30-day S3 TTL bounds the cache-invalidation problem.
+- **HAProxy consistent-hash routing by tile hash.** Round-robin is fine — each worker's persistent connection caches DuckDB-level metadata, not per-tileset state, so any worker can serve any tile.
+- **Multi-worker per pod.** Currently one worker per replica. Uvicorn `--workers N` is a config change when CPU per replica saturates.
+- **Mixed aggregations per tileset.** Register twice; v2 could accept `agg_per_column`.
+- **Non-hex geometry sources** (arbitrary polygons, lines, points). v1 scope is H3 hexes. Generalization is a separate design once we see the shape of real usage.
+- **Auth on the tile endpoint.** Public by construction in v1 (data is in `public-output`).
+
+## Testing strategy
+
+- **Unit:** `h3-cells-covering-tile` logic against known z/x/y → cell-set fixtures.
+- **Integration:** register a small California r8 tileset, pull `{z=6,7,8,9}/{x,y}` samples, assert MVT bytes decode to expected feature counts per resolution.
+- **Scale smoke test:** register CONUS r8 (~10M cells), measure registration time (single `COPY`), tile latency at representative zooms, S3 bytes-read per tile.
+- **Multi-replica:** verify tile responses are identical across both k8s replicas for the same URL.
+
+## Schema contract for pyramid parquet files
+
+```
+s3://public-output/hex/<hash>/res=<N>/data_0.parquet
+```
+
+Columns:
+- `h` — H3 index at resolution `N` (matches the partition value).
+- `<value_col_1>`, `<value_col_2>`, ... — the user's value columns, aggregated by `agg` for `N < finest_res`, raw for `N == finest_res`.
+
+Partition column: `res` (integer).
+
+Readers (the tile endpoint, future clients) can consume the pyramid directly without the tile server if they want — GeoParquet conversion is a follow-up enhancement.
+
+## Open items to resolve during implementation
+
+- Exact `anyio.to_thread.run_sync` pattern for DuckDB cursor use — confirm cursor is thread-safe for our access pattern.
+- Error taxonomy: invalid hash, resolution out of range, empty tile — map to 404 vs. 204 vs. 200-empty-MVT. Convention is 204 for empty tiles so MapLibre treats as "nothing here" rather than "broken source."
+- Tile-covering at very coarse zooms (z < 3) — the whole pyramid may lie in one tile; short-circuit the `h3_polygon_wkt_to_cells` call.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+Four small scripts showing two ways to talk to the duckdb-geo MCP server:
+
+| File | What it does |
+|---|---|
+| [query.py](query.py) | Direct MCP `query` tool call from Python (no LLM) |
+| [query.R](query.R) | Direct MCP `query` tool call from R via JSON-RPC over HTTP |
+| [agent_langchain.py](agent_langchain.py) | LangGraph ReAct agent that calls MCP tools via tool use |
+| [agent_ellmer.R](agent_ellmer.R) | ellmer chat that calls MCP tools via tool use |
+
+All scripts target the public endpoint `https://duckdb-mcp.nrp-nautilus.io/mcp`.
+The agent examples use `langchain-openai` / `ellmer::chat_openai()` so they work with any OpenAI-compatible endpoint — set `OPENAI_API_KEY` (and optionally `OPENAI_BASE_URL` and `MODEL`) in your environment. The R agent example also requires Node.js (for `npx mcp-remote`).

--- a/examples/agent_ellmer.R
+++ b/examples/agent_ellmer.R
@@ -1,0 +1,56 @@
+# ellmer + mcptools example: let an LLM decide when to call the duckdb-geo
+# MCP tools.
+#
+# mcptools is an MCP *client* for R that plugs MCP tools into ellmer chats.
+# It only speaks stdio, so we bridge to the remote HTTP server through
+# `mcp-remote` (an npx-based stdio <-> HTTP proxy).
+#
+# Requirements:
+#   - Node.js / npx on PATH (npx fetches mcp-remote on first use)
+#   - install.packages(c("ellmer", "mcptools"))
+#
+# Set:
+#   export OPENAI_API_KEY=...            # or any OpenAI-compatible key
+#   export OPENAI_BASE_URL=...           # optional, defaults to OpenAI
+#
+# Run:
+#   Rscript agent_ellmer.R
+
+library(mcptools)
+library(ellmer)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+# Build a Claude-Desktop-style config for mcptools.
+# mcp-remote bridges stdio <-> streamable-HTTP so mcptools can connect
+# to the remote MCP server.
+config_file <- tempfile(fileext = ".json")
+write_json(
+  list(
+    mcpServers = list(
+      `duckdb-geo` = list(
+        command = "npx",
+        args = list("-y", "mcp-remote", mcp_url)
+      )
+    )
+  ),
+  config_file,
+  auto_unbox = TRUE,
+  pretty = TRUE
+)
+
+# Fetch the remote server's tools as ellmer-compatible tool definitions.
+tools <- mcp_tools(config = config_file)
+cat("Available tools:", vapply(tools, \(t) t@name, character(1)), "\n")
+
+# Create a chat session with any OpenAI-compatible model.
+chat <- chat_openai(
+  model = Sys.getenv("MODEL", "gpt-4o"),
+  echo = "output"
+)
+chat$set_tools(tools)
+
+# Ask a question — the model will call browse_stac_catalog, get_stac_details,
+# and query as needed.
+chat$chat("What fraction of Australia is protected area?")

--- a/examples/agent_langchain.py
+++ b/examples/agent_langchain.py
@@ -1,0 +1,53 @@
+"""
+LangChain example: let an LLM decide when to call the duckdb-geo MCP tools.
+
+Uses langchain-mcp-adapters to expose every MCP tool to a LangGraph ReAct
+agent. The model picks the tool, generates SQL, and summarises the result.
+
+Install:
+    pip install langchain-mcp-adapters langchain-openai langgraph
+
+Set:
+    export OPENAI_API_KEY=...            # or use any OpenAI-compatible endpoint
+    export OPENAI_BASE_URL=...           # optional, defaults to OpenAI
+
+Run:
+    python agent_langchain.py
+"""
+
+import asyncio
+import os
+
+from langchain_openai import ChatOpenAI
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+QUESTION = "What fraction of Australia is protected area?"
+
+
+async def main() -> None:
+    client = MultiServerMCPClient(
+        {
+            "duckdb-geo": {
+                "url": MCP_URL,
+                "transport": "streamable_http",
+            }
+        }
+    )
+    tools = await client.get_tools()
+
+    model = ChatOpenAI(
+        model=os.environ.get("MODEL", "gpt-4o"),
+        max_tokens=4096,
+    )
+    agent = create_react_agent(model, tools)
+
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": QUESTION}]}
+    )
+    print(result["messages"][-1].content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/query.R
+++ b/examples/query.R
@@ -1,0 +1,67 @@
+# Minimal R example: call the duckdb-geo MCP `query` tool directly.
+#
+# No LLM involved -- this just speaks MCP over streamable HTTP and runs SQL.
+# There is no R MCP client library, so we hit the JSON-RPC endpoint via httr2.
+# The server runs in stateless mode, so no session handshake is required.
+#
+# Install:
+#   install.packages(c("httr2", "jsonlite"))
+#
+# Run:
+#   Rscript query.R
+
+library(httr2)
+library(jsonlite)
+
+mcp_url <- "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+sql <- "
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"
+
+# MCP streamable-HTTP responses come back as text/event-stream (SSE) by
+# default. Each event is a `data: {...}\n\n` block whose payload is JSON-RPC.
+parse_sse <- function(body) {
+  lines <- strsplit(body, "\n", fixed = TRUE)[[1]]
+  data_lines <- sub("^data: ", "", lines[grepl("^data: ", lines)])
+  lapply(data_lines, fromJSON, simplifyVector = FALSE)
+}
+
+mcp_call <- function(method, params, id = 1L) {
+  resp <- request(mcp_url) |>
+    req_headers(
+      Accept = "application/json, text/event-stream",
+      `Content-Type` = "application/json"
+    ) |>
+    req_body_json(list(
+      jsonrpc = "2.0",
+      id = id,
+      method = method,
+      params = params
+    )) |>
+    req_perform()
+
+  body <- resp_body_string(resp)
+  ctype <- resp_content_type(resp)
+  if (grepl("event-stream", ctype, fixed = TRUE)) {
+    msgs <- parse_sse(body)
+    msgs[[length(msgs)]]            # final message holds the result
+  } else {
+    fromJSON(body, simplifyVector = FALSE)
+  }
+}
+
+# Call the `query` tool.
+resp <- mcp_call("tools/call", list(
+  name = "query",
+  arguments = list(sql_query = sql)
+))
+
+# Each content block has a `text` field; print them all.
+for (block in resp$result$content) {
+  cat(block$text, "\n")
+}

--- a/examples/query.py
+++ b/examples/query.py
@@ -1,0 +1,46 @@
+"""
+Minimal Python example: call the duckdb-geo MCP `query` tool directly.
+
+No LLM involved — this just speaks MCP over streamable HTTP and runs SQL.
+
+Install:
+    pip install mcp
+
+Run:
+    python query.py
+"""
+
+import asyncio
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+MCP_URL = "https://duckdb-mcp.nrp-nautilus.io/mcp"
+
+SQL = """
+SELECT country, name_en, subtype
+FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+WHERE subtype = 'country' AND is_land
+ORDER BY name_en
+LIMIT 10
+"""
+
+
+async def main() -> None:
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            # List the tools the server exposes.
+            tools = await session.list_tools()
+            print("Available tools:", [t.name for t in tools.tools])
+
+            # Call the `query` tool with a SQL string.
+            result = await session.call_tool("query", {"sql_query": SQL})
+            for block in result.content:
+                # Each content block has a `.text` field for text results.
+                print(block.text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -4,6 +4,14 @@
 
 **H3 hex joins replace geometry functions.** Do NOT use `ST_Intersects`, `ST_Contains`, `ST_Area`, or `ST_Within` — these require scanning full polygon geometries and are orders of magnitude slower. Instead, join datasets on their shared H3 index (`h8`, `h0`) to compute overlaps, areas, and containment. If two datasets use different H3 resolutions, convert with `h3_cell_to_parent()`.
 
+## Resolution Direction
+
+**Higher H3 resolution numbers are finer (smaller cells); lower numbers are coarser (larger cells).** h0 is the coarsest (~1000 km edge length); h15 is the finest. A higher-resolution cell is always a *child* of a lower-resolution cell — never the reverse.
+
+- h8 cells are children of h6 cells, not parents
+- If a dataset is indexed at h6, it has no h8 column and no h8_parent column
+- Always check the dataset schema for available resolution columns before writing a join
+
 ## Key Facts
 
 - Always report **areas** (km², acres, etc.), never raw hex counts
@@ -29,7 +37,34 @@ SELECT APPROX_COUNT_DISTINCT(h5) * 252.9 AS area_km2 FROM ...
 
 ## Joining Different Resolutions
 
-Use `h3_cell_to_parent()` — not `h3_cell_to_children()` — to join datasets at different resolutions. Always convert the **finer** (higher number) resolution to the **coarser** (lower number) resolution:
+**Always join by converting the finer (higher-numbered) dataset to the coarser resolution — never look for child columns on the coarser dataset.**
+
+### Step 1: Check for pre-computed parent columns (preferred)
+
+Many fine-resolution datasets (e.g. GEBCO h8) already carry pre-computed parent columns (`h7`, `h6`, `h5`, ...). Use these directly — they are faster than calling `h3_cell_to_parent()` on every row. Check the schema first:
+
+```sql
+-- Check what resolution columns exist
+DESCRIBE SELECT * FROM read_parquet('<STAC_PATH>') LIMIT 1;
+```
+
+If the finer dataset has the target parent column, use it directly:
+
+```sql
+-- GEBCO (h8-indexed, has h6 column) joined to geomorphology (h6-indexed)
+WITH gebco_by_h6 AS (
+  SELECT h6, h0, AVG(elevation) AS avg_elevation
+  FROM read_parquet('<GEBCO_PATH>')
+  GROUP BY h6, h0
+)
+SELECT s.feature_type, g.avg_elevation
+FROM read_parquet('<GEOMORPHOLOGY_PATH>') s
+JOIN gebco_by_h6 g ON s.h6 = g.h6 AND s.h0 = g.h0
+```
+
+### Step 2: Fall back to h3_cell_to_parent() when no pre-computed column exists
+
+Use `h3_cell_to_parent()` — not `h3_cell_to_children()` — when the pre-computed parent column is absent:
 
 ```sql
 -- dataset_a has h8, dataset_b has h4: convert h8 → h4

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -171,3 +171,34 @@ COPY (SELECT ...) TO 's3://public-output/unique-file-name.csv' (FORMAT CSV, HEAD
 Then tell the user the *public https* address (note the use of the public, not private endpoint): it should have the format like: `https://s3-west.nrp-nautilus.io/public-output/unique-file-name.csv` (adjust `unique-file-name.csv` part appropriately.)
 
 **Note:** s3://public-output has a 30-day expiration and 1 Gb object size limit. CORS headers will permit files to be placed here and rendered by other tools.
+
+## Rendering hex results as a map layer
+
+For hex result sets too large to display as a table (roughly >100k cells), or
+whenever the user wants to visualize hexes directly on the map, use the
+`register_hex_tiles` MCP tool instead of returning markdown.
+
+**When to use:**
+- User asks to *show*, *render*, *visualize*, or *color* hexes on the map
+- Result set would exceed the 50-row `query` cap with meaningful content
+- The answer is "per-hex values across a region" rather than "top N rows"
+
+**How to use:**
+1. Write your analysis SQL that returns `(h3_index, value1, value2, ...)` — first
+   column must be the H3 index at your chosen resolution.
+2. Call `register_hex_tiles(sql=..., finest_res=N)` with the resolution of that
+   index column.
+3. Return the `tile_url_template` to the client. Any MapLibre-compatible client
+   (including geo-agent) will render it natively as a vector source.
+
+Example SQL shape for the `sql` parameter:
+
+    SELECT h3_latlng_to_cell(lat, lng, 8) AS h8,
+           AVG(carbon_density) AS carbon
+    FROM read_parquet('s3://public-cng/.../carbon_r8.parquet')
+    WHERE <region filter>
+    GROUP BY 1
+
+The tool handles pyramiding (coarser hexes at lower zooms) and partitioned
+parquet storage automatically. Repeat calls with identical inputs return the
+same URL — natural caching.

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -2,7 +2,12 @@
 
 **Most datasets have H3 hex versions.** Always use them for spatial operations instead of GeoParquet geometry columns.
 
-**H3 hex joins replace geometry functions.** Do NOT use `ST_Intersects`, `ST_Contains`, `ST_Area`, or `ST_Within` — these require scanning full polygon geometries and are orders of magnitude slower. Instead, join datasets on their shared H3 index (`h8`, `h0`) to compute overlaps, areas, and containment. If two datasets use different H3 resolutions, convert with `h3_cell_to_parent()`.
+**Always use H3 hex datasets for filtering and joining — never spatial predicates on GeoParquet.**
+When a dataset appears in the STAC catalog as GeoParquet, a hex-indexed version almost always exists alongside it. Find and use the hex version. Never use `ST_Within`, `ST_Intersects`, `ST_Contains`, or similar predicates to filter or join large datasets — on global data these run 10+ minutes and return nothing useful.
+
+If you browse the catalog and only find a GeoParquet with no hex equivalent, **say so** rather than falling back to spatial predicates. A missing hex version is a data pipeline gap (not something to work around silently).
+
+Small spatial operations on a **single already-retrieved geometry** are fine — e.g. `ST_Centroid` or `ST_AsText` on one result row for display or map zoom. This is different from using spatial predicates to scan or filter a dataset.
 
 ## Resolution Direction
 

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -1,25 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: duckdb-mcp
+  name: dev-duckdb-mcp
   namespace: biodiversity
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
-      app: duckdb-mcp
+      app: dev-duckdb-mcp
   template:
     metadata:
       labels:
-        app: duckdb-mcp
+        app: dev-duckdb-mcp
     spec:
-#      nodeSelector:
-#        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
-#      tolerations:
-#      - key: "nautilus.io/issue"
-#        operator: "Equal"
-#        value: "1476"
-#        effect: "NoSchedule"    
       containers:
       - name: server
         image: astral/uv:python3.12-bookworm-slim
@@ -27,17 +20,19 @@ spec:
         args:
           - |
             apt-get update && apt-get install -y git && \
-            git clone https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch dev https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             uv run --with "mcp" --with "duckdb" --with pandas --with uvicorn --with tabulate --with pystac --with requests server.py
         env:
         - name: STAC_CATALOG_URL
           value: "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
-        resources:   
+        - name: MCP_PUBLIC_BASE_URL
+          value: "https://dev-duckdb-mcp.nrp-nautilus.io"
+        resources:
           requests:
             memory: 16Gi
             cpu: 1
-          limits: 
+          limits:
             memory: 160Gi
             cpu: 16
         ports:
@@ -45,7 +40,6 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 8000
-          initialDelaySeconds: 15  # Give 'uv' time to install deps
+          initialDelaySeconds: 15
           periodSeconds: 5
           failureThreshold: 5
-

--- a/k8s/dev-ingress.yaml
+++ b/k8s/dev-ingress.yaml
@@ -1,39 +1,32 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: mcp-server-duckdb-ingress
+  name: dev-mcp-server-duckdb-ingress
   namespace: biodiversity
   annotations:
-    # CORS configuration for HAProxy Ingress
     haproxy-ingress.github.io/cors-enable: "true"
     haproxy-ingress.github.io/cors-allow-origin: "*"
     haproxy-ingress.github.io/cors-allow-methods: "GET, POST, OPTIONS"
     haproxy-ingress.github.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,mcp-session-id"
     haproxy-ingress.github.io/cors-allow-credentials: "true"
     haproxy-ingress.github.io/cors-max-age: "86400"
-    
-    # Load balancing: route new requests to the pod with fewest active connections
-    # (default round-robin is blind to load; leastconn avoids piling onto busy pods)
     haproxy-ingress.github.io/balance-algorithm: leastconn
-
-    # Timeout settings for long-running queries
-    haproxy-ingress.github.io/timeout-client: "600s"  # 10 minutes - must match timeout-server
-    haproxy-ingress.github.io/timeout-server: "600s"  # 10 minutes for long DuckDB queries
-    haproxy-ingress.github.io/timeout-tunnel: "3600s"  # 1 hour for long-lived SSE connections
-
+    haproxy-ingress.github.io/timeout-client: "600s"
+    haproxy-ingress.github.io/timeout-server: "600s"
+    haproxy-ingress.github.io/timeout-tunnel: "3600s"
 spec:
   ingressClassName: haproxy
   tls:
     - hosts:
-        - duckdb-mcp.nrp-nautilus.io
+        - dev-duckdb-mcp.nrp-nautilus.io
   rules:
-    - host: duckdb-mcp.nrp-nautilus.io
+    - host: dev-duckdb-mcp.nrp-nautilus.io
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: mcp-server-duckdb
+                name: dev-mcp-server-duckdb
                 port:
                   number: 8000

--- a/k8s/dev-service.yaml
+++ b/k8s/dev-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dev-mcp-server-duckdb
+  namespace: biodiversity
+spec:
+  selector:
+    app: dev-duckdb-mcp
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -11,6 +11,10 @@ metadata:
     haproxy-ingress.github.io/cors-allow-credentials: "true"
     haproxy-ingress.github.io/cors-max-age: "86400"
     
+    # Load balancing: route new requests to the pod with fewest active connections
+    # (default round-robin is blind to load; leastconn avoids piling onto busy pods)
+    haproxy-ingress.github.io/balance-algorithm: leastconn
+
     # Timeout settings for long-running queries
     haproxy-ingress.github.io/timeout-client: "600s"  # 10 minutes - must match timeout-server
     haproxy-ingress.github.io/timeout-server: "600s"  # 10 minutes for long DuckDB queries

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mcp-server-duckdb
+  namespace: biodiversity
 spec:
   selector:
     app: duckdb-mcp  

--- a/query-optimization.md
+++ b/query-optimization.md
@@ -49,7 +49,14 @@ program names) are often stored in uppercase or mixed case. Always normalize bot
 WHERE lower(site) LIKE '%' || lower('user input') || '%'
 ```
 
-## 4. Apostrophes in string literals
+## 4. GeoParquet geometry columns
+
+GeoParquet files contain a geometry column (usually `geom`) typed as `GEOMETRY('OGC:CRS84')`.
+This type cannot be displayed in tabular output — the server drops it automatically.
+Avoid `SELECT *` on GeoParquet files; select only the columns you need. If you need
+coordinates, cast explicitly: `ST_AsText(geom) AS geom_wkt`.
+
+## 5. Apostrophes in string literals
 
 Site names and owner names can contain apostrophes (e.g. `O'Brien Ranch`). Double any
 single quote inside a SQL string literal — do not use a backslash:

--- a/server.py
+++ b/server.py
@@ -195,7 +195,6 @@ mcp.tool()(query)
 # -------------------------------------------------------------------------
 # 8b. TILE ENDPOINT — dynamic MVT for H3 hex visualization (see issue #4)
 # -------------------------------------------------------------------------
-from starlette.routing import Route
 from tiles.endpoint import serve_tile
 from tiles.db import build_tile_connection
 from tiles.pyramid import register_hex_tiles as _register_hex_tiles
@@ -252,9 +251,7 @@ def mount_tiles(app):
     # Pre-initialize the connection so first tile request is fast.
     con = _get_tile_con()
     app.state.tile_con = con
-    app.router.routes.append(
-        Route("/tiles/{namespace}/{name}/{z:int}/{x:int}/{y:int}.pbf", serve_tile)
-    )
+    app.add_route("/tiles/{namespace}/{name}/{z:int}/{x:int}/{y:int}.pbf", serve_tile)
 
 # -------------------------------------------------------------------------
 # 9. OPTIONAL BEARER TOKEN AUTH

--- a/server.py
+++ b/server.py
@@ -193,6 +193,70 @@ Credentials are scoped to this request only and never persisted.
 mcp.tool()(query)
 
 # -------------------------------------------------------------------------
+# 8b. TILE ENDPOINT — dynamic MVT for H3 hex visualization (see issue #4)
+# -------------------------------------------------------------------------
+from starlette.routing import Route
+from tiles.endpoint import serve_tile
+from tiles.db import build_tile_connection
+from tiles.pyramid import register_hex_tiles as _register_hex_tiles
+
+
+# Module-level persistent connection. Initialized lazily at first use OR
+# at startup via the lifespan in mount_tiles().
+_tile_con = None
+
+
+def _get_tile_con():
+    global _tile_con
+    if _tile_con is None:
+        _tile_con = build_tile_connection()
+    return _tile_con
+
+
+def register_hex_tiles(
+    sql: str,
+    finest_res: int,
+    min_res: int = 2,
+    agg: str = "AVG",
+    zoom_offset: int = 4,
+) -> dict:
+    """Materialize a partitioned H3 hex pyramid to public object storage and return
+    a MapLibre-compatible vector tile URL template.
+
+    Use this tool for H3 hex datasets too large to return as markdown table —
+    roughly >100k cells, or any case where the user wants to visualize hexes
+    directly on the map (rather than color an existing polygon layer).
+
+    Input SQL contract: return (h3_index, value1, value2, ...) where the first
+    column is an H3 index at resolution `finest_res`, and subsequent columns
+    are numeric values. All value columns are aggregated by `agg` (AVG, SUM, MIN,
+    MAX, COUNT) at each coarser resolution down to `min_res`.
+
+    Returns a dict with `tile_url_template` that any MapLibre client can consume
+    via:
+        map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
+        map.addLayer({..., 'source-layer': 'hex', paint: {...}});
+    """
+    con = _get_tile_con()
+    return _register_hex_tiles(
+        con=con, sql=sql, finest_res=finest_res, min_res=min_res,
+        agg=agg, zoom_offset=zoom_offset,
+    )
+
+
+mcp.tool()(register_hex_tiles)
+
+
+def mount_tiles(app):
+    """Mount the /tiles route onto the Starlette app and ensure tile con is ready."""
+    # Pre-initialize the connection so first tile request is fast.
+    con = _get_tile_con()
+    app.state.tile_con = con
+    app.router.routes.append(
+        Route("/tiles/{namespace}/{name}/{z:int}/{x:int}/{y:int}.pbf", serve_tile)
+    )
+
+# -------------------------------------------------------------------------
 # 9. OPTIONAL BEARER TOKEN AUTH
 # -------------------------------------------------------------------------
 _MCP_AUTH_TOKEN = os.environ.get("MCP_AUTH_TOKEN", "").strip()
@@ -211,6 +275,7 @@ class _BearerAuthMiddleware(BaseHTTPMiddleware):
 if __name__ == "__main__":
     app = mcp.streamable_http_app()
     app.router.redirect_slashes = False
+    mount_tiles(app)
 
     if _MCP_AUTH_TOKEN:
         app.add_middleware(_BearerAuthMiddleware)

--- a/server.py
+++ b/server.py
@@ -90,7 +90,6 @@ TOOL_INJECTED_CONTEXT = f"""
 def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None):
     conn = duckdb.connect(database=":memory:")
     try:
-        conn.execute("SET statement_timeout = '600s'")
         for stmt in (s.strip() for s in SETUP_SQL.split(";") if s.strip()):
             try:
                 conn.sql(stmt)
@@ -161,6 +160,13 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
         with get_isolated_db(s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope) as db:
             result = db.sql(sql_query)
             if result is None: return "Command executed successfully."
+
+            # Drop geometry columns — GEOMETRY('OGC:CRS84') crashes pandas conversion
+            # (DuckDB issue: unsupported NumPy type). Geometry is not useful in tabular output.
+            geom_cols = [c for c, t in zip(result.columns, result.dtypes) if "GEOMETRY" in str(t).upper()]
+            if geom_cols:
+                keep = [f'"{c}"' for c in result.columns if c not in geom_cols]
+                result = result.select(", ".join(keep))
 
             df = result.limit(50).df()
             if df.empty: return "No results found."

--- a/server.py
+++ b/server.py
@@ -90,6 +90,7 @@ TOOL_INJECTED_CONTEXT = f"""
 def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None):
     conn = duckdb.connect(database=":memory:")
     try:
+        conn.execute("SET statement_timeout = '600s'")
         for stmt in (s.strip() for s in SETUP_SQL.split(";") if s.strip()):
             try:
                 conn.sql(stmt)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -275,5 +275,25 @@ class TestS3Credentials:
         assert "MY_SECRET_VALUE" not in captured.err
 
 
+class TestTileRouteMounted:
+    def test_tile_route_exists_in_starlette_app(self):
+        """After importing server, the streamable_http_app should have a /tiles route."""
+        from server import mcp
+        app = mcp.streamable_http_app()
+        # Also apply our own mount (mimicking the startup block).
+        from server import mount_tiles
+        mount_tiles(app)
+        paths = [getattr(r, "path", None) or getattr(r, "path_format", None) for r in app.routes]
+        assert any(p and "/tiles/" in p for p in paths)
+
+    def test_register_hex_tiles_is_an_mcp_tool(self):
+        """The MCP server should expose register_hex_tiles as a tool."""
+        from server import mcp
+        # FastMCP tracks tools on its internal registry; adapt to the API.
+        import anyio
+        tool_names = [t.name for t in anyio.run(mcp.list_tools)]
+        assert "register_hex_tiles" in tool_names
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -76,3 +76,28 @@ class TestServeTile:
         client = TestClient(app_with_tiles)
         r = client.get(f"/tiles/bogus/{registered_ca}/5/5/12.pbf")
         assert r.status_code == 404
+
+
+class TestMetadataDriven:
+    def test_endpoint_reads_finest_res_from_metadata(self, app_with_tiles, local_bucket):
+        """After registering with finest_res=4, a tile request should use res=4 max."""
+        con = app_with_tiles.state.tile_con
+        user_sql = """
+            SELECT h3_latlng_to_cell(37.8, -122.3, 4) AS h4, 1.0 AS val
+        """
+        result = register_hex_tiles(
+            con=con, sql=user_sql, finest_res=4, min_res=2, agg="AVG", zoom_offset=4,
+        )
+        client = TestClient(app_with_tiles)
+        # At z=20 with zoom_offset=4 → target_res=16, clamped to finest_res=4.
+        # Tile over (37.8, -122.3) at z=20 covers one r4 hex or so. Main assertion:
+        # request succeeds (not 404 from "no pyramid at res=16").
+        # Compute approximate tile (x,y) at z=20 for (37.8, -122.3):
+        import math
+        lat_rad = math.radians(37.8)
+        z = 20
+        n = 2 ** z
+        x = int((-122.3 + 180) / 360 * n)
+        y = int((1 - math.log(math.tan(lat_rad) + 1/math.cos(lat_rad)) / math.pi) / 2 * n)
+        r = client.get(f"/tiles/hex/{result['hash']}/{z}/{x}/{y}.pbf")
+        assert r.status_code in (200, 204)  # not 404

--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -1,0 +1,78 @@
+import os
+import pytest
+import duckdb
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tiles.endpoint import serve_tile
+from tiles.pyramid import register_hex_tiles
+from tiles.db import build_tile_connection
+
+
+@pytest.fixture
+def local_bucket(tmp_path, monkeypatch):
+    bucket = tmp_path / "tiles-bucket"
+    bucket.mkdir()
+    monkeypatch.setenv("TILE_BUCKET_BASE", str(bucket))
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "http://test.local")
+    return bucket
+
+
+@pytest.fixture
+def app_with_tiles(local_bucket):
+    """Build a minimal Starlette app that mounts the tile route with a live connection."""
+    con = build_tile_connection()
+    app = Starlette(routes=[
+        Route("/tiles/{namespace}/{name}/{z:int}/{x:int}/{y:int}.pbf", serve_tile),
+    ])
+    app.state.tile_con = con
+    yield app
+    con.close()
+
+
+@pytest.fixture
+def registered_ca(app_with_tiles):
+    """Register a small California tileset and return its hash."""
+    con = app_with_tiles.state.tile_con
+    # Generate ~few hundred r5 cells across California.
+    user_sql = """
+        SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, 1.0 AS val
+        FROM (
+            SELECT 36 + random()*3 AS lat, -121 - random()*3 AS lng
+            FROM range(500)
+        )
+    """
+    result = register_hex_tiles(
+        con=con, sql=user_sql, finest_res=5, min_res=2, agg="AVG", zoom_offset=4,
+    )
+    return result["hash"]
+
+
+class TestServeTile:
+    def test_returns_mvt_content_type_for_covering_tile(self, app_with_tiles, registered_ca):
+        client = TestClient(app_with_tiles)
+        # z=5 tile that covers part of California.
+        # California is near tile (5, 5, 12) in XYZ.
+        r = client.get(f"/tiles/hex/{registered_ca}/5/5/12.pbf")
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "application/vnd.mapbox-vector-tile"
+        assert len(r.content) > 0
+
+    def test_empty_tile_returns_204(self, app_with_tiles, registered_ca):
+        client = TestClient(app_with_tiles)
+        # A tile over open ocean far from California should be empty.
+        r = client.get(f"/tiles/hex/{registered_ca}/5/0/0.pbf")
+        assert r.status_code in (200, 204)  # implementations may differ
+        if r.status_code == 200:
+            assert len(r.content) < 100  # empty MVT is very small
+
+    def test_unknown_hash_returns_404(self, app_with_tiles):
+        client = TestClient(app_with_tiles)
+        r = client.get("/tiles/hex/0000000000000000/5/5/12.pbf")
+        assert r.status_code == 404
+
+    def test_unknown_namespace_returns_404(self, app_with_tiles, registered_ca):
+        client = TestClient(app_with_tiles)
+        r = client.get(f"/tiles/bogus/{registered_ca}/5/5/12.pbf")
+        assert r.status_code == 404

--- a/tests/test_tile_math.py
+++ b/tests/test_tile_math.py
@@ -1,1 +1,33 @@
-"""Tests for tiles.tile_math. Populated in Task 2."""
+import math
+import pytest
+from tiles.tile_math import tile_xyz_to_lnglat_bounds
+
+
+class TestTileBounds:
+    def test_z0_is_whole_world(self):
+        w, s, e, n = tile_xyz_to_lnglat_bounds(0, 0, 0)
+        assert w == pytest.approx(-180.0)
+        assert e == pytest.approx(180.0)
+        assert s == pytest.approx(-math.degrees(math.atan(math.sinh(math.pi))))
+        assert n == pytest.approx(math.degrees(math.atan(math.sinh(math.pi))))
+
+    def test_z1_nw_quadrant(self):
+        # Tile (0,0) at z=1 is the northwest quadrant.
+        w, s, e, n = tile_xyz_to_lnglat_bounds(1, 0, 0)
+        assert w == pytest.approx(-180.0)
+        assert e == pytest.approx(0.0)
+        assert n > 0
+        assert s == pytest.approx(0.0)
+
+    def test_z1_se_quadrant(self):
+        w, s, e, n = tile_xyz_to_lnglat_bounds(1, 1, 1)
+        assert w == pytest.approx(0.0)
+        assert e == pytest.approx(180.0)
+        assert s < 0
+        assert n == pytest.approx(0.0)
+
+    def test_bounds_monotonic_in_x(self):
+        # Adjacent tiles share an edge.
+        _, _, e1, _ = tile_xyz_to_lnglat_bounds(5, 10, 12)
+        w2, _, _, _ = tile_xyz_to_lnglat_bounds(5, 11, 12)
+        assert e1 == pytest.approx(w2)

--- a/tests/test_tile_math.py
+++ b/tests/test_tile_math.py
@@ -1,0 +1,1 @@
+"""Tests for tiles.tile_math. Populated in Task 2."""

--- a/tests/test_tile_math.py
+++ b/tests/test_tile_math.py
@@ -31,3 +31,43 @@ class TestTileBounds:
         _, _, e1, _ = tile_xyz_to_lnglat_bounds(5, 10, 12)
         w2, _, _, _ = tile_xyz_to_lnglat_bounds(5, 11, 12)
         assert e1 == pytest.approx(w2)
+
+
+from tiles.tile_math import zoom_to_h3_res, content_hash
+
+
+class TestZoomToRes:
+    def test_default_offset_maps_z8_to_r4(self):
+        assert zoom_to_h3_res(8, min_res=2, finest_res=9, zoom_offset=4) == 4
+
+    def test_clamped_at_min_res(self):
+        assert zoom_to_h3_res(0, min_res=2, finest_res=9, zoom_offset=4) == 2
+        assert zoom_to_h3_res(3, min_res=2, finest_res=9, zoom_offset=4) == 2
+
+    def test_clamped_at_finest_res(self):
+        assert zoom_to_h3_res(20, min_res=2, finest_res=8, zoom_offset=4) == 8
+
+    def test_custom_offset(self):
+        assert zoom_to_h3_res(10, min_res=2, finest_res=9, zoom_offset=2) == 8
+
+
+class TestContentHash:
+    def test_stable_for_identical_inputs(self):
+        h1 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        h2 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        assert h1 == h2
+
+    def test_differs_when_sql_differs(self):
+        h1 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        h2 = content_hash(sql="SELECT 2", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        assert h1 != h2
+
+    def test_differs_when_agg_differs(self):
+        h1 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        h2 = content_hash(sql="SELECT 1", finest_res=8, min_res=2, agg="SUM", zoom_offset=4)
+        assert h1 != h2
+
+    def test_length_is_16_hex_chars(self):
+        h = content_hash(sql="x", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -44,8 +44,8 @@ class TestBuildPyramidSQL:
             h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        # Parent selects use SUM(val)
-        assert "SUM(val)" in sql
+        # Parent selects use SUM("val") — column names are quoted
+        assert 'SUM("val")' in sql
 
     def test_partitions_by_res(self):
         sql = build_pyramid_sql(
@@ -65,8 +65,8 @@ class TestBuildPyramidSQL:
             value_columns=["v1", "v2"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        assert "AVG(v1)" in sql
-        assert "AVG(v2)" in sql
+        assert 'AVG("v1")' in sql
+        assert 'AVG("v2")' in sql
 
     def test_min_res_equals_finest_res_single_level(self):
         sql = build_pyramid_sql(

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -77,3 +77,77 @@ class TestBuildPyramidSQL:
         )
         # Only the finest level — no UNION ALL.
         assert "UNION ALL" not in sql
+
+
+import os
+import duckdb
+from pathlib import Path
+from tiles.pyramid import register_hex_tiles
+
+
+@pytest.fixture
+def local_bucket(tmp_path, monkeypatch):
+    """Point TILE_BUCKET_BASE at a local directory so no S3 is required."""
+    bucket = tmp_path / "tiles-bucket"
+    bucket.mkdir()
+    monkeypatch.setenv("TILE_BUCKET_BASE", str(bucket))
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "http://test.local")
+    return bucket
+
+
+@pytest.fixture
+def h3_conn():
+    con = duckdb.connect(":memory:")
+    con.sql("INSTALL h3 FROM community; LOAD h3")
+    con.sql("INSTALL spatial; LOAD spatial")
+    con.sql("INSTALL httpfs; LOAD httpfs")
+    yield con
+    con.close()
+
+
+class TestRegisterHexTiles:
+    def test_writes_pyramid_partitions(self, local_bucket, h3_conn):
+        # Source: 5 cells at r5 around a point.
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, val
+            FROM (VALUES (37.8, -122.3, 1.0),
+                         (37.9, -122.4, 2.0),
+                         (38.0, -122.5, 3.0),
+                         (38.1, -122.6, 4.0),
+                         (38.2, -122.7, 5.0)) t(lat, lng, val)
+        """
+        result = register_hex_tiles(
+            con=h3_conn,
+            sql=user_sql,
+            finest_res=5,
+            min_res=2,
+            agg="AVG",
+            zoom_offset=4,
+        )
+        assert "hash" in result
+        # Partitioned files written: res=2 through res=5.
+        for res in (2, 3, 4, 5):
+            partition = local_bucket / "hex" / result["hash"] / f"res={res}"
+            assert partition.exists(), f"Missing res={res}"
+            assert any(partition.iterdir()), f"Empty res={res}"
+
+    def test_tile_url_template_uses_public_base(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+        )
+        assert result["tile_url_template"].startswith("http://test.local/tiles/hex/")
+        assert result["tile_url_template"].endswith("/{z}/{x}/{y}.pbf")
+
+    def test_returns_value_columns(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS v1, 2.0 AS v2"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+        )
+        assert result["value_columns"] == ["v1", "v2"]
+
+    def test_identical_inputs_same_hash(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        r1 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
+        r2 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
+        assert r1["hash"] == r2["hash"]

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -151,3 +151,28 @@ class TestRegisterHexTiles:
         r1 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
         r2 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
         assert r1["hash"] == r2["hash"]
+
+
+from tiles.db import build_tile_connection
+
+
+class TestBuildTileConnection:
+    def test_loads_required_extensions(self):
+        con = build_tile_connection()
+        try:
+            # Proxy: LOAD must have succeeded if these functions are callable.
+            con.sql("SELECT h3_latlng_to_cell(37.8, -122.3, 5)").fetchone()
+            con.sql("SELECT ST_Point(0, 0)").fetchone()
+            # httpfs loaded — confirm by presence of its config.
+            con.sql("SELECT current_setting('s3_region')").fetchone()
+        finally:
+            con.close()
+
+    def test_no_s3_secret_created(self):
+        con = build_tile_connection()
+        try:
+            names = [r[0] for r in con.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+            # Persistent tile connection reads only from public buckets.
+            assert "client_s3" not in names
+        finally:
+            con.close()

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -153,6 +153,25 @@ class TestRegisterHexTiles:
         assert r1["hash"] == r2["hash"]
 
 
+import json as _json
+
+
+class TestTilesetMetadata:
+    def test_metadata_written_alongside_pyramid(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=3, agg="SUM", zoom_offset=3,
+        )
+        meta_path = local_bucket / "hex" / result["hash"] / "metadata.json"
+        assert meta_path.exists()
+        meta = _json.loads(meta_path.read_text())
+        assert meta["finest_res"] == 5
+        assert meta["min_res"] == 3
+        assert meta["agg"] == "SUM"
+        assert meta["zoom_offset"] == 3
+        assert meta["value_columns"] == ["val"]
+
+
 from tiles.db import build_tile_connection
 
 

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -1,0 +1,79 @@
+import re
+import pytest
+from tiles.pyramid import build_pyramid_sql
+
+
+class TestBuildPyramidSQL:
+    def test_contains_one_select_per_resolution(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8,
+            min_res=2,
+            agg="AVG",
+            value_columns=["val"],
+            h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Parents at res 2..7, plus finest level at res 8. 7 SELECTs total.
+        union_alls = len(re.findall(r"\bUNION ALL\b", sql, re.IGNORECASE))
+        assert union_alls == 6  # 7 selects → 6 UNION ALLs
+
+    def test_finest_level_is_ungrouped(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8,
+            min_res=2,
+            agg="AVG",
+            value_columns=["val"],
+            h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # The finest-res SELECT should NOT have AVG/SUM wrapping the value column.
+        # Look for the "... AS res" marker equal to finest_res.
+        finest_select = re.search(r"SELECT[^)]*?8 AS res FROM src", sql, re.DOTALL)
+        assert finest_select is not None
+        assert "AVG" not in finest_select.group(0)
+
+    def test_parent_levels_aggregate(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8,
+            min_res=2,
+            agg="SUM",
+            value_columns=["val"],
+            h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Parent selects use SUM(val)
+        assert "SUM(val)" in sql
+
+    def test_partitions_by_res(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert "PARTITION_BY (res)" in sql
+        assert "OVERWRITE_OR_IGNORE" in sql
+        assert "FORMAT PARQUET" in sql
+
+    def test_multiple_value_columns(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, v1, v2 FROM src",
+            finest_res=8, min_res=2, agg="AVG",
+            value_columns=["v1", "v2"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert "AVG(v1)" in sql
+        assert "AVG(v2)" in sql
+
+    def test_min_res_equals_finest_res_single_level(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=8, agg="AVG",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Only the finest level — no UNION ALL.
+        assert "UNION ALL" not in sql

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -1,0 +1,39 @@
+"""Persistent :memory: DuckDB connection for the tile endpoint.
+
+Separate from the per-request isolated connections used by the `query` tool:
+tile requests never take user credentials, so the connection can be long-lived
+and shared across requests via con.cursor() for per-request isolation.
+"""
+import sys
+from contextlib import asynccontextmanager
+import duckdb
+
+
+def build_tile_connection() -> duckdb.DuckDBPyConnection:
+    """Create a :memory: connection with extensions loaded.
+
+    Extensions are assumed to be pre-installed in the image (see mcp-data-server#54);
+    LOAD is per-session and always required.
+    """
+    con = duckdb.connect(":memory:")
+    # Extensions may not be pre-installed in dev environments — install defensively.
+    con.sql("INSTALL httpfs; LOAD httpfs")
+    con.sql("INSTALL spatial; LOAD spatial")
+    con.sql("INSTALL h3 FROM community; LOAD h3")
+    return con
+
+
+@asynccontextmanager
+async def tile_lifespan(app):
+    """Starlette lifespan that creates and tears down the persistent connection.
+
+    Stored on app.state.tile_con so request handlers can reach it.
+    """
+    con = build_tile_connection()
+    print("📦 Tile endpoint: persistent DuckDB connection ready", file=sys.stderr)
+    app.state.tile_con = con
+    try:
+        yield
+    finally:
+        con.close()
+        print("📦 Tile endpoint: connection closed", file=sys.stderr)

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -4,8 +4,6 @@ Separate from the per-request isolated connections used by the `query` tool:
 tile requests never take user credentials, so the connection can be long-lived
 and shared across requests via con.cursor() for per-request isolation.
 """
-import sys
-from contextlib import asynccontextmanager
 import duckdb
 
 
@@ -21,19 +19,3 @@ def build_tile_connection() -> duckdb.DuckDBPyConnection:
     con.sql("INSTALL spatial; LOAD spatial")
     con.sql("INSTALL h3 FROM community; LOAD h3")
     return con
-
-
-@asynccontextmanager
-async def tile_lifespan(app):
-    """Starlette lifespan that creates and tears down the persistent connection.
-
-    Stored on app.state.tile_con so request handlers can reach it.
-    """
-    con = build_tile_connection()
-    print("📦 Tile endpoint: persistent DuckDB connection ready", file=sys.stderr)
-    app.state.tile_con = con
-    try:
-        yield
-    finally:
-        con.close()
-        print("📦 Tile endpoint: connection closed", file=sys.stderr)

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -41,20 +41,20 @@ def _tileset_dir(namespace: str, name: str) -> str:
     return f"{_bucket_base()}/{namespace}/{name}"
 
 
-def _read_metadata(namespace: str, name: str):
-    """Read the metadata.json sidecar for a tileset. Returns None if missing."""
+def _read_metadata(con, namespace: str, name: str):
+    """Read the metadata.json sidecar for a tileset using an existing connection.
+
+    Uses the persistent tile_con (already has httpfs loaded) rather than
+    opening a new DuckDB connection per request.
+    Returns None if the sidecar is missing or unreadable.
+    """
     uri = f"{_tileset_dir(namespace, name)}/metadata.json"
     try:
-        # Local path shortcut for tests (no need for an extra DuckDB connection).
+        # Local path shortcut for tests.
         if not uri.startswith("s3://") and not uri.startswith("http"):
             with open(uri, "r") as f:
                 return json.loads(f.read().strip())
-        # For S3, use a one-off DuckDB connection to read via httpfs.
-        import duckdb
-        c = duckdb.connect(":memory:")
-        c.sql("INSTALL httpfs; LOAD httpfs")
-        row = c.sql(f"SELECT content FROM read_text('{uri}')").fetchone()
-        c.close()
+        row = con.cursor().sql(f"SELECT content FROM read_text('{uri}')").fetchone()
         if row is None:
             return None
         return json.loads(row[0])
@@ -62,6 +62,26 @@ def _read_metadata(namespace: str, name: str):
         return None
     except Exception:
         return None
+
+
+def _get_cached_metadata(app_state, con, namespace: str, name: str):
+    """Return metadata for a tileset, caching it on app.state after first read.
+
+    Metadata never changes after registration, so one read per server lifetime
+    is sufficient.
+    """
+    cache_attr = "_tile_meta_cache"
+    cache = getattr(app_state, cache_attr, None)
+    if cache is None:
+        cache = {}
+        setattr(app_state, cache_attr, cache)
+    key = f"{namespace}/{name}"
+    if key not in cache:
+        meta = _read_metadata(con, namespace, name)
+        if meta is not None:
+            cache[key] = meta
+        return meta
+    return cache[key]
 
 
 def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
@@ -134,7 +154,9 @@ async def serve_tile(request: Request) -> Response:
 
     con = request.app.state.tile_con
 
-    meta = await anyio.to_thread.run_sync(_read_metadata, namespace, name)
+    meta = await anyio.to_thread.run_sync(
+        _get_cached_metadata, request.app.state, con, namespace, name
+    )
     if meta is None:
         return Response(status_code=404)
     finest_res = meta["finest_res"]

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -1,0 +1,148 @@
+"""Starlette request handler for /tiles/{namespace}/{name}/{z}/{x}/{y}.pbf.
+
+Verified DuckDB signatures (from Task 1 probe, commit 0ff46e8):
+- ST_AsMVTGeom(geom, bounds[, extent, buffer, clip_geom]) -> GEOMETRY
+  bounds must be BOX_2D, not GEOMETRY. Use struct cast: {'min_x':…}::BOX_2D
+- ST_AsMVT(col0[, col1..col4]) -> BLOB  (aggregate)
+- h3_polygon_wkt_to_cells(wkt, resolution) -> UBIGINT[]
+- h3_cell_to_boundary_wkt(cell) -> VARCHAR
+- ST_Transform requires always_xy=true (4th arg) for EPSG:4326→EPSG:3857
+"""
+import math
+import os
+import sys
+import anyio
+from starlette.requests import Request
+from starlette.responses import Response
+
+from tiles.tile_math import tile_xyz_to_lnglat_bounds, zoom_to_h3_res
+
+
+MVT_CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
+
+
+def _lng_to_merc_x(lng: float) -> float:
+    """Convert longitude (degrees) to Web Mercator X (EPSG:3857)."""
+    return lng * 20037508.34 / 180.0
+
+
+def _lat_to_merc_y(lat: float) -> float:
+    """Convert latitude (degrees) to Web Mercator Y (EPSG:3857)."""
+    y = math.log(math.tan((90.0 + lat) * math.pi / 360.0)) / (math.pi / 180.0)
+    return y * 20037508.34 / 180.0
+
+
+def _bucket_base() -> str:
+    return os.environ.get("TILE_BUCKET_BASE", "s3://public-output").rstrip("/")
+
+
+def _tileset_dir(namespace: str, name: str) -> str:
+    return f"{_bucket_base()}/{namespace}/{name}"
+
+
+def _pyramid_exists(con, namespace: str, name: str, res: int) -> bool:
+    """Check whether the pyramid partition for (namespace, name, res) is readable."""
+    uri = f"{_tileset_dir(namespace, name)}/res={res}/*.parquet"
+    try:
+        cur = con.cursor()
+        cur.sql(f"SELECT 1 FROM read_parquet('{uri}') LIMIT 1").fetchone()
+        return True
+    except Exception:
+        return False
+
+
+def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
+                    target_res: int, finest_res: int) -> str:
+    """Produce the SQL that returns a single BLOB row (the MVT for this tile).
+
+    Strategy:
+      1. Compute the tile's web-mercator bounds as a BOX_2D struct (Python-side).
+      2. Compute H3 cells at target_res covering the tile's lng/lat polygon.
+      3. Select rows from the pyramid partition whose cell is in that set.
+      4. Project cell geometries with ST_AsMVTGeom then aggregate with ST_AsMVT.
+
+    Notes:
+    - ST_AsMVTGeom requires BOX_2D (not GEOMETRY). We build it as a struct cast.
+    - ST_Transform needs always_xy=true (4th arg) for EPSG:4326→EPSG:3857.
+    """
+    west, south, east, north = tile_xyz_to_lnglat_bounds(z, x, y)
+    tileset = _tileset_dir(namespace, name)
+    tile_wkt = (
+        f"POLYGON(("
+        f"{west} {south}, {east} {south}, {east} {north}, "
+        f"{west} {north}, {west} {south}))"
+    )
+    # Pre-compute web-mercator bounds in Python — avoids ST_Transform inside SQL
+    # for the envelope, and lets us pass a literal BOX_2D struct.
+    mx_w = _lng_to_merc_x(west)
+    mx_e = _lng_to_merc_x(east)
+    my_s = _lat_to_merc_y(south)
+    my_n = _lat_to_merc_y(north)
+    return f"""
+        WITH cells AS (
+          SELECT UNNEST(h3_polygon_wkt_to_cells('{tile_wkt}', {target_res})) AS cell
+        ),
+        src AS (
+          SELECT p.* FROM read_parquet('{tileset}/res={target_res}/*.parquet') p
+          SEMI JOIN cells c ON p.h = c.cell
+        ),
+        projected AS (
+          SELECT
+            ST_AsMVTGeom(
+              ST_Transform(h3_cell_to_boundary_wkt(h)::GEOMETRY, 'EPSG:4326', 'EPSG:3857', true),
+              {{'min_x': {mx_w}, 'min_y': {my_s}, 'max_x': {mx_e}, 'max_y': {my_n}}}::BOX_2D
+            ) AS geom,
+            src.* EXCLUDE (h)
+          FROM src
+        )
+        SELECT ST_AsMVT(projected) FROM projected WHERE geom IS NOT NULL
+    """
+
+
+def _run_tile_query(con, sql: str) -> bytes:
+    """Run the tile SQL on a fresh cursor and return raw MVT bytes (or empty)."""
+    cur = con.cursor()
+    row = cur.sql(sql).fetchone()
+    if row is None or row[0] is None:
+        return b""
+    return bytes(row[0])
+
+
+async def serve_tile(request: Request) -> Response:
+    """GET /tiles/{namespace}/{name}/{z}/{x}/{y}.pbf"""
+    namespace = request.path_params["namespace"]
+    name = request.path_params["name"]
+    z = int(request.path_params["z"])
+    x = int(request.path_params["x"])
+    y = int(request.path_params["y"])
+
+    if namespace != "hex":
+        return Response(status_code=404)
+
+    con = request.app.state.tile_con
+
+    # Probe whether the tileset exists at any res — use finest since it's always present.
+    # We don't know finest_res at tile-serving time without metadata; try a few.
+    # Convention: we accept whatever res in [2..15] has data.
+    target_res = None
+    for guess_finest in range(15, 1, -1):
+        if await anyio.to_thread.run_sync(_pyramid_exists, con, namespace, name, guess_finest):
+            finest_res = guess_finest
+            # (Floor of) zoom_to_h3_res with default zoom_offset=4 and min_res=2.
+            # In v1 we don't persist zoom_offset/min_res per-tileset — caller's registered
+            # URL captures the content hash, so clients get stable tiles. Use defaults.
+            target_res = zoom_to_h3_res(z, min_res=2, finest_res=finest_res, zoom_offset=4)
+            break
+    if target_res is None:
+        return Response(status_code=404)
+
+    sql = _build_tile_sql(namespace, name, z, x, y, target_res, finest_res)
+    try:
+        mvt_bytes = await anyio.to_thread.run_sync(_run_tile_query, con, sql)
+    except Exception as e:
+        print(f"Tile {z}/{x}/{y} error: {e}", file=sys.stderr)
+        return Response(status_code=500)
+
+    if not mvt_bytes:
+        return Response(status_code=204)
+    return Response(content=mvt_bytes, media_type=MVT_CONTENT_TYPE)

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -8,6 +8,7 @@ Verified DuckDB signatures (from Task 1 probe, commit 0ff46e8):
 - h3_cell_to_boundary_wkt(cell) -> VARCHAR
 - ST_Transform requires always_xy=true (4th arg) for EPSG:4326→EPSG:3857
 """
+import json
 import math
 import os
 import sys
@@ -40,15 +41,27 @@ def _tileset_dir(namespace: str, name: str) -> str:
     return f"{_bucket_base()}/{namespace}/{name}"
 
 
-def _pyramid_exists(con, namespace: str, name: str, res: int) -> bool:
-    """Check whether the pyramid partition for (namespace, name, res) is readable."""
-    uri = f"{_tileset_dir(namespace, name)}/res={res}/*.parquet"
+def _read_metadata(namespace: str, name: str):
+    """Read the metadata.json sidecar for a tileset. Returns None if missing."""
+    uri = f"{_tileset_dir(namespace, name)}/metadata.json"
     try:
-        cur = con.cursor()
-        cur.sql(f"SELECT 1 FROM read_parquet('{uri}') LIMIT 1").fetchone()
-        return True
+        # Local path shortcut for tests (no need for an extra DuckDB connection).
+        if not uri.startswith("s3://") and not uri.startswith("http"):
+            with open(uri, "r") as f:
+                return json.loads(f.read().strip())
+        # For S3, use a one-off DuckDB connection to read via httpfs.
+        import duckdb
+        c = duckdb.connect(":memory:")
+        c.sql("INSTALL httpfs; LOAD httpfs")
+        row = c.sql(f"SELECT content FROM read_text('{uri}')").fetchone()
+        c.close()
+        if row is None:
+            return None
+        return json.loads(row[0])
+    except FileNotFoundError:
+        return None
     except Exception:
-        return False
+        return None
 
 
 def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
@@ -121,20 +134,13 @@ async def serve_tile(request: Request) -> Response:
 
     con = request.app.state.tile_con
 
-    # Probe whether the tileset exists at any res — use finest since it's always present.
-    # We don't know finest_res at tile-serving time without metadata; try a few.
-    # Convention: we accept whatever res in [2..15] has data.
-    target_res = None
-    for guess_finest in range(15, 1, -1):
-        if await anyio.to_thread.run_sync(_pyramid_exists, con, namespace, name, guess_finest):
-            finest_res = guess_finest
-            # (Floor of) zoom_to_h3_res with default zoom_offset=4 and min_res=2.
-            # In v1 we don't persist zoom_offset/min_res per-tileset — caller's registered
-            # URL captures the content hash, so clients get stable tiles. Use defaults.
-            target_res = zoom_to_h3_res(z, min_res=2, finest_res=finest_res, zoom_offset=4)
-            break
-    if target_res is None:
+    meta = await anyio.to_thread.run_sync(_read_metadata, namespace, name)
+    if meta is None:
         return Response(status_code=404)
+    finest_res = meta["finest_res"]
+    min_res = meta["min_res"]
+    zoom_offset = meta["zoom_offset"]
+    target_res = zoom_to_h3_res(z, min_res=min_res, finest_res=finest_res, zoom_offset=zoom_offset)
 
     sql = _build_tile_sql(namespace, name, z, x, y, target_res, finest_res)
     try:

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -3,6 +3,7 @@
 register_hex_tiles() materializes a partitioned parquet pyramid to object storage.
 Tile requests read directly from the pyramid — no coordination needed.
 """
+import json
 import os
 from typing import List
 
@@ -59,6 +60,12 @@ def _public_base_url() -> str:
     return os.environ.get("MCP_PUBLIC_BASE_URL", "https://duckdb-mcp.nrp-nautilus.io").rstrip("/")
 
 
+def _json_dumps_escaped(obj) -> str:
+    # DuckDB's COPY ... (FORMAT CSV, QUOTE '') writes the raw string. We must
+    # escape any single quotes in the JSON so they don't break the SQL literal.
+    return json.dumps(obj).replace("'", "''")
+
+
 def _inspect_user_sql(con: duckdb.DuckDBPyConnection, user_sql: str):
     """Run user SQL with LIMIT 0 to extract column names without materializing data."""
     columns = con.sql(f"SELECT * FROM ({user_sql}) LIMIT 0").columns
@@ -103,6 +110,20 @@ def register_hex_tiles(
     if not output_uri.startswith("s3://"):
         os.makedirs(output_uri, exist_ok=True)
     con.sql(pyramid_sql)
+
+    # Write a sidecar metadata.json so the tile handler knows finest_res / zoom_offset.
+    metadata = {
+        "finest_res": finest_res,
+        "min_res": min_res,
+        "agg": agg,
+        "zoom_offset": zoom_offset,
+        "value_columns": value_columns,
+    }
+    metadata_sql = (
+        f"COPY (SELECT '{_json_dumps_escaped(metadata)}' AS j) "
+        f"TO '{output_uri}metadata.json' (FORMAT CSV, HEADER false, QUOTE '')"
+    )
+    con.sql(metadata_sql)
 
     # Bounds of finest-level cells (approximate via simple min/max on cell centers).
     finest_uri = f"{output_uri}res={finest_res}/*.parquet"

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -3,7 +3,12 @@
 register_hex_tiles() materializes a partitioned parquet pyramid to object storage.
 Tile requests read directly from the pyramid — no coordination needed.
 """
+import os
 from typing import List
+
+import duckdb
+
+from tiles.tile_math import content_hash
 
 
 def build_pyramid_sql(
@@ -44,3 +49,81 @@ def build_pyramid_sql(
         f") TO '{output_uri}' "
         f"(FORMAT PARQUET, PARTITION_BY (res), OVERWRITE_OR_IGNORE)"
     )
+
+
+def _bucket_base() -> str:
+    return os.environ.get("TILE_BUCKET_BASE", "s3://public-output").rstrip("/")
+
+
+def _public_base_url() -> str:
+    return os.environ.get("MCP_PUBLIC_BASE_URL", "https://duckdb-mcp.nrp-nautilus.io").rstrip("/")
+
+
+def _inspect_user_sql(con: duckdb.DuckDBPyConnection, user_sql: str):
+    """Run user SQL with LIMIT 0 to extract column names without materializing data."""
+    columns = con.sql(f"SELECT * FROM ({user_sql}) LIMIT 0").columns
+    if not columns:
+        raise ValueError("user SQL returned no columns")
+    h3_column = columns[0]
+    value_columns = list(columns[1:])
+    if not value_columns:
+        raise ValueError("user SQL must return at least one value column after the H3 index")
+    return h3_column, value_columns
+
+
+def register_hex_tiles(
+    con: duckdb.DuckDBPyConnection,
+    sql: str,
+    finest_res: int,
+    min_res: int = 2,
+    agg: str = "AVG",
+    zoom_offset: int = 4,
+) -> dict:
+    """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
+
+    The connection must have httpfs, spatial, and h3 extensions loaded.
+    """
+    if finest_res < min_res:
+        raise ValueError(f"finest_res ({finest_res}) must be >= min_res ({min_res})")
+
+    h3_column, value_columns = _inspect_user_sql(con, sql)
+    h = content_hash(sql=sql, finest_res=finest_res, min_res=min_res, agg=agg, zoom_offset=zoom_offset)
+    output_uri = f"{_bucket_base()}/hex/{h}/"
+
+    pyramid_sql = build_pyramid_sql(
+        user_sql=sql,
+        finest_res=finest_res,
+        min_res=min_res,
+        agg=agg,
+        value_columns=value_columns,
+        h3_column=h3_column,
+        output_uri=output_uri,
+    )
+    # For local filesystem URIs, DuckDB does not create intermediate directories.
+    if not output_uri.startswith("s3://"):
+        os.makedirs(output_uri, exist_ok=True)
+    con.sql(pyramid_sql)
+
+    # Bounds of finest-level cells (approximate via simple min/max on cell centers).
+    finest_uri = f"{output_uri}res={finest_res}/*.parquet"
+    bounds_row = con.sql(
+        f"SELECT "
+        f"MIN(h3_cell_to_lat(h)) AS s, MAX(h3_cell_to_lat(h)) AS n, "
+        f"MIN(h3_cell_to_lng(h)) AS w, MAX(h3_cell_to_lng(h)) AS e, "
+        f"COUNT(*) AS ct "
+        f"FROM read_parquet('{finest_uri}')"
+    ).fetchone()
+    w, s, e, n, feature_count = bounds_row[2], bounds_row[0], bounds_row[3], bounds_row[1], bounds_row[4]
+
+    tile_url_template = f"{_public_base_url()}/tiles/hex/{h}/{{z}}/{{x}}/{{y}}.pbf"
+
+    return {
+        "tile_url_template": tile_url_template,
+        "hash": h,
+        "bounds": [w, s, e, n],
+        "finest_res": finest_res,
+        "min_res": min_res,
+        "zoom_offset": zoom_offset,
+        "value_columns": value_columns,
+        "feature_count_finest": feature_count,
+    }

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -26,19 +26,25 @@ def build_pyramid_sql(
     The finest-resolution level stores the user's values unaggregated; parents
     at each coarser resolution aggregate via the user-chosen `agg` function.
     """
-    value_list_raw = ", ".join(value_columns)
-    value_list_agg = ", ".join(f"{agg}({c}) AS {c}" for c in value_columns)
+    _VALID_AGG = {"AVG", "SUM", "MIN", "MAX", "COUNT"}
+    if agg.upper() not in _VALID_AGG:
+        raise ValueError(f"agg must be one of {_VALID_AGG}, got {agg!r}")
+
+    # Quote identifiers to handle column names with spaces or reserved keywords.
+    qh = f'"{h3_column}"'
+    value_list_raw = ", ".join(f'"{c}"' for c in value_columns)
+    value_list_agg = ", ".join(f'{agg}("{c}") AS "{c}"' for c in value_columns)
 
     selects = []
     # Parents: min_res .. finest_res - 1, each aggregated.
     for res in range(min_res, finest_res):
         selects.append(
-            f"  SELECT h3_cell_to_parent({h3_column}, {res}) AS h, "
+            f"  SELECT h3_cell_to_parent({qh}, {res}) AS h, "
             f"{value_list_agg}, {res} AS res FROM src GROUP BY 1"
         )
     # Finest level: raw values, no aggregation.
     selects.append(
-        f"  SELECT {h3_column} AS h, {value_list_raw}, {finest_res} AS res FROM src"
+        f"  SELECT {qh} AS h, {value_list_raw}, {finest_res} AS res FROM src"
     )
 
     body = "\n  UNION ALL\n".join(selects)

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -1,0 +1,46 @@
+"""Pyramid SQL generation and registration.
+
+register_hex_tiles() materializes a partitioned parquet pyramid to object storage.
+Tile requests read directly from the pyramid — no coordination needed.
+"""
+from typing import List
+
+
+def build_pyramid_sql(
+    user_sql: str,
+    finest_res: int,
+    min_res: int,
+    agg: str,
+    value_columns: List[str],
+    h3_column: str,
+    output_uri: str,
+) -> str:
+    """Return the COPY ... TO SQL that writes a partitioned pyramid.
+
+    The finest-resolution level stores the user's values unaggregated; parents
+    at each coarser resolution aggregate via the user-chosen `agg` function.
+    """
+    value_list_raw = ", ".join(value_columns)
+    value_list_agg = ", ".join(f"{agg}({c}) AS {c}" for c in value_columns)
+
+    selects = []
+    # Parents: min_res .. finest_res - 1, each aggregated.
+    for res in range(min_res, finest_res):
+        selects.append(
+            f"  SELECT h3_cell_to_parent({h3_column}, {res}) AS h, "
+            f"{value_list_agg}, {res} AS res FROM src GROUP BY 1"
+        )
+    # Finest level: raw values, no aggregation.
+    selects.append(
+        f"  SELECT {h3_column} AS h, {value_list_raw}, {finest_res} AS res FROM src"
+    )
+
+    body = "\n  UNION ALL\n".join(selects)
+
+    return (
+        "COPY (\n"
+        f"  WITH src AS (\n{user_sql}\n  )\n"
+        f"{body}\n"
+        f") TO '{output_uri}' "
+        f"(FORMAT PARQUET, PARTITION_BY (res), OVERWRITE_OR_IGNORE)"
+    )

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -1,0 +1,13 @@
+"""Pure helper functions for tile math. No side effects, no DuckDB."""
+import math
+from typing import Tuple
+
+
+def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, float, float]:
+    """Return (west, south, east, north) in lng/lat (EPSG:4326) for XYZ tile."""
+    n = 2.0 ** z
+    west = x / n * 360.0 - 180.0
+    east = (x + 1) / n * 360.0 - 180.0
+    lat_n = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * y / n))))
+    lat_s = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * (y + 1) / n))))
+    return (west, lat_s, east, lat_n)

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -11,3 +11,22 @@ def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, flo
     lat_n = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * y / n))))
     lat_s = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * (y + 1) / n))))
     return (west, lat_s, east, lat_n)
+
+
+import hashlib
+
+
+def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 4) -> int:
+    """Clamp(z - zoom_offset, min_res, finest_res) — coarser hexes at lower zooms."""
+    target = z - zoom_offset
+    return max(min_res, min(finest_res, target))
+
+
+def content_hash(sql: str, finest_res: int, min_res: int, agg: str, zoom_offset: int) -> str:
+    """Deterministic 16-char hex hash of the registration inputs.
+
+    Used as the <name> component of tile URLs so identical registrations
+    dedupe naturally and URLs are CDN-friendly.
+    """
+    canonical = f"{sql}\0{finest_res}\0{min_res}\0{agg}\0{zoom_offset}"
+    return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:16]

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -1,4 +1,5 @@
 """Pure helper functions for tile math. No side effects, no DuckDB."""
+import hashlib
 import math
 from typing import Tuple
 
@@ -11,9 +12,6 @@ def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, flo
     lat_n = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * y / n))))
     lat_s = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * (y + 1) / n))))
     return (west, lat_s, east, lat_n)
-
-
-import hashlib
 
 
 def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 4) -> int:


### PR DESCRIPTION
## Summary

- Adds `register_hex_tiles` MCP tool that materializes a pre-aggregated H3 resolution pyramid to S3 and returns a MapLibre-compatible vector tile URL template
- Adds `/tiles/hex/{hash}/{z}/{x}/{y}.pbf` endpoint serving MVT tiles from the pyramid via DuckDB `ST_AsMVT`
- New `tiles/` package: `tile_math.py` (pure helpers), `db.py` (persistent DuckDB connection), `pyramid.py` (pyramid materialization), `endpoint.py` (Starlette request handler)
- Docs: `h3-guide.md` usage section, `assistant-role.md` dispatch hints, R & Python programmatic access examples

Implements #4.

## Test plan

- [ ] 32 unit/integration tests pass locally (`test_tile_math`, `test_tile_pyramid`, `test_tile_endpoint`, `test_server::TestTileRouteMounted`)
- [ ] Deploy test server from this branch and register a small tileset against real S3
- [ ] Verify tile responses decode correctly in a MapLibre client
- [ ] Check no regression in existing `query` tool and STAC endpoints