### PR TITLE
ops: tag-based production deploys, dev tracks main

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -4,6 +4,14 @@
 
 **H3 hex joins replace geometry functions.** Do NOT use `ST_Intersects`, `ST_Contains`, `ST_Area`, or `ST_Within` — these require scanning full polygon geometries and are orders of magnitude slower. Instead, join datasets on their shared H3 index (`h8`, `h0`) to compute overlaps, areas, and containment. If two datasets use different H3 resolutions, convert with `h3_cell_to_parent()`.
 
+## Resolution Direction
+
+**Higher H3 resolution numbers are finer (smaller cells); lower numbers are coarser (larger cells).** h0 is the coarsest (~1000 km edge length); h15 is the finest. A higher-resolution cell is always a *child* of a lower-resolution cell — never the reverse.
+
+- h8 cells are children of h6 cells, not parents
+- If a dataset is indexed at h6, it has no h8 column and no h8_parent column
+- Always check the dataset schema for available resolution columns before writing a join
+
 ## Key Facts
 
 - Always report **areas** (km², acres, etc.), never raw hex counts
@@ -29,7 +37,34 @@ SELECT APPROX_COUNT_DISTINCT(h5) * 252.9 AS area_km2 FROM ...
 
 ## Joining Different Resolutions
 
-Use `h3_cell_to_parent()` — not `h3_cell_to_children()` — to join datasets at different resolutions. Always convert the **finer** (higher number) resolution to the **coarser** (lower number) resolution:
+**Always join by converting the finer (higher-numbered) dataset to the coarser resolution — never look for child columns on the coarser dataset.**
+
+### Step 1: Check for pre-computed parent columns (preferred)
+
+Many fine-resolution datasets (e.g. GEBCO h8) already carry pre-computed parent columns (`h7`, `h6`, `h5`, ...). Use these directly — they are faster than calling `h3_cell_to_parent()` on every row. Check the schema first:
+
+```sql
+-- Check what resolution columns exist
+DESCRIBE SELECT * FROM read_parquet('<STAC_PATH>') LIMIT 1;
+```
+
+If the finer dataset has the target parent column, use it directly:
+
+```sql
+-- GEBCO (h8-indexed, has h6 column) joined to geomorphology (h6-indexed)
+WITH gebco_by_h6 AS (
+  SELECT h6, h0, AVG(elevation) AS avg_elevation
+  FROM read_parquet('<GEBCO_PATH>')
+  GROUP BY h6, h0
+)
+SELECT s.feature_type, g.avg_elevation
+FROM read_parquet('<GEOMORPHOLOGY_PATH>') s
+JOIN gebco_by_h6 g ON s.h6 = g.h6 AND s.h0 = g.h0
+```
+
+### Step 2: Fall back to h3_cell_to_parent() when no pre-computed column exists
+
+Use `h3_cell_to_parent()` — not `h3_cell_to_children()` — when the pre-computed parent column is absent:
 
 ```sql
 -- dataset_a has h8, dataset_b has h4: convert h8 → h4

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: duckdb-mcp
   namespace: biodiversity
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: duckdb-mcp
@@ -13,13 +13,6 @@ spec:
       labels:
         app: duckdb-mcp
     spec:
-#      nodeSelector:
-#        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
-#      tolerations:
-#      - key: "nautilus.io/issue"
-#        operator: "Equal"
-#        value: "1476"
-#        effect: "NoSchedule"    
       containers:
       - name: server
         image: astral/uv:python3.12-bookworm-slim
@@ -27,12 +20,14 @@ spec:
         args:
           - |
             apt-get update && apt-get install -y git && \
-            git clone https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.3.0 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             uv run --with "mcp" --with "duckdb" --with pandas --with uvicorn --with tabulate --with pystac --with requests server.py
         env:
         - name: STAC_CATALOG_URL
           value: "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
+        - name: MCP_PUBLIC_BASE_URL
+          value: "https://duckdb-mcp.nrp-nautilus.io"
         resources:   
           requests:
             memory: 16Gi

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         args:
           - |
             apt-get update && apt-get install -y git && \
-            git clone --branch dev https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             uv run --with "mcp" --with "duckdb" --with pandas --with uvicorn --with tabulate --with pystac --with requests server.py
         env:


### PR DESCRIPTION
## Summary

- Production deployment clones from tag `v0.3.0` instead of default branch — explicit promotion only
- Dev deployment clones from `main` (default branch) instead of `--branch dev`
- Production scaled to 3 replicas, dev to 1
- Add `MCP_PUBLIC_BASE_URL` to production env for tile endpoint URLs
- Remove stale commented-out nodeSelector/tolerations from production

Implements #58.

## Test plan

- [x] Both YAMLs validated by visual inspection
- [ ] `kubectl apply` both deployments + rollout restart
- [ ] Verify production serves from v0.3.0 tag
- [ ] Verify dev serves from main HEAD