### PR TITLE
k8s: bump prod to v0.5.2 (get_stac_details renders full schema)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.5.1 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.5.2 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
Bumps prod deployment to `v0.5.2`, which includes the #84 fix for `get_stac_details` truncation. Dev smoke-tested post-merge of #85 against `conservation-almanac-2024`:

- All 33 columns render on both `almanac-parquet` and `almanac-hex` (including `program`, `amount`, `sponsor_type`).
- `owner_type`, `easement_type`, `sponsor_type` each show their `values` arrays.
- `almanac-hex` shows `h3:native_resolution: 10` and `h3:parent_resolutions: [9, 8, 0]`.

After merge: `kubectl -n biodiversity rollout restart deployment/duckdb-mcp`.