### PR TITLE
Mask-first raster aggregation: h3-guide.md callout + register_hex_tiles patterns (fixes #89)

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -142,6 +142,29 @@ GROUP BY h8, h0
 
 Check the dataset's STAC description — it will note when aggregation is required and which method (SUM, AVG, or MODE) to use.
 
+**If you plan to mask this result against another hex dataset:** put the
+`SEMI JOIN` on the raw `read_parquet(...)` *before* `GROUP BY`, not in a
+CTE after it. Aggregation blocks DuckDB's dynamic partition pruning, so a
+post-aggregation mask forces every h0 partition of the value dataset to
+be scanned — turning a small masked query into a global one.
+
+```sql
+-- ❌ Mask after aggregation → scans every h0 file
+WITH lc_agg AS (
+    SELECT h8, h0, MODE(lc_class) AS dominant
+    FROM read_parquet('<raster_hex>', hive_partitioning = true)
+    GROUP BY h8, h0
+)
+SELECT m.h8, l.dominant FROM mask m JOIN lc_agg l USING (h8, h0);
+
+-- ✅ Mask first → only matching h0 files scanned
+SELECT a.h8, MODE(a.lc_class) AS dominant
+FROM read_parquet('<raster_hex>', hive_partitioning = true) a
+SEMI JOIN mask m USING (h8, h0)
+WHERE a.lc_class IS NOT NULL
+GROUP BY a.h8;
+```
+
 ---
 
 ### Diagnostic: check rows-per-hex before writing queries

--- a/server.py
+++ b/server.py
@@ -255,6 +255,31 @@ def register_hex_tiles(
     MapLibre usage:
         map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
         map.addLayer({..., 'source-layer': layer_name, paint: {...}});
+
+    SQL patterns — pick the one matching the ask; paste exact paths from
+    get_stac_details. `<H>` is the H3 resolution, usually 8.
+
+    1. Density (count features per hex):
+
+       SELECT h<H> FROM read_parquet('<hex_path>') WHERE <filter>
+
+       Call agg="COUNT". Works for pre-indexed points (GBIF) or polygons
+       (PAD-US). For raw points with lat/lng:
+       `h3_latlng_to_cell(lat, lng, <H>) AS h<H>`.
+
+    2. Masked aggregate (value dataset inside a geographic mask):
+
+       SELECT a.h<H>, AVG(a.value) AS value         -- or MODE(class) / SUM / MAX
+       FROM read_parquet('<values_hex>', hive_partitioning = true) a
+       SEMI JOIN read_parquet('<mask_hex>', hive_partitioning = true) b
+                 USING (h<H>, h0)
+       WHERE a.value IS NOT NULL
+       GROUP BY a.h<H>;
+
+       Call agg="AVG" (or the matching op). The SEMI JOIN must sit on the
+       raw read_parquet(), upstream of GROUP BY — see h3-guide.md Problem 2.
+
+    Always pass hive_partitioning = true so the planner can prune h0=* files.
     """
     con = _get_tile_con()
     return _register_hex_tiles(


### PR DESCRIPTION
## Summary

- Adds a mask-first callout to `h3-guide.md` Problem 2, at the site of the raster-aggregation snippet the agent copies verbatim.
- Adds two SQL patterns (density / masked aggregate) to the `register_hex_tiles` docstring in `server.py`, keeping tile-specific guidance out of the per-query `h3-guide.md` injection.

Fixes #89. Follows #87's abstract rule in `query-optimization.md` with concrete, copy-site guidance — the 2026-04-19 prod land-cover run showed the abstract rule alone wasn't enough.

## Test plan

- [ ] After merge, rollout restart `dev-duckdb-mcp` and confirm new text appears in `tools/list` response.
- [ ] Re-run the Conservation Almanac land-cover prompt against dev; SQL should put `SEMI JOIN <mask> USING (h8, h0)` directly on a raw `read_parquet(...)` scan, not after a CTE.
- [ ] Bump prod tag (v0.5.4) in a follow-up PR.