### PR TITLE
stac: enqueue sub-children of retry-rescued parents

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -463,54 +463,69 @@ def fetch_stac_catalog(catalog_url: str = None, catalog_token: str = None) -> di
 
     # --- Phase 2.5: retry failed children once with a longer timeout ---
     # Rescues tail-latency failures (borderline-slow S3 responses). A retry that
-    # also fails leaves the original error in STAC_LOAD_ERRORS. If a previously-failed
-    # parent succeeds on retry, its sub-children are NOT re-fetched here — they
-    # weren't attempted the first time because we didn't have the parent's JSON;
-    # a cache-miss on any specific sub-child ID will trigger a fresh walk later.
+    # also fails leaves the original error in STAC_LOAD_ERRORS. When a previously-
+    # failed parent succeeds on retry, its sub-children ARE now enqueued to the
+    # same retry pool — otherwise a rescued parent would be in the catalog without
+    # any of its sub-datasets indexed (observed on dev: us-census retry rescued
+    # the parent but left its 6 census-year collections absent).
     if failed_parents or failed_subchildren:
         with ThreadPoolExecutor(max_workers=_STAC_FETCH_CONCURRENCY) as retry_pool:
-            retry_futures: dict = {}
+            retry_pending: dict = {}
             for href, title in failed_parents:
                 fut = retry_pool.submit(
                     _fetch_parent, href, title, catalog_token, _STAC_CHILD_RETRY_TIMEOUT,
                 )
-                retry_futures[fut] = ("parent", href, title)
+                retry_pending[fut] = ("parent", href, title)
             for sub_href, parent_col_id in failed_subchildren:
                 fut = retry_pool.submit(
                     _fetch_subchild, sub_href, parent_col_id, catalog_token, _STAC_CHILD_RETRY_TIMEOUT,
                 )
-                retry_futures[fut] = ("subchild", sub_href, parent_col_id)
-            for fut in retry_futures:
-                entry = retry_futures[fut]
-                kind = entry[0]
-                if kind == "parent":
-                    _, href, title = entry
-                    col, _subchild_hrefs, error = fut.result()
-                    if col is not None:
-                        parent_cols[col.id] = col
-                        # Clear the first-pass error for this parent since retry succeeded
-                        errors.pop(_child_identifier(href, title_hint=title), None)
-                        print(
-                            f"🔁 Retry succeeded for parent: {col.id}",
-                            file=sys.stderr,
-                        )
-                    # If retry also failed, `error` carries the same identifier key as the
-                    # first-pass error; updating with it leaves the STAC_LOAD_ERRORS entry
-                    # pointing at the most-recent (retry) reason.
-                    if error:
-                        errors.update(error)
-                else:  # subchild
-                    _, sub_href, parent_col_id = entry
-                    col, error = fut.result()
-                    if col is not None:
-                        subchild_cols_by_parent.setdefault(parent_col_id, {})[col.id] = col
-                        errors.pop(_child_identifier(sub_href, title_hint=None), None)
-                        print(
-                            f"🔁 Retry succeeded for sub-child: {col.id}",
-                            file=sys.stderr,
-                        )
-                    if error:
-                        errors.update(error)
+                retry_pending[fut] = ("subchild", sub_href, parent_col_id)
+            # Dynamic drain — mirrors the main pool's pattern so that sub-children of
+            # retry-rescued parents can be enqueued mid-loop.
+            while retry_pending:
+                done, _ = wait(retry_pending.keys(), return_when=FIRST_COMPLETED)
+                for fut in done:
+                    entry = retry_pending.pop(fut)
+                    kind = entry[0]
+                    if kind == "parent":
+                        _, href, title = entry
+                        col, subchild_hrefs, error = fut.result()
+                        if col is not None:
+                            parent_cols[col.id] = col
+                            # Clear the first-pass error for this parent since retry succeeded
+                            errors.pop(_child_identifier(href, title_hint=title), None)
+                            print(
+                                f"🔁 Retry succeeded for parent: {col.id}",
+                                file=sys.stderr,
+                            )
+                            # Enqueue sub-children of the newly-rescued parent. These are
+                            # first-time fetches, not retries — they use the retry timeout
+                            # so they have the same generous budget as the rest of this pool.
+                            if subchild_hrefs:
+                                subchild_cols_by_parent.setdefault(col.id, {})
+                            for sub_href in subchild_hrefs:
+                                sub_fut = retry_pool.submit(
+                                    _fetch_subchild, sub_href, col.id, catalog_token, _STAC_CHILD_RETRY_TIMEOUT,
+                                )
+                                retry_pending[sub_fut] = ("subchild", sub_href, col.id)
+                        # If retry also failed, `error` carries the same identifier key as
+                        # the first-pass error; updating leaves STAC_LOAD_ERRORS pointing at
+                        # the most-recent (retry) reason.
+                        if error:
+                            errors.update(error)
+                    else:  # subchild
+                        _, sub_href, parent_col_id = entry
+                        col, error = fut.result()
+                        if col is not None:
+                            subchild_cols_by_parent.setdefault(parent_col_id, {})[col.id] = col
+                            errors.pop(_child_identifier(sub_href, title_hint=None), None)
+                            print(
+                                f"🔁 Retry succeeded for sub-child: {col.id}",
+                                file=sys.stderr,
+                            )
+                        if error:
+                            errors.update(error)
 
     # --- Phase 3: render markdown / dicts; swap module state ---
     datasets: dict = {}

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1097,3 +1097,62 @@ class TestFetchResilience:
         assert 5 in child_timeouts, f"expected first-pass child timeout (5s) in {child_timeouts}"
         assert 8 in child_timeouts, f"expected retry child timeout (8s) in {child_timeouts}"
 
