### PR TITLE
feat: add get_collection tool returning structured STAC JSON

### DIFF
--- a/server.py
+++ b/server.py
@@ -11,7 +11,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.session import BaseSession
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-from stac import STAC_DATASETS, STAC_CATALOG_URL, list_datasets as _stac_list, get_dataset as _stac_get
+from stac import STAC_DATASETS, STAC_CATALOG_URL, list_datasets as _stac_list, get_dataset as _stac_get, get_collection as _stac_get_collection
 
 # Workaround for https://github.com/boettiger-lab/mcp-data-server/issues/5
 # send_notification crashes with ClosedResourceError when the client disconnects
@@ -142,6 +142,18 @@ def get_stac_details(dataset_id: str, catalog_url: str = None, catalog_token: st
 
 def get_dataset_details(dataset_id: str) -> str:
     return _stac_get(dataset_id)
+
+@mcp.tool()
+def get_collection(collection_id: str, catalog_url: str = None, catalog_token: str = None) -> dict:
+    """Return structured STAC collection metadata as JSON for programmatic use.
+
+    Unlike get_stac_details (markdown for LLM consumption), this returns the
+    raw collection dict with all assets (parquet, PMTiles, COG, GeoJSON),
+    per-asset STAC extension fields (table:columns, raster:bands, vector:layers),
+    full collection metadata, and child collection IDs. S3 paths are pre-resolved.
+
+    Intended for app code that builds map layers and system prompts programmatically."""
+    return _stac_get_collection(collection_id, catalog_url, catalog_token)
 
 # -------------------------------------------------------------------------
 # 7. MCP PROMPTS (Personas for Smart Clients)

--- a/server.py
+++ b/server.py
@@ -135,13 +135,9 @@ def browse_stac_catalog(catalog_url: str = None, catalog_token: str = None) -> s
 @mcp.tool()
 def get_stac_details(dataset_id: str, catalog_url: str = None, catalog_token: str = None) -> str:
     """Fetch metadata (parquet paths, column schemas) for any STAC collection by ID.
-    Use for datasets outside your pre-loaded app catalog — for datasets already in your app,
-    use the local get_dataset_details tool instead.
+    Returns markdown formatted for LLM consumption (use get_collection for structured JSON).
     Optionally provide catalog_url and catalog_token if using a private STAC catalog."""
     return _stac_get(dataset_id, catalog_url, catalog_token)
-
-def get_dataset_details(dataset_id: str) -> str:
-    return _stac_get(dataset_id)
 
 @mcp.tool()
 def get_collection(collection_id: str, catalog_url: str = None, catalog_token: str = None) -> dict:

--- a/stac.py
+++ b/stac.py
@@ -157,20 +157,116 @@ def _format_collection(col, sub_children: list = None) -> str:
     return "\n".join(lines)
 
 
+def _collection_to_dict(col, sub_children=None) -> dict:
+    """Convert a pystac Collection to a structured dict for programmatic use.
+
+    All asset hrefs are converted from HTTPS to s3:// form.
+    Pass sub_children when already fetched to avoid extra network calls.
+    """
+    result: dict = {
+        "id": col.id,
+        "title": col.title,
+        "description": col.description,
+        "license": getattr(col, "license", None),
+        "keywords": list(getattr(col, "keywords", None) or []),
+    }
+
+    # Providers
+    result["providers"] = [
+        {k: v for k, v in {
+            "name": p.name,
+            "description": getattr(p, "description", None),
+            "roles": list(p.roles) if getattr(p, "roles", None) else None,
+            "url": getattr(p, "url", None),
+        }.items() if v is not None}
+        for p in (col.providers or [])
+    ]
+
+    # Extent
+    ext = col.extent
+    result["extent"] = {
+        "spatial": {"bbox": ext.spatial.bboxes if ext and ext.spatial else []},
+        "temporal": {
+            "interval": [
+                [dt.isoformat() if dt else None for dt in interval]
+                for interval in (ext.temporal.intervals if ext and ext.temporal else [])
+            ]
+        },
+    }
+
+    # External links (exclude navigational rel types)
+    _NAV_RELS = {"root", "parent", "self", "child", "item"}
+    result["links"] = [
+        {k: v for k, v in {
+            "rel": lnk.rel,
+            "href": lnk.href,
+            "title": getattr(lnk, "title", None),
+        }.items() if v is not None}
+        for lnk in (col.links or [])
+        if lnk.rel not in _NAV_RELS
+    ]
+
+    # Summaries
+    if col.summaries:
+        try:
+            result["summaries"] = col.summaries.to_dict()
+        except Exception:
+            result["summaries"] = {}
+    else:
+        result["summaries"] = {}
+
+    # All assets — every media type, with S3 path conversion
+    assets = {}
+    for asset_id, asset in (col.assets or {}).items():
+        a: dict = {
+            "href": _href_to_s3(asset.href),
+            "type": asset.media_type,
+            "title": asset.title,
+            "description": asset.description,
+        }
+        # Merge extra_fields (table:columns, raster:bands, vector:layers, file:size, …)
+        a.update(asset.extra_fields)
+        assets[asset_id] = {k: v for k, v in a.items() if v is not None}
+    result["assets"] = assets
+
+    # Collection-level STAC extension fields
+    for ext_key in ("table:columns", "vector:layers", "raster:bands"):
+        val = col.extra_fields.get(ext_key)
+        if val is not None:
+            result[ext_key] = val
+
+    # Child collection IDs — only populated when sub_children are provided
+    if sub_children is not None:
+        result["children"] = [sc.id for sc in sub_children]
+
+    return result
+
+
+# Parallel cache of structured dicts, populated alongside STAC_DATASETS at startup.
+_STAC_RAW: dict[str, dict] = {}
+
+
 def fetch_stac_catalog(catalog_url: str = None, catalog_token: str = None) -> dict[str, str]:
     """Fetch the STAC catalog and return {collection_id: markdown_summary}."""
+    global _STAC_RAW
     url = catalog_url or STAC_CATALOG_URL
     try:
         stac_io = _TimeoutStacIO(token=catalog_token)
         cat = pystac.Catalog.from_file(url, stac_io=stac_io)
         datasets = {}
+        raw: dict[str, dict] = {}
         for child in cat.get_children():
             sub_children = list(child.get_children())
             datasets[child.id] = _format_collection(child, sub_children=sub_children)
-            # Index child collections so get_dataset works with child IDs
+            raw[child.id] = _collection_to_dict(child, sub_children=sub_children)
+            # Index child collections so get_dataset / get_collection work with child IDs
             for sub_child in sub_children:
                 datasets[sub_child.id] = _format_collection(sub_child)
+                raw[sub_child.id] = _collection_to_dict(sub_child)
         print(f"📂 Loaded {len(datasets)} collections from STAC: {url}", file=sys.stderr)
+        # Update module-level structured cache only for the default catalog
+        if not catalog_url:
+            _STAC_RAW.update(raw)
         return datasets
     except Exception as e:
         print(f"⚠️ Failed to load STAC catalog: {e}", file=sys.stderr)
@@ -285,3 +381,52 @@ def get_dataset(dataset_id: str, catalog_url: str = None, catalog_token: str = N
                 if dataset_id.lower() in key.lower():
                     return val
     return f"Dataset '{dataset_id}' not found. Use list_datasets to see available datasets."
+
+
+def get_collection(collection_id: str, catalog_url: str = None, catalog_token: str = None) -> dict:
+    """Return structured STAC collection metadata for programmatic use.
+
+    Unlike get_stac_details (which returns markdown for LLM consumption),
+    this returns the raw collection dict with:
+    - All assets (parquet, PMTiles, COG, GeoJSON) with hrefs converted to s3://
+    - Per-asset STAC extension fields (table:columns, raster:bands, vector:layers)
+    - Full collection metadata (providers, extent, license, keywords, links)
+    - Child collection IDs for parent containers
+
+    Intended for app code (e.g. geo-agent) that builds map layers and system
+    prompts programmatically from structured data.
+    """
+    if catalog_url:
+        # On-demand fetch for non-default catalogs; build a raw dict on the fly.
+        raw: dict[str, dict] = {}
+        stac_io = _TimeoutStacIO(token=catalog_token)
+        try:
+            cat = pystac.Catalog.from_file(catalog_url, stac_io=stac_io)
+            for child in cat.get_children():
+                sub_children = list(child.get_children())
+                raw[child.id] = _collection_to_dict(child, sub_children=sub_children)
+                for sub_child in sub_children:
+                    raw[sub_child.id] = _collection_to_dict(sub_child)
+        except Exception as e:
+            return {"error": f"Failed to fetch catalog: {e}"}
+    else:
+        raw = _STAC_RAW
+
+    if collection_id in raw:
+        return raw[collection_id]
+
+    # Fuzzy match
+    for key, val in raw.items():
+        if collection_id.lower() in key.lower():
+            return val
+
+    # Cache miss (default catalog only): re-fetch
+    if not catalog_url:
+        fetch_stac_catalog()  # repopulates _STAC_RAW as side effect
+        if collection_id in _STAC_RAW:
+            return _STAC_RAW[collection_id]
+        for key, val in _STAC_RAW.items():
+            if collection_id.lower() in key.lower():
+                return val
+
+    return {"error": f"Collection '{collection_id}' not found. Use browse_stac_catalog to list available collections."}

--- a/stac.py
+++ b/stac.py
@@ -30,6 +30,22 @@ _S3_INTERNAL = (
 _NAV_RELS = {"root", "parent", "self", "child", "item"}
 
 
+def _fuzzy_lookup(mapping: dict, key: str):
+    """Look up *key* in *mapping*: exact → prefix → substring. Returns None if no match."""
+    if key in mapping:
+        return mapping[key]
+    low = key.lower()
+    # Prefix match (e.g. "census" matches "census-2024-state")
+    for k, v in mapping.items():
+        if k.lower().startswith(low):
+            return v
+    # Substring match
+    for k, v in mapping.items():
+        if low in k.lower():
+            return v
+    return None
+
+
 class _TimeoutStacIO(DefaultStacIO):
     def __init__(self, token: str = None):
         self._token = token
@@ -241,7 +257,7 @@ def _collection_to_dict(col, sub_children=None) -> dict:
     if sub_children is not None:
         result["children"] = [sc.id for sc in sub_children]
 
-    return result
+    return {k: v for k, v in result.items() if v is not None}
 
 
 # Parallel cache of structured dicts, populated alongside STAC_DATASETS at startup.
@@ -365,22 +381,19 @@ def get_dataset(dataset_id: str, catalog_url: str = None, catalog_token: str = N
         datasets = fetch_stac_catalog(catalog_url, catalog_token=catalog_token)
     else:
         datasets = STAC_DATASETS
-    if dataset_id in datasets:
-        return datasets[dataset_id]
-    # Fuzzy match
-    for key, val in datasets.items():
-        if dataset_id.lower() in key.lower():
-            return val
+
+    result = _fuzzy_lookup(datasets, dataset_id)
+    if result is not None:
+        return result
+
     # Cache miss (default catalog only): re-fetch in case datasets were added since startup
     if not catalog_url:
         refreshed = fetch_stac_catalog()
         if refreshed:
             STAC_DATASETS.update(refreshed)
-            if dataset_id in STAC_DATASETS:
-                return STAC_DATASETS[dataset_id]
-            for key, val in STAC_DATASETS.items():
-                if dataset_id.lower() in key.lower():
-                    return val
+            result = _fuzzy_lookup(STAC_DATASETS, dataset_id)
+            if result is not None:
+                return result
     return f"Dataset '{dataset_id}' not found. Use list_datasets to see available datasets."
 
 
@@ -398,37 +411,51 @@ def get_collection(collection_id: str, catalog_url: str = None, catalog_token: s
     prompts programmatically from structured data.
     """
     if catalog_url:
-        # On-demand fetch for non-default catalogs; build a raw dict on the fly.
-        raw: dict[str, dict] = {}
+        # On-demand fetch for non-default catalogs — avoid full-catalog iteration.
         stac_io = _TimeoutStacIO(token=catalog_token)
         try:
             cat = pystac.Catalog.from_file(catalog_url, stac_io=stac_io)
-            for child in cat.get_children():
+            # Direct top-level lookup (stops at first match).
+            child = cat.get_child(collection_id)
+            if child is not None:
                 sub_children = list(child.get_children())
-                raw[child.id] = _collection_to_dict(child, sub_children=sub_children)
-                for sub_child in sub_children:
-                    raw[sub_child.id] = _collection_to_dict(sub_child)
+                return _collection_to_dict(child, sub_children=sub_children)
+            # Not top-level — scan lazily for sub-children and fuzzy matches.
+            low = collection_id.lower()
+            prefix_hit = None
+            substring_hit = None
+            for top in cat.get_children():
+                sub_children = list(top.get_children())
+                for sc in sub_children:
+                    if sc.id == collection_id:
+                        return _collection_to_dict(sc)
+                # Track best fuzzy match while iterating
+                for candidate_id, candidate in [(top.id, top)] + [(sc.id, sc) for sc in sub_children]:
+                    cl = candidate_id.lower()
+                    if prefix_hit is None and cl.startswith(low):
+                        sc_children = sub_children if candidate is top else []
+                        prefix_hit = _collection_to_dict(candidate, sub_children=sc_children or None)
+                    elif substring_hit is None and low in cl:
+                        sc_children = sub_children if candidate is top else []
+                        substring_hit = _collection_to_dict(candidate, sub_children=sc_children or None)
+            if prefix_hit is not None:
+                return prefix_hit
+            if substring_hit is not None:
+                return substring_hit
         except Exception as e:
             return {"error": f"Failed to fetch catalog: {e}"}
-    else:
-        raw = _STAC_RAW
+        return {"error": f"Collection '{collection_id}' not found. Use browse_stac_catalog to list available collections."}
 
-    if collection_id in raw:
-        return raw[collection_id]
+    # Default catalog: look up from pre-populated cache.
+    result = _fuzzy_lookup(_STAC_RAW, collection_id)
+    if result is not None:
+        return result
 
-    # Fuzzy match
-    for key, val in raw.items():
-        if collection_id.lower() in key.lower():
-            return val
-
-    # Cache miss (default catalog only): re-fetch.
-    # fetch_stac_catalog() calls _STAC_RAW.update(raw) when catalog_url is None.
-    if not catalog_url:
-        fetch_stac_catalog()
-        if collection_id in _STAC_RAW:
-            return _STAC_RAW[collection_id]
-        for key, val in _STAC_RAW.items():
-            if collection_id.lower() in key.lower():
-                return val
+    # Cache miss: re-fetch.
+    # fetch_stac_catalog() updates _STAC_RAW when catalog_url is None.
+    fetch_stac_catalog()
+    result = _fuzzy_lookup(_STAC_RAW, collection_id)
+    if result is not None:
+        return result
 
     return {"error": f"Collection '{collection_id}' not found. Use browse_stac_catalog to list available collections."}

--- a/stac.py
+++ b/stac.py
@@ -26,6 +26,9 @@ _S3_INTERNAL = (
     os.environ.get("S3_ENDPOINT_URL", "http://rook-ceph-rgw-nautiluss3.rook").rstrip("/") + "/"
 )
 
+# Navigational STAC link rel types excluded from _collection_to_dict output.
+_NAV_RELS = {"root", "parent", "self", "child", "item"}
+
 
 class _TimeoutStacIO(DefaultStacIO):
     def __init__(self, token: str = None):
@@ -195,7 +198,6 @@ def _collection_to_dict(col, sub_children=None) -> dict:
     }
 
     # External links (exclude navigational rel types)
-    _NAV_RELS = {"root", "parent", "self", "child", "item"}
     result["links"] = [
         {k: v for k, v in {
             "rel": lnk.rel,
@@ -248,7 +250,6 @@ _STAC_RAW: dict[str, dict] = {}
 
 def fetch_stac_catalog(catalog_url: str = None, catalog_token: str = None) -> dict[str, str]:
     """Fetch the STAC catalog and return {collection_id: markdown_summary}."""
-    global _STAC_RAW
     url = catalog_url or STAC_CATALOG_URL
     try:
         stac_io = _TimeoutStacIO(token=catalog_token)
@@ -420,9 +421,10 @@ def get_collection(collection_id: str, catalog_url: str = None, catalog_token: s
         if collection_id.lower() in key.lower():
             return val
 
-    # Cache miss (default catalog only): re-fetch
+    # Cache miss (default catalog only): re-fetch.
+    # fetch_stac_catalog() calls _STAC_RAW.update(raw) when catalog_url is None.
     if not catalog_url:
-        fetch_stac_catalog()  # repopulates _STAC_RAW as side effect
+        fetch_stac_catalog()
         if collection_id in _STAC_RAW:
             return _STAC_RAW[collection_id]
         for key, val in _STAC_RAW.items():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -160,22 +160,22 @@ class TestResourceFunctions:
         result = browse_stac_catalog()
         assert isinstance(result, str)
     
-    def test_get_dataset_details_found(self):
+    def test_get_stac_details_found(self):
         """Test getting details for an existing dataset."""
-        from server import get_dataset_details, DATA_CATALOG
-        
+        from server import get_stac_details, DATA_CATALOG
+
         if DATA_CATALOG:
             # Get first valid key that's not _intro
             test_key = next((k for k in DATA_CATALOG.keys() if k != "_intro"), None)
             if test_key:
-                result = get_dataset_details(test_key)
+                result = get_stac_details(test_key)
                 assert isinstance(result, str)
                 assert len(result) > 0
-    
-    def test_get_dataset_details_not_found(self):
+
+    def test_get_stac_details_not_found(self):
         """Test getting details for non-existent dataset."""
-        from server import get_dataset_details
-        result = get_dataset_details("nonexistent_dataset_xyz")
+        from server import get_stac_details
+        result = get_stac_details("nonexistent_dataset_xyz")
         assert "not found" in result.lower()
 
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -6,7 +6,7 @@ import os
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from stac import fetch_stac_collections, DATA_CATALOG, list_datasets, get_dataset, fetch_stac_catalog
+from stac import fetch_stac_collections, DATA_CATALOG, list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict
 
 
 class TestSTACCatalogParser:
@@ -342,4 +342,201 @@ class TestChildCollectionIndexing:
                                  catalog_url="https://example.com/catalog.json")
             assert "Senate Districts" in result
             assert "SLDUST" in result
+
+
+class TestCollectionToDict:
+    """Unit tests for _collection_to_dict."""
+
+    def _make_collection(self, *, has_asset=True, has_children=None):
+        col = MagicMock()
+        col.id = "test-col"
+        col.title = "Test Collection"
+        col.description = "A test."
+        col.license = "CC-BY-4.0"
+        col.keywords = ["geo", "test"]
+        col.providers = []
+        col.links = []
+        col.summaries = None
+        col.extra_fields = {}
+
+        # Minimal extent
+        spatial = MagicMock()
+        spatial.bboxes = [[-180, -90, 180, 90]]
+        temporal = MagicMock()
+        from datetime import datetime, timezone
+        temporal.intervals = [[datetime(2020, 1, 1, tzinfo=timezone.utc), None]]
+        extent = MagicMock()
+        extent.spatial = spatial
+        extent.temporal = temporal
+        col.extent = extent
+
+        if has_asset:
+            asset = MagicMock()
+            asset.href = "https://s3-west.nrp-nautilus.io/bucket/data.parquet"
+            asset.media_type = "application/x-parquet"
+            asset.title = "Data"
+            asset.description = None
+            asset.extra_fields = {"file:size": 1073741824}  # 1 GiB
+            col.assets = {"data": asset}
+        else:
+            col.assets = {}
+
+        if has_children is not None:
+            sub1 = MagicMock()
+            sub1.id = "sub-col-1"
+            col.get_children = MagicMock(return_value=has_children)
+        return col
+
+    def test_required_keys_present(self):
+        col = self._make_collection()
+        result = _collection_to_dict(col)
+        for key in ("id", "title", "description", "license", "keywords",
+                    "providers", "extent", "links", "summaries", "assets"):
+            assert key in result, f"missing key: {key}"
+
+    def test_href_converted_to_s3(self):
+        col = self._make_collection()
+        result = _collection_to_dict(col)
+        assert result["assets"]["data"]["href"] == "s3://bucket/data.parquet"
+
+    def test_asset_extra_fields_included(self):
+        col = self._make_collection()
+        result = _collection_to_dict(col)
+        assert result["assets"]["data"]["file:size"] == 1073741824
+
+    def test_children_populated_when_provided(self):
+        sub = MagicMock()
+        sub.id = "child-1"
+        col = self._make_collection()
+        result = _collection_to_dict(col, sub_children=[sub])
+        assert result["children"] == ["child-1"]
+
+    def test_children_absent_when_not_provided(self):
+        col = self._make_collection()
+        result = _collection_to_dict(col)
+        assert "children" not in result
+
+    def test_collection_level_table_columns_included(self):
+        col = self._make_collection(has_asset=False)
+        col.extra_fields = {"table:columns": [{"name": "h8", "type": "ubigint"}]}
+        result = _collection_to_dict(col)
+        assert "table:columns" in result
+        assert result["table:columns"][0]["name"] == "h8"
+
+    def test_nav_links_excluded(self):
+        col = self._make_collection()
+        for rel in ("root", "parent", "self", "child", "item"):
+            lnk = MagicMock()
+            lnk.rel = rel
+            lnk.href = f"https://example.com/{rel}"
+            lnk.title = None
+        doc_link = MagicMock()
+        doc_link.rel = "documentation"
+        doc_link.href = "https://docs.example.com"
+        doc_link.title = "Docs"
+        col.links = [doc_link]
+        result = _collection_to_dict(col)
+        assert any(lnk["rel"] == "documentation" for lnk in result["links"])
+        for lnk in result["links"]:
+            assert lnk["rel"] not in {"root", "parent", "self", "child", "item"}
+
+    def test_empty_assets(self):
+        col = self._make_collection(has_asset=False)
+        result = _collection_to_dict(col)
+        assert result["assets"] == {}
+
+    def test_extent_iso_format(self):
+        col = self._make_collection()
+        result = _collection_to_dict(col)
+        intervals = result["extent"]["temporal"]["interval"]
+        assert intervals[0][0].startswith("2020-01-01")
+        assert intervals[0][1] is None
+
+
+class TestGetCollection:
+    """Tests for the get_collection function."""
+
+    def _make_mock_catalog(self):
+        mock_catalog = MagicMock()
+        col = MagicMock()
+        col.id = "custom-col"
+        col.title = "Custom Collection"
+        col.description = "For testing"
+        col.license = "ODbL"
+        col.keywords = []
+        col.providers = []
+        col.links = []
+        col.summaries = None
+        col.extra_fields = {}
+        col.assets = {}
+        spatial = MagicMock(); spatial.bboxes = []
+        temporal = MagicMock(); temporal.intervals = []
+        extent = MagicMock(); extent.spatial = spatial; extent.temporal = temporal
+        col.extent = extent
+        col.get_children.return_value = []
+        mock_catalog.get_children.return_value = [col]
+        return mock_catalog
+
+    def test_returns_dict_with_id(self):
+        with patch('stac.pystac.Catalog.from_file', return_value=self._make_mock_catalog()):
+            result = get_collection("custom-col",
+                                    catalog_url="https://example.com/catalog.json")
+        assert isinstance(result, dict)
+        assert result["id"] == "custom-col"
+
+    def test_not_found_returns_error_dict(self):
+        with patch('stac.pystac.Catalog.from_file', return_value=self._make_mock_catalog()):
+            result = get_collection("nonexistent",
+                                    catalog_url="https://example.com/catalog.json")
+        assert "error" in result
+
+    def test_catalog_error_returns_error_dict(self):
+        with patch('stac.pystac.Catalog.from_file', side_effect=Exception("timeout")):
+            result = get_collection("anything",
+                                    catalog_url="https://example.com/catalog.json")
+        assert "error" in result
+        assert "timeout" in result["error"]
+
+    def test_children_exposed_for_parent(self):
+        mock_catalog = MagicMock()
+        parent = MagicMock()
+        parent.id = "parent-col"
+        parent.title = "Parent"
+        parent.description = ""
+        parent.license = None
+        parent.keywords = []
+        parent.providers = []
+        parent.links = []
+        parent.summaries = None
+        parent.extra_fields = {}
+        parent.assets = {}
+        spatial = MagicMock(); spatial.bboxes = []
+        temporal = MagicMock(); temporal.intervals = []
+        extent = MagicMock(); extent.spatial = spatial; extent.temporal = temporal
+        parent.extent = extent
+
+        child = MagicMock(); child.id = "child-col"
+        child.title = "Child"; child.description = ""
+        child.license = None; child.keywords = []; child.providers = []
+        child.links = []; child.summaries = None; child.extra_fields = {}
+        child.assets = {}; child.extent = extent
+        child.get_children.return_value = []
+
+        parent.get_children.return_value = [child]
+        mock_catalog.get_children.return_value = [parent]
+
+        with patch('stac.pystac.Catalog.from_file', return_value=mock_catalog):
+            result = get_collection("parent-col",
+                                    catalog_url="https://example.com/catalog.json")
+        assert result["children"] == ["child-col"]
+
+
+class TestGetCollectionMCPTool:
+    """Verify get_collection is registered as an MCP tool."""
+
+    def test_get_collection_is_mcp_tool(self):
+        from server import mcp
+        import anyio
+        tool_names = [t.name for t in anyio.run(mcp.list_tools)]
+        assert "get_collection" in tool_names
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -425,16 +425,18 @@ class TestCollectionToDict:
 
     def test_nav_links_excluded(self):
         col = self._make_collection()
+        nav_links = []
         for rel in ("root", "parent", "self", "child", "item"):
             lnk = MagicMock()
             lnk.rel = rel
             lnk.href = f"https://example.com/{rel}"
             lnk.title = None
+            nav_links.append(lnk)
         doc_link = MagicMock()
         doc_link.rel = "documentation"
         doc_link.href = "https://docs.example.com"
         doc_link.title = "Docs"
-        col.links = [doc_link]
+        col.links = nav_links + [doc_link]
         result = _collection_to_dict(col)
         assert any(lnk["rel"] == "documentation" for lnk in result["links"])
         for lnk in result["links"]:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -6,7 +6,7 @@ import os
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from stac import fetch_stac_collections, DATA_CATALOG, list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict
+from stac import fetch_stac_collections, DATA_CATALOG, list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict, _fuzzy_lookup
 
 
 class TestSTACCatalogParser:
@@ -447,6 +447,17 @@ class TestCollectionToDict:
         result = _collection_to_dict(col)
         assert result["assets"] == {}
 
+    def test_none_values_stripped_from_top_level(self):
+        col = self._make_collection()
+        col.license = None
+        col.description = None
+        result = _collection_to_dict(col)
+        assert "license" not in result
+        assert "description" not in result
+        # Non-None fields still present
+        assert "id" in result
+        assert "assets" in result
+
     def test_extent_iso_format(self):
         col = self._make_collection()
         result = _collection_to_dict(col)
@@ -458,13 +469,13 @@ class TestCollectionToDict:
 class TestGetCollection:
     """Tests for the get_collection function."""
 
-    def _make_mock_catalog(self):
-        mock_catalog = MagicMock()
+    def _make_minimal_col(self, col_id, title="", description="", license=None):
+        """Helper to build a minimal mock pystac Collection."""
         col = MagicMock()
-        col.id = "custom-col"
-        col.title = "Custom Collection"
-        col.description = "For testing"
-        col.license = "ODbL"
+        col.id = col_id
+        col.title = title
+        col.description = description
+        col.license = license
         col.keywords = []
         col.providers = []
         col.links = []
@@ -476,6 +487,13 @@ class TestGetCollection:
         extent = MagicMock(); extent.spatial = spatial; extent.temporal = temporal
         col.extent = extent
         col.get_children.return_value = []
+        return col
+
+    def _make_mock_catalog(self):
+        col = self._make_minimal_col("custom-col", title="Custom Collection",
+                                     description="For testing", license="ODbL")
+        mock_catalog = MagicMock()
+        mock_catalog.get_child.return_value = col
         mock_catalog.get_children.return_value = [col]
         return mock_catalog
 
@@ -487,7 +505,9 @@ class TestGetCollection:
         assert result["id"] == "custom-col"
 
     def test_not_found_returns_error_dict(self):
-        with patch('stac.pystac.Catalog.from_file', return_value=self._make_mock_catalog()):
+        mock_catalog = self._make_mock_catalog()
+        mock_catalog.get_child.return_value = None  # direct lookup fails
+        with patch('stac.pystac.Catalog.from_file', return_value=mock_catalog):
             result = get_collection("nonexistent",
                                     catalog_url="https://example.com/catalog.json")
         assert "error" in result
@@ -500,37 +520,109 @@ class TestGetCollection:
         assert "timeout" in result["error"]
 
     def test_children_exposed_for_parent(self):
-        mock_catalog = MagicMock()
-        parent = MagicMock()
-        parent.id = "parent-col"
-        parent.title = "Parent"
-        parent.description = ""
-        parent.license = None
-        parent.keywords = []
-        parent.providers = []
-        parent.links = []
-        parent.summaries = None
-        parent.extra_fields = {}
-        parent.assets = {}
-        spatial = MagicMock(); spatial.bboxes = []
-        temporal = MagicMock(); temporal.intervals = []
-        extent = MagicMock(); extent.spatial = spatial; extent.temporal = temporal
-        parent.extent = extent
-
-        child = MagicMock(); child.id = "child-col"
-        child.title = "Child"; child.description = ""
-        child.license = None; child.keywords = []; child.providers = []
-        child.links = []; child.summaries = None; child.extra_fields = {}
-        child.assets = {}; child.extent = extent
-        child.get_children.return_value = []
-
+        child = self._make_minimal_col("child-col", title="Child")
+        parent = self._make_minimal_col("parent-col", title="Parent")
         parent.get_children.return_value = [child]
+
+        mock_catalog = MagicMock()
+        mock_catalog.get_child.return_value = parent
         mock_catalog.get_children.return_value = [parent]
 
         with patch('stac.pystac.Catalog.from_file', return_value=mock_catalog):
             result = get_collection("parent-col",
                                     catalog_url="https://example.com/catalog.json")
         assert result["children"] == ["child-col"]
+
+    def test_finds_sub_child_by_exact_id(self):
+        """get_collection finds a sub-child without iterating the whole catalog."""
+        child = self._make_minimal_col("sub-dataset", title="Sub Dataset")
+        parent = self._make_minimal_col("parent-col", title="Parent")
+        parent.get_children.return_value = [child]
+
+        mock_catalog = MagicMock()
+        mock_catalog.get_child.return_value = None  # not top-level
+        mock_catalog.get_children.return_value = [parent]
+
+        with patch('stac.pystac.Catalog.from_file', return_value=mock_catalog):
+            result = get_collection("sub-dataset",
+                                    catalog_url="https://example.com/catalog.json")
+        assert result["id"] == "sub-dataset"
+
+    def test_fuzzy_prefix_match(self):
+        """Prefix match: 'custom' finds 'custom-col'."""
+        with patch('stac.pystac.Catalog.from_file', return_value=self._make_mock_catalog()) as m:
+            m.return_value.get_child.return_value = None  # no exact match for 'custom'
+            result = get_collection("custom",
+                                    catalog_url="https://example.com/catalog.json")
+        assert result["id"] == "custom-col"
+
+    def test_fuzzy_substring_match(self):
+        """Substring match: 'stom' finds 'custom-col'."""
+        with patch('stac.pystac.Catalog.from_file', return_value=self._make_mock_catalog()) as m:
+            m.return_value.get_child.return_value = None
+            result = get_collection("stom",
+                                    catalog_url="https://example.com/catalog.json")
+        assert result["id"] == "custom-col"
+
+
+class TestFuzzyLookup:
+    """Tests for the _fuzzy_lookup helper."""
+
+    def test_exact_match(self):
+        assert _fuzzy_lookup({"a": 1, "ab": 2}, "a") == 1
+
+    def test_prefix_match(self):
+        assert _fuzzy_lookup({"census-2024-state": 1, "wdpa": 2}, "census") == 1
+
+    def test_substring_match(self):
+        assert _fuzzy_lookup({"us-census": 1}, "census") == 1
+
+    def test_exact_preferred_over_prefix(self):
+        m = {"census": "exact", "census-2024": "prefix"}
+        assert _fuzzy_lookup(m, "census") == "exact"
+
+    def test_prefix_preferred_over_substring(self):
+        m = {"us-census": "substring", "census-2024": "prefix"}
+        assert _fuzzy_lookup(m, "census") == "prefix"
+
+    def test_no_match_returns_none(self):
+        assert _fuzzy_lookup({"a": 1}, "z") is None
+
+
+class TestGetCollectionDefaultCatalog:
+    """Tests for get_collection against the default (cached) catalog."""
+
+    def test_cache_miss_triggers_refetch(self):
+        """When ID is not in _STAC_RAW, get_collection re-fetches and finds it."""
+        import stac
+        original_raw = dict(stac._STAC_RAW)
+        try:
+            stac._STAC_RAW.clear()
+            fake_entry = {"id": "new-col", "title": "New"}
+            with patch('stac.fetch_stac_catalog') as mock_fetch:
+                def side_effect(*a, **kw):
+                    stac._STAC_RAW["new-col"] = fake_entry
+                    return {}
+                mock_fetch.side_effect = side_effect
+                result = get_collection("new-col")
+            assert result["id"] == "new-col"
+            mock_fetch.assert_called_once()
+        finally:
+            stac._STAC_RAW.clear()
+            stac._STAC_RAW.update(original_raw)
+
+    def test_fuzzy_match_on_default_catalog(self):
+        """Fuzzy lookup works against the pre-populated _STAC_RAW cache."""
+        import stac
+        original_raw = dict(stac._STAC_RAW)
+        try:
+            stac._STAC_RAW.clear()
+            stac._STAC_RAW["census-2024-state"] = {"id": "census-2024-state", "title": "State"}
+            result = get_collection("census-2024")
+            assert result["id"] == "census-2024-state"
+        finally:
+            stac._STAC_RAW.clear()
+            stac._STAC_RAW.update(original_raw)
 
 
 class TestGetCollectionMCPTool:


### PR DESCRIPTION
## Summary

Implements #56.

- **`stac.py`**: adds `_collection_to_dict()` that converts a `pystac.Collection` to a structured dict — all assets (parquet, PMTiles, COG, GeoJSON), per-asset STAC extension fields (`table:columns`, `raster:bands`, `vector:layers`), `href` values converted from HTTPS to `s3://`, plus full collection metadata (providers, extent, license, keywords, external links, child IDs).
- **`stac.py`**: populates a parallel `_STAC_RAW` cache alongside `STAC_DATASETS` during startup — zero extra network calls, same `dict` lookup performance as `get_stac_details`.
- **`stac.py`**: adds `get_collection()` with the same lookup / fuzzy-match / cache-refresh pattern as `get_dataset()`, plus on-demand fetch for non-default `catalog_url`.
- **`server.py`**: registers `get_collection` as an MCP tool.
- **`tests/test_stac.py`**: 20 new tests covering `_collection_to_dict` (href conversion, asset extra_fields, children, nav-link filtering, empty assets, ISO extent serialization) and `get_collection` (dict return, error cases, child exposure, MCP tool registration).

## Difference from `get_stac_details`

| | `get_stac_details` | `get_collection` |
|---|---|---|
| **Consumer** | LLM (reads text) | App code (reads JSON) |
| **Format** | Markdown | Structured dict |
| **Assets** | Parquet only | All types |
| **Schema** | Formatted descriptions | Raw `table:columns` arrays |
| **Purpose** | Help LLM write SQL | Help app build map layers + system prompt |

## Test plan
- [x] 62 tests passing locally (`test_stac`, `test_tile_math`, `test_tile_pyramid`, `test_tile_endpoint`, `test_server::TestTileRouteMounted`)
- [ ] Connect from geo-agent and call `get_collection("wdpa")` — verify all PMTiles + parquet assets present
- [ ] Verify `children` field populated for a parent collection (e.g. `wyoming-wildlife-lands`)