### PR TITLE
chore: ignore Claude Code and superpowers tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 .python-version
 .mcpregistry_*
 
+# Claude Code / superpowers tooling
+.claude/
+memory/
+docs/superpowers/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary

- Ignore `.claude/`, `memory/`, and `docs/superpowers/` — all Claude Code / superpowers local tooling artifacts that shouldn't be committed.

## Test plan

- [x] `git status` shows a clean tree with those directories present