### PR TITLE
register_hex_tiles: expose MVT layer_name in return value

### DIFF
--- a/server.py
+++ b/server.py
@@ -248,12 +248,13 @@ def register_hex_tiles(
       value columns.
     - `value_stats`: {<col>: {"by_res": {"<res>": {"min": <num>, "max": <num>}}}}.
       Per-resolution min/max for each value column — pass to the map client.
+    - `layer_name`: the MVT source-layer name; use as `source-layer` in the client.
     - `hash`, `bounds`, `finest_res`, `min_res`, `zoom_offset`, `feature_count_finest`:
       tileset metadata.
 
     MapLibre usage:
         map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
-        map.addLayer({..., 'source-layer': 'hex', paint: {...}});
+        map.addLayer({..., 'source-layer': layer_name, paint: {...}});
     """
     con = _get_tile_con()
     return _register_hex_tiles(

--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -77,6 +77,23 @@ class TestServeTile:
         r = client.get(f"/tiles/bogus/{registered_ca}/5/5/12.pbf")
         assert r.status_code == 404
 
+    def test_mvt_layer_name_matches_return(self, app_with_tiles, local_bucket):
+        con = app_with_tiles.state.tile_con
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, 1.0 AS val
+            FROM (SELECT 36 + random()*3 AS lat, -121 - random()*3 AS lng FROM range(500))
+        """
+        result = register_hex_tiles(
+            con=con, sql=user_sql, finest_res=5, min_res=2, agg="AVG", zoom_offset=4,
+        )
+        layer_name = result["layer_name"]
+        client = TestClient(app_with_tiles)
+        r = client.get(f"/tiles/hex/{result['hash']}/5/5/12.pbf")
+        assert r.status_code == 200
+        # MVT protobuf encodes the layer name as a length-prefixed string.
+        expected = bytes([len(layer_name)]) + layer_name.encode()
+        assert expected in r.content, f"layer name {layer_name!r} not found in MVT bytes"
+
 
 class TestMetadataDriven:
     def test_endpoint_reads_finest_res_from_metadata(self, app_with_tiles, local_bucket):

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -191,6 +191,13 @@ class TestRegisterHexTiles:
         )
         assert result["value_columns"] == ["v1", "v2"]
 
+    def test_returns_layer_name(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+        )
+        assert result["layer_name"] == "layer"
+
     def test_identical_inputs_same_hash(self, local_bucket, h3_conn):
         user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
         r1 = register_hex_tiles(con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4)
@@ -312,6 +319,15 @@ class TestTilesetMetadata:
         assert set(meta["value_stats"]["count"]["by_res"].keys()) == {"3", "4", "5"}
         # Sanity: persisted stats equal the returned stats.
         assert meta["value_stats"] == result["value_stats"]
+
+    def test_metadata_includes_layer_name(self, local_bucket, h3_conn):
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=5, agg="AVG", zoom_offset=4,
+        )
+        meta_path = local_bucket / "hex" / result["hash"] / "metadata.json"
+        meta = _json.loads(meta_path.read_text())
+        assert meta["layer_name"] == result["layer_name"]
 
 
 from tiles.db import build_tile_connection

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -12,6 +12,11 @@ import duckdb
 
 from tiles.tile_math import content_hash
 
+# DuckDB's ST_AsMVT emits a single layer named "layer" (see probe in
+# tests/test_tile_pyramid.py). Clients reference this via MapLibre's
+# `source-layer` option.
+MVT_LAYER_NAME = "layer"
+
 
 def build_pyramid_sql(
     user_sql: str,
@@ -172,6 +177,7 @@ def register_hex_tiles(
         "zoom_offset": zoom_offset,
         "value_columns": value_columns,
         "value_stats": value_stats,
+        "layer_name": MVT_LAYER_NAME,
     }
     metadata_sql = (
         f"COPY (SELECT '{_json_dumps_escaped(metadata)}' AS j) "
@@ -200,5 +206,6 @@ def register_hex_tiles(
         "zoom_offset": zoom_offset,
         "value_columns": value_columns,
         "value_stats": value_stats,
+        "layer_name": MVT_LAYER_NAME,
         "feature_count_finest": feature_count,
     }


### PR DESCRIPTION
## Summary
- Adds `layer_name` (currently `"layer"`, DuckDB's default for `ST_AsMVT`) to the `register_hex_tiles` return dict and the persisted `metadata.json`. Module-level `MVT_LAYER_NAME` constant is the single source of truth.
- Updates the MCP tool docstring: adds `layer_name` to the documented return keys, and changes the MapLibre usage example from the incorrect hardcoded `source-layer: 'hex'` to `source-layer: layer_name`.
- Verified via three tests: return-value assertion, metadata round-trip, and an MVT-bytes decode check confirming the name DuckDB actually emits matches what we return.

Fixes #77.

DuckDB's `ST_AsMVT(col0, ..., col4)` has no layer-name parameter — extra `colN` args produce additional layers (`layer_1`, `layer_2`, …). Renaming the primary layer would require rewriting MVT protobuf bytes, which isn't worth it for a name clients can read off the return value.

## Test plan
- [x] `.venv/bin/pytest tests/ -q` — 153/153 pass (3 new).
- [ ] After merge + dev rollout: call `register_hex_tiles(...)` and confirm `result["layer_name"] == "layer"` and `metadata.json` matches.
- [ ] geo-agent client change (follow-up issue): consume `layer_name` from the return value rather than hardcoding `"hex"`.