### PR TITLE
Add optional query_backend plugin hook

### DIFF
--- a/server.py
+++ b/server.py
@@ -194,7 +194,10 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
     """Placeholder (overwritten below)."""
     print(f"🔍 Executing: {sql_query}", file=sys.stderr)
     if _CUSTOM_BACKEND:
-        return _query_backend.execute(sql_query, s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope)
+        try:
+            return _query_backend.execute(sql_query, s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope)
+        except Exception as e:
+            return f"SQL Error: {str(e)}"
     try:
         with get_isolated_db(s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope) as db:
             result = db.sql(sql_query)

--- a/server.py
+++ b/server.py
@@ -13,6 +13,14 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from stac import STAC_DATASETS, STAC_LOAD_ERRORS, STAC_CATALOG_URL, list_datasets as _stac_list, get_dataset as _stac_get, get_collection as _stac_get_collection
 
+# Optional swappable query backend (e.g. GPU-accelerated).
+# If query_backend.py is present alongside server.py it replaces the built-in DuckDB engine.
+try:
+    import query_backend as _query_backend
+    _CUSTOM_BACKEND = True
+except ImportError:
+    _CUSTOM_BACKEND = False
+
 # Workaround for https://github.com/boettiger-lab/mcp-data-server/issues/5
 # send_notification crashes with ClosedResourceError when the client disconnects
 # (e.g. after a ~60s client-side timeout) while a query is still running.
@@ -185,6 +193,8 @@ def analyst_persona() -> str:
 def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None) -> str:
     """Placeholder (overwritten below)."""
     print(f"🔍 Executing: {sql_query}", file=sys.stderr)
+    if _CUSTOM_BACKEND:
+        return _query_backend.execute(sql_query, s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope)
     try:
         with get_isolated_db(s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope) as db:
             result = db.sql(sql_query)


### PR DESCRIPTION
## Summary

- Adds a `try: import query_backend` block near the top of `server.py`
- If `query_backend.py` is present alongside `server.py`, its `execute()` function replaces the built-in DuckDB isolation engine for the `query` tool
- Falls back silently to DuckDB when no plugin is found — existing deployments are unaffected

## Interface contract

`query_backend.execute(sql, s3_key=None, s3_secret=None, s3_endpoint=None, s3_scope=None) -> str`

Plugins receive all credential kwargs; they may use or ignore them.

## Motivation

Enables `mcp-gpu-data-server` (https://github.com/boettiger-lab/mcp-gpu-data-server) to stay in sync with this repo rather than maintaining a diverging fork. That repo's Dockerfile clones this repo at build time and drops in a GPU-accelerated `query_backend.py` via this hook.

## Test plan
- [ ] Server starts normally with no `query_backend.py` present (DuckDB path)
- [ ] Server routes queries through plugin when `query_backend.py` is present