+    def test_retry_rescued_parent_fetches_its_subchildren(self):
+        """When a parent-of-children fails the first pass and succeeds on retry,
+        its sub-children must ALSO be fetched (in the retry pool). Otherwise the
+        parent ends up indexed without any of its sub-datasets — observed on the
+        2026-04-18 dev rollout where us-census retried but left 6 sub-collections
+        absent.
+        """
+        from unittest.mock import patch, MagicMock
+        import requests
+        import stac
+
+        self._reset_module_state(stac)
+
+        cat = self._make_root_catalog([
+            "https://example.com/public-census/stac-collection.json",
+        ])
+
+        # Parent has two sub-child links. Note: we must set `.links` (not just
+        # rely on get_children) because the new loader walks `.links`.
+        parent = self._make_leaf_collection("us-census")
+        sub1_link = MagicMock(); sub1_link.rel = "child"
+        sub1_link.href = "https://example.com/public-census/census-2024/state/stac-collection.json"
+        sub1_link.title = None
+        sub2_link = MagicMock(); sub2_link.rel = "child"
+        sub2_link.href = "https://example.com/public-census/census-2024/county/stac-collection.json"
+        sub2_link.title = None
+        parent.links = [sub1_link, sub2_link]
+
+        sub1 = self._make_leaf_collection("census-2024-state")
+        sub2 = self._make_leaf_collection("census-2024-county")
+
+        call_log = []
+
+        def fetch_side_effect(href, *args, **kwargs):
+            call_log.append(href)
+            # Parent fails first attempt, succeeds second.
+            if href.endswith("/public-census/stac-collection.json"):
+                parent_attempts = [h for h in call_log if h.endswith("/public-census/stac-collection.json")]
+                if len(parent_attempts) == 1:
+                    raise requests.exceptions.Timeout("parent slow first time")
+                return parent
+            if "state" in href:
+                return sub1
+            if "county" in href:
+                return sub2
+            raise ValueError(f"Unexpected href: {href}")
+
+        with patch("stac.pystac.Catalog.from_file", return_value=cat), \
+             patch("stac.pystac.Collection.from_file", side_effect=fetch_side_effect):
+            result = stac.fetch_stac_catalog()
+
+        # Parent is in the catalog (retry rescued it)
+        assert "us-census" in result, f"parent missing from result; got {list(result.keys())}"
+        # Both sub-children are indexed — this is the behavior the fix guarantees
+        assert "census-2024-state" in result, "sub-child 1 missing — retry didn't enqueue sub-children"
+        assert "census-2024-county" in result, "sub-child 2 missing — retry didn't enqueue sub-children"
+        # No errors — retry rescued everything cleanly
+        assert stac.STAC_LOAD_ERRORS == {}
+


### PR DESCRIPTION
Fix for the gap observed in v0.5.0 dev rollout: us-census retried successfully but its 6 sub-collections were never fetched (the static retry drain didn't enqueue them).

Switches the retry pool from static iteration to the same dynamic drain pattern as the main pool — when a parent succeeds on retry, its sub-child links get submitted into the retry pool immediately. Uses the retry timeout for the generous budget.

Test: `test_retry_rescued_parent_fetches_its_subchildren` proves both the parent AND its sub-children end up in the catalog.

96/96 tests passing.