### PR TITLE
k8s: right-size dev deployment to match actual usage

### DIFF
--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -30,11 +30,11 @@ spec:
           value: "https://dev-duckdb-mcp.nrp-nautilus.io"
         resources:
           requests:
-            memory: 16Gi
-            cpu: 1
+            memory: 2Gi
+            cpu: 250m
           limits:
-            memory: 160Gi
-            cpu: 16
+            memory: 16Gi
+            cpu: 4
         ports:
         - containerPort: 8000
         readinessProbe:


### PR DESCRIPTION
## Summary

NRP's admission webhook was blocking \`rollout restart\` on the dev deployment because the requests (16 GiB / 1 CPU) are ~14x actual usage (1.2 GiB / 0.001 CPU), well below the ~20% utilization floor NRP enforces per-account.

Drop dev's requests to 2 GiB / 250m; keep limits at 16 GiB / 4 CPU for ad-hoc DuckDB query headroom. Prod is untouched (its usage pattern justifies the larger request).

## Test plan

- [x] Confirm admission webhook accepts the new shape (apply + rollout)
- [ ] Pod reaches Ready after rollout