### PR TITLE
query-optimization.md: document aggregate-after-join pattern

### DIFF
--- a/query-optimization.md
+++ b/query-optimization.md
@@ -40,6 +40,28 @@ JOIN read_parquet('<STAC_CARBON_HEX_PATH>') c
 
 You must read parquet datasets from S3 using read_parquet(). There are no local tables.
 
+**Aggregate after the join, never before.** When joining a small scope to a large hex dataset, do the join against the raw `read_parquet(...)` of the large side. Wrapping the large side in a pre-aggregation CTE (`GROUP BY`, `MODE`, `SUM`) before the join forces DuckDB to scan every h0 partition of it — the small scope's h0 values cannot prune through an aggregation operator.
+
+```sql
+-- ❌ WRONG: large side aggregated first → scans all h0 partitions
+WITH lc_agg AS (
+  SELECT h8, h0, MODE(lc_class) AS dominant
+  FROM read_parquet('<large_hex>') GROUP BY h8, h0
+)
+SELECT s.h8, a.dominant
+FROM scope s JOIN lc_agg a USING (h8, h0);
+
+-- ✅ RIGHT: join first, aggregate after → only scope's h0 partitions opened
+WITH lc_on_scope AS (
+  SELECT s.h8, s.h0, l.lc_class
+  FROM scope s
+  JOIN read_parquet('<large_hex>') l USING (h8, h0)
+  WHERE l.lc_class IS NOT NULL
+)
+SELECT h8, h0, MODE(lc_class) AS dominant
+FROM lc_on_scope GROUP BY h8, h0;
+```
+
 ## 3. Case-insensitive text search
 
 DuckDB `LIKE` is case-sensitive by default. Name/label fields (site names, owner names,


### PR DESCRIPTION
Refs #83 (closed as dup of #81, but the general-audience piece still stands on its own).

## Summary

Adds one rule and a WRONG/RIGHT code pair to section 2 of `query-optimization.md`:

> **Aggregate after the join, never before.** Wrapping the large side of a join in a pre-aggregation CTE before the join forces DuckDB to scan every h0 partition of it — the small scope's h0 values cannot prune through an aggregation operator.

This is the `query`-tool-generic version of #81's Problem-2 callout. Lives here rather than in `h3-guide.md` because it applies to any mask-join through `query`, not just hex tile workflows. Kept deliberately compact: 22 lines of diff, no DPP-mechanism prose, no `EXPLAIN ANALYZE` verification steps.

## Test plan

- [ ] After merge, restart dev: `kubectl -n biodiversity rollout restart deployment/dev-duckdb-mcp`
- [ ] Re-run the land-cover-composition-of-protected-areas question (the one from #83's repro) on dev against the TPL app and confirm the pre-aggregation form is no longer produced, or if produced completes instead of timing out.
- [ ] Tag `v0.5.3` and bump prod `k8s/deployment.yaml` once dev validates.