### PR TITLE
k8s: scale prod duckdb-mcp to 2 replicas

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: duckdb-mcp
   namespace: biodiversity
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: duckdb-mcp


### PR DESCRIPTION
## Summary

Drop prod replicas from 3 (file) / 4 (live cluster) to 2. The extra replicas didn't add effective capacity — query load is bimodal across pods (usually 1-2 idle at <1 GiB, 1-2 active at 50-160 GiB) — and each idle replica reserves a full 16 GiB / 1 CPU request against the account quota, dragging account-wide utilization below NRP's admission floor and blocking rollouts.

## Test plan

- [x] Apply to cluster; confirm active sessions finish cleanly (rollingUpdate default)
- [x] Confirm account utilization ratio improves (precondition for later redeploys)