### PR TITLE
register_hex_tiles: emit count property and per-resolution value_stats

### DIFF
--- a/server.py
+++ b/server.py
@@ -232,13 +232,28 @@ def register_hex_tiles(
     roughly >100k cells, or any case where the user wants to visualize hexes
     directly on the map (rather than color an existing polygon layer).
 
-    Input SQL contract: return (h3_index, value1, value2, ...) where the first
-    column is an H3 index at resolution `finest_res`, and subsequent columns
-    are numeric values. All value columns are aggregated by `agg` (AVG, SUM, MIN,
-    MAX, COUNT) at each coarser resolution down to `min_res`.
+    Input SQL contract:
+    - First column must be an H3 index at resolution `finest_res`.
+    - For agg="COUNT": no other columns required. Output has a single `count`
+      column (row count per hex). If the user SQL returns extra columns, they
+      are ignored.
+    - For agg in {AVG, SUM, MIN, MAX}: at least one numeric value column must
+      follow the H3 index. Each is aggregated by `agg` at each coarser
+      resolution down to `min_res`.
 
-    Returns a dict with `tile_url_template` that any MapLibre client can consume
-    via:
+    Returns a dict with:
+    - `tile_url_template`: MapLibre vector tile URL with {z}/{x}/{y} placeholders.
+    - `value_columns`: list of output column names available as MVT feature
+      properties. For agg="COUNT" this is ["count"]; otherwise the user's
+      value columns.
+    - `value_stats`: {<col>: {"by_res": {"<res>": {"min": <num>, "max": <num>}}}}.
+      Clients colouring across multiple zooms should match on the per-feature
+      `res` property to pick the right min/max band for each resolution, since
+      COUNT/SUM ranges differ by ~7× per H3 level.
+    - `bounds`, `finest_res`, `min_res`, `zoom_offset`, `feature_count_finest`:
+      tileset metadata.
+
+    MapLibre usage:
         map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
         map.addLayer({..., 'source-layer': 'hex', paint: {...}});
     """

--- a/server.py
+++ b/server.py
@@ -247,10 +247,8 @@ def register_hex_tiles(
       properties. For agg="COUNT" this is ["count"]; otherwise the user's
       value columns.
     - `value_stats`: {<col>: {"by_res": {"<res>": {"min": <num>, "max": <num>}}}}.
-      Clients colouring across multiple zooms should match on the per-feature
-      `res` property to pick the right min/max band for each resolution, since
-      COUNT/SUM ranges differ by ~7× per H3 level.
-    - `bounds`, `finest_res`, `min_res`, `zoom_offset`, `feature_count_finest`:
+      Per-resolution min/max for each value column — pass to the map client.
+    - `hash`, `bounds`, `finest_res`, `min_res`, `zoom_offset`, `feature_count_finest`:
       tileset metadata.
 
     MapLibre usage:

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -236,6 +236,52 @@ class TestRegisterHexTiles:
                 finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
             )
 
+    def test_value_stats_returned_per_resolution(self, local_bucket, h3_conn):
+        # 5 rows, 3 distinct res=5 cells. At finest res the pyramid stores
+        # `1 AS count` per input row (ungrouped), so naive MIN/MAX gives
+        # {1, 1}. At coarser parent resolutions rows collapse into fewer
+        # cells and COUNT(*) produces max counts > 1.
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5
+            FROM (VALUES (37.80, -122.30),
+                         (37.80001, -122.30001),
+                         (37.80002, -122.30002),
+                         (38.00, -122.50),
+                         (40.00, -100.00)) t(lat, lng)
+        """
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql,
+            finest_res=5, min_res=3, agg="COUNT", zoom_offset=4,
+        )
+        stats = result["value_stats"]
+        assert set(stats.keys()) == {"count"}
+        by_res = stats["count"]["by_res"]
+        # Resolutions 3, 4, 5 all present (string keys).
+        assert set(by_res.keys()) == {"3", "4", "5"}
+        # Finest-res parquet carries `1 AS count` per row; MIN/MAX collapse to 1.
+        assert by_res["5"]["min"] == 1
+        assert by_res["5"]["max"] == 1
+        # Coarser resolutions aggregate via COUNT(*); at least one parent cell
+        # contains 3 of the clustered points at res=4.
+        assert by_res["4"]["max"] >= 3
+        # Coarser levels can only aggregate further — max is non-decreasing.
+        assert by_res["3"]["max"] >= by_res["4"]["max"]
+
+    def test_value_stats_for_non_count_agg(self, local_bucket, h3_conn):
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, val
+            FROM (VALUES (37.8, -122.3, 1.0),
+                         (38.0, -122.5, 5.0)) t(lat, lng, val)
+        """
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql,
+            finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+        )
+        stats = result["value_stats"]
+        assert set(stats.keys()) == {"val"}
+        assert stats["val"]["by_res"]["5"]["min"] == 1.0
+        assert stats["val"]["by_res"]["5"]["max"] == 5.0
+
 
 import json as _json
 
@@ -254,6 +300,18 @@ class TestTilesetMetadata:
         assert meta["agg"] == "SUM"
         assert meta["zoom_offset"] == 3
         assert meta["value_columns"] == ["val"]
+
+    def test_metadata_includes_value_stats(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=3, agg="COUNT", zoom_offset=4,
+        )
+        meta_path = local_bucket / "hex" / result["hash"] / "metadata.json"
+        meta = _json.loads(meta_path.read_text())
+        assert "value_stats" in meta
+        assert set(meta["value_stats"]["count"]["by_res"].keys()) == {"3", "4", "5"}
+        # Sanity: persisted stats equal the returned stats.
+        assert meta["value_stats"] == result["value_stats"]
 
 
 from tiles.db import build_tile_connection

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -197,6 +197,45 @@ class TestRegisterHexTiles:
         r2 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
         assert r1["hash"] == r2["hash"]
 
+    def test_count_agg_with_index_only_sql(self, local_bucket, h3_conn):
+        # Three rows → two map to the same res=5 cell, one to another.
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5
+            FROM (VALUES (37.8, -122.3),
+                         (37.80001, -122.30001),
+                         (40.0, -100.0)) t(lat, lng)
+        """
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql,
+            finest_res=5, min_res=2, agg="COUNT", zoom_offset=4,
+        )
+        assert result["value_columns"] == ["count"]
+        # Verify the parquet pyramid actually has the count column.
+        import duckdb as _d
+        for res in (2, 3, 4, 5):
+            uri = str(local_bucket / "hex" / result["hash"] / f"res={res}" / "*.parquet")
+            cols = _d.connect(":memory:").sql(f"SELECT * FROM read_parquet('{uri}') LIMIT 0").columns
+            assert "count" in cols, f"res={res} missing 'count' column: {cols}"
+
+    def test_count_agg_ignores_user_value_columns(self, local_bucket, h3_conn):
+        # User supplies an extra column; COUNT mode drops it.
+        user_sql = """
+            SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 'ignored' AS extra
+        """
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql,
+            finest_res=5, min_res=5, agg="COUNT", zoom_offset=4,
+        )
+        assert result["value_columns"] == ["count"]
+
+    def test_non_count_still_requires_value_columns(self, local_bucket, h3_conn):
+        with pytest.raises(ValueError, match="value column"):
+            register_hex_tiles(
+                con=h3_conn,
+                sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5",
+                finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+            )
+
 
 import json as _json
 

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -109,7 +109,7 @@ class TestBuildPyramidSQL:
 import os
 import duckdb
 from pathlib import Path
