### PR TITLE
k8s: bump prod to v0.5.3 (aggregate-after-join rule)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.5.2 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.5.3 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
Bumps prod deployment to v0.5.3, picking up the #83 aggregate-after-join rule added to query-optimization.md. Dev verified: rule present in injected context (13kB TOOL_INJECTED_CONTEXT).

After merge: `kubectl apply -f k8s/deployment.yaml && kubectl -n biodiversity rollout status deployment/duckdb-mcp`.