### PR TITLE
k8s: bump prod to v0.5.1

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         args:
           - |
             apt-get update && apt-get install -y git && \
-            git clone --branch v0.5.0 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.5.1 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             uv run --with "mcp" --with "duckdb" --with pandas --with uvicorn --with tabulate --with pystac --with requests server.py
         env:


### PR DESCRIPTION
Pulls in the retry-rescued-parent sub-children fix from PR #75. Release notes: https://github.com/boettiger-lab/mcp-data-server/releases/tag/v0.5.1