-from tiles.pyramid import register_hex_tiles
+from tiles.pyramid import register_hex_tiles, _inspect_user_sql
 
 
 @pytest.fixture
@@ -130,6 +130,24 @@ def h3_conn():
     con.sql("INSTALL httpfs; LOAD httpfs")
     yield con
     con.close()
+
+
+class TestInspectUserSQL:
+    def test_allows_single_column_sql(self, h3_conn):
+        # SQL returning only the h3 index — valid input for agg="COUNT".
+        h3_col, value_cols = _inspect_user_sql(
+            h3_conn, "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5"
+        )
+        assert h3_col == "h5"
+        assert value_cols == []
+
+    def test_still_extracts_value_cols_when_present(self, h3_conn):
+        h3_col, value_cols = _inspect_user_sql(
+            h3_conn,
+            "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS v1, 2.0 AS v2",
+        )
+        assert h3_col == "h5"
+        assert value_cols == ["v1", "v2"]
 
 
 class TestRegisterHexTiles:

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -78,6 +78,33 @@ class TestBuildPyramidSQL:
         # Only the finest level — no UNION ALL.
         assert "UNION ALL" not in sql
 
+    def test_count_mode_emits_count_column_no_value_cols(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8 FROM src",
+            finest_res=8, min_res=2, agg="COUNT",
+            value_columns=["count"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Parents: COUNT(*) AS count at every parent level.
+        assert "COUNT(*) AS count" in sql
+        # Finest: literal 1 AS count (no aggregation at finest level).
+        assert "1 AS count" in sql
+        # No stray references to user value columns (there are none).
+        assert 'AVG(' not in sql and 'SUM(' not in sql
+
+    def test_count_mode_finest_level_has_literal_one(self):
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8 FROM src",
+            finest_res=5, min_res=2, agg="COUNT",
+            value_columns=["count"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Finest-level SELECT is identifiable by the "5 AS res" literal.
+        finest_select = re.search(r"SELECT[^)]*?5 AS res FROM src", sql, re.DOTALL)
+        assert finest_select is not None
+        assert "1 AS count" in finest_select.group(0)
+        assert "COUNT(*)" not in finest_select.group(0)
+
 
 import os
 import duckdb

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -81,15 +81,16 @@ def _json_dumps_escaped(obj) -> str:
 
 
 def _inspect_user_sql(con: duckdb.DuckDBPyConnection, user_sql: str):
-    """Run user SQL with LIMIT 0 to extract column names without materializing data."""
+    """Run user SQL with LIMIT 0 to extract column names without materializing data.
+
+    Returns (h3_column, value_columns). value_columns may be empty — the caller
+    is responsible for validating that an empty list is acceptable for the
+    chosen aggregation (only agg="COUNT" supports it).
+    """
     columns = con.sql(f"SELECT * FROM ({user_sql}) LIMIT 0").columns
     if not columns:
         raise ValueError("user SQL returned no columns")
-    h3_column = columns[0]
-    value_columns = list(columns[1:])
-    if not value_columns:
-        raise ValueError("user SQL must return at least one value column after the H3 index")
-    return h3_column, value_columns
+    return columns[0], list(columns[1:])
 
 
 def register_hex_tiles(

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -5,6 +5,7 @@ Tile requests read directly from the pyramid — no coordination needed.
 """
 import json
 import os
+from decimal import Decimal
 from typing import List
 
 import duckdb
@@ -144,12 +145,33 @@ def register_hex_tiles(
         os.makedirs(output_uri, exist_ok=True)
     con.sql(pyramid_sql)
 
+    # Per-resolution min/max for every output value column.
+    def _jsonable(v):
+        # DuckDB returns DECIMAL for literal-typed numerics; coerce to float
+        # so the metadata sidecar stays JSON-serializable.
+        if isinstance(v, Decimal):
+            return float(v)
+        return v
+
+    value_stats = {}
+    for col in value_columns:
+        by_res = {}
+        for res in range(min_res, finest_res + 1):
+            uri = f"{output_uri}res={res}/*.parquet"
+            row = con.sql(
+                f'SELECT MIN("{col}") AS mn, MAX("{col}") AS mx '
+                f"FROM read_parquet('{uri}')"
+            ).fetchone()
+            by_res[str(res)] = {"min": _jsonable(row[0]), "max": _jsonable(row[1])}
+        value_stats[col] = {"by_res": by_res}
+
     metadata = {
         "finest_res": finest_res,
         "min_res": min_res,
         "agg": agg,
         "zoom_offset": zoom_offset,
         "value_columns": value_columns,
+        "value_stats": value_stats,
     }
     metadata_sql = (
         f"COPY (SELECT '{_json_dumps_escaped(metadata)}' AS j) "
@@ -177,5 +199,6 @@ def register_hex_tiles(
         "min_res": min_res,
         "zoom_offset": zoom_offset,
         "value_columns": value_columns,
+        "value_stats": value_stats,
         "feature_count_finest": feature_count,
     }

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -104,11 +104,30 @@ def register_hex_tiles(
     """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
 
     The connection must have httpfs, spatial, and h3 extensions loaded.
+
+    Value-column contract:
+    - agg="COUNT": user SQL needs only the H3 index column. Output has a single
+      `count` column (row count per hex at parent resolutions; 1 at finest).
+      Any extra columns in the user SQL are ignored.
+    - Other aggs: user SQL must return at least one value column after the H3
+      index. Each is aggregated via `agg` at parent resolutions and passed
+      through raw at the finest level.
     """
     if finest_res < min_res:
         raise ValueError(f"finest_res ({finest_res}) must be >= min_res ({min_res})")
 
-    h3_column, value_columns = _inspect_user_sql(con, sql)
+    h3_column, sql_value_columns = _inspect_user_sql(con, sql)
+    agg_upper = agg.upper()
+    if agg_upper == "COUNT":
+        value_columns = ["count"]
+    else:
+        if not sql_value_columns:
+            raise ValueError(
+                "user SQL must return at least one value column after the H3 index "
+                "(or use agg='COUNT')"
+            )
+        value_columns = sql_value_columns
+
     h = content_hash(sql=sql, finest_res=finest_res, min_res=min_res, agg=agg, zoom_offset=zoom_offset)
     output_uri = f"{_bucket_base()}/hex/{h}/"
 
@@ -121,12 +140,10 @@ def register_hex_tiles(
         h3_column=h3_column,
         output_uri=output_uri,
     )
-    # For local filesystem URIs, DuckDB does not create intermediate directories.
     if not output_uri.startswith("s3://"):
         os.makedirs(output_uri, exist_ok=True)
     con.sql(pyramid_sql)
 
-    # Write a sidecar metadata.json so the tile handler knows finest_res / zoom_offset.
     metadata = {
         "finest_res": finest_res,
         "min_res": min_res,
@@ -140,7 +157,6 @@ def register_hex_tiles(
     )
     con.sql(metadata_sql)
 
-    # Bounds of finest-level cells (approximate via simple min/max on cell centers).
     finest_uri = f"{output_uri}res={finest_res}/*.parquet"
     bounds_row = con.sql(
         f"SELECT "

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -23,28 +23,36 @@ def build_pyramid_sql(
 ) -> str:
     """Return the COPY ... TO SQL that writes a partitioned pyramid.
 
-    The finest-resolution level stores the user's values unaggregated; parents
-    at each coarser resolution aggregate via the user-chosen `agg` function.
+    The finest-resolution level stores raw per-row values; parent resolutions
+    aggregate via the chosen `agg` function.
+
+    When agg="COUNT", `value_columns` must be exactly ["count"] and the SQL
+    emits `COUNT(*) AS count` at parent levels and `1 AS count` at the finest
+    level. Any value columns from the user SQL are ignored — callers requesting
+    COUNT get row-count semantics, nothing else.
     """
     _VALID_AGG = {"AVG", "SUM", "MIN", "MAX", "COUNT"}
-    if agg.upper() not in _VALID_AGG:
+    agg_upper = agg.upper()
+    if agg_upper not in _VALID_AGG:
         raise ValueError(f"agg must be one of {_VALID_AGG}, got {agg!r}")
 
-    # Quote identifiers to handle column names with spaces or reserved keywords.
     qh = f'"{h3_column}"'
-    value_list_raw = ", ".join(f'"{c}"' for c in value_columns)
-    value_list_agg = ", ".join(f'{agg}("{c}") AS "{c}"' for c in value_columns)
+
+    if agg_upper == "COUNT":
+        parent_values = "COUNT(*) AS count"
+        finest_values = "1 AS count"
+    else:
+        parent_values = ", ".join(f'{agg_upper}("{c}") AS "{c}"' for c in value_columns)
+        finest_values = ", ".join(f'"{c}"' for c in value_columns)
 
     selects = []
-    # Parents: min_res .. finest_res - 1, each aggregated.
     for res in range(min_res, finest_res):
         selects.append(
             f"  SELECT h3_cell_to_parent({qh}, {res}) AS h, "
-            f"{value_list_agg}, {res} AS res FROM src GROUP BY 1"
+            f"{parent_values}, {res} AS res FROM src GROUP BY 1"
         )
-    # Finest level: raw values, no aggregation.
     selects.append(
-        f"  SELECT {qh} AS h, {value_list_raw}, {finest_res} AS res FROM src"
+        f"  SELECT {qh} AS h, {finest_values}, {finest_res} AS res FROM src"
     )
 
     body = "\n  UNION ALL\n".join(selects)


### PR DESCRIPTION
## Summary
- `agg="COUNT"` now emits a dedicated `count` MVT property (row count per hex at parent resolutions; literal `1` at the finest level) and accepts SQL that returns only the H3 index column.
- `register_hex_tiles` returns and persists `value_stats.{col}.by_res.{res}.{min,max}` for every output value column so clients can paint correctly across H3 resolutions whose aggregate ranges differ by ~7× per level.
- MCP tool docstring updated to reflect the new contract.

Fixes #78.

Requires matching client-side paint changes in boettiger-lab/geo-agent#174 — ship together.

## Design notes

- **COUNT at `finest_res` is literal `1`**, not aggregated. Rows in the caller's SQL are assumed distinct at `finest_res`. Use `value_stats[col].by_res["<res>"]` at a coarser resolution for realistic max-count bands. This is intentional; a `GROUP BY` at finest level would silently change non-COUNT semantics.
- **Stats sweep** runs one `MIN`/`MAX` query per (column, resolution) pair after the pyramid COPY. Current workloads are small (~8 queries); a single query per resolution with grouped aggregates is a future optimization if we add many-column value sets.
- **`test_rejects_empty_sql`** from the plan was dropped after discovering DuckDB's `SELECT *` always produces at least one column — the "no columns" guard is unreachable from any valid SQL. The defensive check in `_inspect_user_sql` is retained.

## Test plan
- [x] `.venv/bin/pytest tests/test_tile_pyramid.py -v` — 23/23 pass.
- [x] Full suite — 150/150 pass.
- [ ] After merge + deploy: call `register_hex_tiles(sql="SELECT DISTINCT h8 FROM ... WHERE State_Nm = 'AZ'", finest_res=8, min_res=2, agg="COUNT")`; confirm response has `value_columns == ["count"]` and non-trivial `value_stats.count.by_res` spanning res 2–8.
- [ ] Decode one tile per zoom level; confirm every feature has a numeric `count` property.
- [ ] Cross-check returned per-res `max` against `SELECT MAX(ct) FROM (SELECT COUNT(*) ct FROM src GROUP BY h3_cell_to_parent(h8, <res>))`.