### PR TITLE
server: disable register_hex_tiles tool until ready for production

### DIFF
--- a/server.py
+++ b/server.py
@@ -288,7 +288,8 @@ def register_hex_tiles(
     )
 
 
-mcp.tool()(register_hex_tiles)
+# register_hex_tiles is not yet ready for production — see GitHub issue
+# mcp.tool()(register_hex_tiles)
 
 
 def mount_tiles(app):


### PR DESCRIPTION
Unregisters the `register_hex_tiles` MCP tool so agents no longer see or attempt to use it.

The underlying implementation in `tiles/pyramid.py` is unchanged. Only the `mcp.tool()` registration line is commented out.

Closes #96.

Cutting v0.5.6 after merge to trigger a prod rollout.