### PR TITLE
AGENTS.md: document dev/prod rollout workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,29 @@
 
 ## Deployment
 
-The MCP server runs on the NRP Nautilus Kubernetes cluster at **`https://duckdb-mcp.nrp-nautilus.io`**.
+The MCP server runs on the NRP Nautilus Kubernetes cluster.
 
-- **2 replicas** of the `duckdb-mcp` pod, each cloning this repo at startup and running `server.py` via `uv`
+- **Prod:** `https://duckdb-mcp.nrp-nautilus.io` — 2 replicas, `k8s/deployment.yaml`
+- **Dev:** `https://dev-duckdb-mcp.nrp-nautilus.io` — 1 replica, `k8s/dev-deployment.yaml`
 - **Resources:** 16 Gi RAM requested, up to 160 Gi / 16 CPU per pod
 - **STAC catalog:** `https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json` (set via `STAC_CATALOG_URL` env var)
 - **Ingress:** HAProxy with CORS enabled, 10-minute query timeout, 1-hour SSE tunnel timeout
 
-To redeploy after pushing changes to `main`, restart the pods so they re-clone:
+### Rollout workflow
+
+**Merge to `main` → redeploy dev only:**
 ```
-kubectl rollout restart deployment/duckdb-mcp
+kubectl apply -f k8s/dev-deployment.yaml
+kubectl rollout restart deployment/dev-duckdb-mcp -n biodiversity
 ```
+
+**Tag a release → redeploy prod:**
+```
+kubectl apply -f k8s/deployment.yaml
+kubectl rollout restart deployment/duckdb-mcp -n biodiversity
+```
+
+`kubectl apply` must precede `rollout restart` — a git push alone does not update the cluster.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,14 @@
 > and prompts. Editing them changes what the agent is instructed to do.
 > `README.md` is the only human-facing documentation.
 
+## Contributing
+
+This repo uses **GitHub Flow**: all changes go through a branch + PR, never committed directly to `main`. `main` has branch protection enforced — direct pushes are rejected.
+
+1. Create a branch for your change
+2. Open a PR against `main`
+3. Merge via the GitHub UI (squash merge preferred)
+
 ## Deployment
 
 The MCP server runs on the NRP Nautilus Kubernetes cluster.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.5.4 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.5.5 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
## Summary

- Documents that merging to `main` redeploys **dev** only (`dev-duckdb-mcp`)
- Documents that tagging a release redeploys **prod** (`duckdb-mcp`)
- Adds the `kubectl apply` + `rollout restart` commands with correct deployment names and namespace
- Removes the stale instruction that implied a plain `main` push triggered a prod rollout