### PR TITLE
k8s: bump prod to v0.5.5 (h3-guide data model + tiling dedup)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.5.4 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.5.5 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
Bumps the prod deployment git clone branch from v0.5.4 to v0.5.5, picking up #93 (h3-guide data model section, _cng_fid tiling dedup, ST_Centroid ban).