### PR TITLE
k8s: bump prod to v0.5.4 (mask-first hex patterns)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.5.3 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.5.4 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
Ships #90 (fixes #89) to prod.

Dev already verified: the `tools/list` response now carries the mask-first Problem-2 callout and the `register_hex_tiles` SQL patterns block.