### PR TITLE
get_stac_details: render full column schema and asset extension fields

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -133,13 +133,16 @@ def _format_columns(table_cols: list) -> list[str]:
         if c.get("name", "").lower() not in ("geometry", "geom", "bbox")
     ]
     h3_cols = [c for c in display_cols if c.get("name", "") in ("h0", "h8", "h9", "h10", "h11")]
-    other_cols = [c for c in display_cols if c not in h3_cols][:20]
+    other_cols = [c for c in display_cols if c not in h3_cols]
 
     lines = []
     if other_cols:
         for c in other_cols:
             desc = f" — {c['description']}" if c.get("description") else ""
             lines.append(f"    - `{c['name']}` ({c.get('type', '?')}){desc}")
+            values = c.get("values")
+            if values:
+                lines.append(f"      values: {list(values)}")
     if h3_cols:
         lines.append(f"    - H3 index columns: {', '.join(c['name'] for c in h3_cols)}")
     return lines
@@ -165,6 +168,16 @@ def _extract_parquet_assets(col) -> list[str]:
             size = asset.extra_fields.get("file:size")
             size_note = f" ({size/1024**3:.2f} GiB)" if size and size > 1024**2 else ""
             assets.append(f"  - {title}{size_note}: `read_parquet('{s3}')`")
+            # Asset-level STAC extension fields (h3, raster, vector)
+            for ext_key in (
+                "h3:native_resolution",
+                "h3:parent_resolutions",
+                "raster:bands",
+                "vector:layers",
+            ):
+                ext_val = asset.extra_fields.get(ext_key)
+                if ext_val is not None:
+                    assets.append(f"    - {ext_key}: {ext_val}")
             # Inline per-asset column schema if present
             asset_cols = asset.extra_fields.get("table:columns", [])
             col_lines = _format_columns(asset_cols)

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1156,3 +1156,89 @@ class TestFetchResilience:
         # No errors — retry rescued everything cleanly
         assert stac.STAC_LOAD_ERRORS == {}
 
+
+class TestFormatColumnsFullRender:
+    """`_format_columns` must render all columns (no 20-entry cap) and include
+    categorical `values` arrays. Regression test for issue #84.
+    """
+
+    def test_more_than_twenty_columns_all_rendered(self):
+        from stac import _format_columns
+        cols = [{"name": f"col_{i:02d}", "type": "varchar"} for i in range(30)]
+        lines = _format_columns(cols)
+        rendered = "\n".join(lines)
+        # All 30 columns should appear, not just the first 20
+        for i in range(30):
+            assert f"col_{i:02d}" in rendered, f"col_{i:02d} missing — renderer truncated"
+
+    def test_h3_columns_still_collapsed(self):
+        """H3 index columns collapse to one line regardless of how many non-H3 columns precede."""
+        from stac import _format_columns
+        cols = [{"name": f"col_{i:02d}", "type": "varchar"} for i in range(25)]
+        cols += [{"name": n, "type": "ubigint"} for n in ("h0", "h8", "h9", "h10")]
+        lines = _format_columns(cols)
+        rendered = "\n".join(lines)
+        assert "H3 index columns" in rendered
+        assert "h0" in rendered and "h8" in rendered and "h9" in rendered and "h10" in rendered
+
+    def test_categorical_values_rendered(self):
+        """Columns with a `values` array have those values included in output."""
+        from stac import _format_columns
+        cols = [{
+            "name": "owner_type",
+            "type": "varchar",
+            "description": "Land owner type",
+            "values": ["public", "private", "tribal", "ngo"],
+        }]
+        lines = _format_columns(cols)
+        rendered = "\n".join(lines)
+        for v in ("public", "private", "tribal", "ngo"):
+            assert v in rendered, f"value {v!r} missing from rendered output"
+
+
+class TestExtractParquetAssetsExtensions:
+    """`_extract_parquet_assets` must render H3, raster, and vector extension
+    fields from per-asset extra_fields. Regression test for issue #84.
+    """
+
+    def _make_collection_with_asset(self, asset_extra_fields: dict):
+        col = MagicMock()
+        col.id = "test-col"
+        asset = MagicMock()
+        asset.href = "https://s3-west.nrp-nautilus.io/bucket/hex/"
+        asset.media_type = "application/x-parquet"
+        asset.title = "hex"
+        asset.extra_fields = asset_extra_fields
+        col.assets = {"hex": asset}
+        return col
+
+    def test_h3_native_resolution_rendered(self):
+        from stac import _extract_parquet_assets
+        col = self._make_collection_with_asset({
+            "h3:native_resolution": 10,
+            "h3:parent_resolutions": [9, 8, 0],
+        })
+        rendered = "\n".join(_extract_parquet_assets(col))
+        assert "h3:native_resolution" in rendered
+        assert "10" in rendered
+
+    def test_h3_parent_resolutions_rendered(self):
+        from stac import _extract_parquet_assets
+        col = self._make_collection_with_asset({
+            "h3:native_resolution": 10,
+            "h3:parent_resolutions": [9, 8, 0],
+        })
+        rendered = "\n".join(_extract_parquet_assets(col))
+        assert "h3:parent_resolutions" in rendered
+        # All parent resolutions should be present
+        for r in (9, 8, 0):
+            assert str(r) in rendered
+
+    def test_no_h3_fields_when_absent(self):
+        """Asset without h3 fields should not render h3 lines."""
+        from stac import _extract_parquet_assets
+        col = self._make_collection_with_asset({})
+        rendered = "\n".join(_extract_parquet_assets(col))
+        assert "h3:native_resolution" not in rendered
+        assert "h3:parent_resolutions" not in rendered
+


### PR DESCRIPTION
## Summary

Fixes #84. The markdown renderer used by `get_stac_details` was truncating each asset's `table:columns` at 20 entries and dropping several STAC extension fields. Agents consuming the markdown output were forced into `SELECT *` / `DISTINCT` / `information_schema.columns` exploration loops to rediscover columns that already existed in the STAC.

## Changes

- `stac.py` `_format_columns`: drop the `[:20]` slice — render all non-H3 columns. H3 columns still collapse to one line.
- `stac.py` `_format_columns`: when a column has a `values` array, render it on the next line (`values: [...]`) so categorical enumerations reach the agent.
- `stac.py` `_extract_parquet_assets`: after each asset's `read_parquet(...)` line, render `h3:native_resolution`, `h3:parent_resolutions`, `raster:bands`, `vector:layers` from `asset.extra_fields` when present.
- `tests/test_stac.py`: two new classes (6 tests) covering 30-column render, H3 collapse, `values` arrays, h3 resolution fields present/absent.

## Test plan

- [x] Full suite green locally (159 tests).
- [ ] After merge: `kubectl rollout restart deployment/dev-duckdb-mcp -n biodiversity`
- [ ] Call `get_stac_details(dataset_id="conservation-almanac-2024")` on dev and verify:
  - Both `almanac-parquet` and `almanac-hex` list all 33 columns including `program`, `amount`, `sponsor_type`.
  - `owner_type` / `easement_type` / `sponsor_type` lines are followed by their `values` arrays.
  - `almanac-hex` shows `h3:native_resolution: 10` and `h3:parent_resolutions: [9, 8, 0]`.
- [ ] Re-run the Texas conservation-funding question on tpl.nrp-nautilus.io and confirm no `SELECT *` / `DISTINCT sponsor_type` / `information_schema.columns` exploration loops.
- [ ] Tag `v0.5.2` and bump `k8s/deployment.yaml` in a follow-up PR.