### PR TITLE
stac: render H3 column descriptions inline (Fixes #110)

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -132,19 +132,14 @@ def _format_columns(table_cols: list) -> list[str]:
         c for c in table_cols
         if c.get("name", "").lower() not in ("geometry", "geom", "bbox")
     ]
-    h3_cols = [c for c in display_cols if c.get("name", "") in ("h0", "h8", "h9", "h10", "h11")]
-    other_cols = [c for c in display_cols if c not in h3_cols]
 
     lines = []
-    if other_cols:
-        for c in other_cols:
-            desc = f" — {c['description']}" if c.get("description") else ""
-            lines.append(f"    - `{c['name']}` ({c.get('type', '?')}){desc}")
-            values = c.get("values")
-            if values:
-                lines.append(f"      values: {list(values)}")
-    if h3_cols:
-        lines.append(f"    - H3 index columns: {', '.join(c['name'] for c in h3_cols)}")
+    for c in display_cols:
+        desc = f" — {c['description']}" if c.get("description") else ""
+        lines.append(f"    - `{c['name']}` ({c.get('type', '?')}){desc}")
+        values = c.get("values")
+        if values:
+            lines.append(f"      values: {list(values)}")
     return lines
 
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1176,15 +1176,26 @@ class TestFormatColumnsFullRender:
         for i in range(30):
             assert f"col_{i:02d}" in rendered, f"col_{i:02d} missing — renderer truncated"
 
-    def test_h3_columns_still_collapsed(self):
-        """H3 index columns collapse to one line regardless of how many non-H3 columns precede."""
+    def test_h3_columns_render_with_descriptions(self):
+        """H3 index columns render inline with name/type/description like other columns,
+        so models see the partition-key role of h0 instead of treating it as a small ordinal."""
         from stac import _format_columns
         cols = [{"name": f"col_{i:02d}", "type": "varchar"} for i in range(25)]
-        cols += [{"name": n, "type": "ubigint"} for n in ("h0", "h8", "h9", "h10")]
+        cols += [
+            {"name": "h0", "type": "ubigint",
+             "description": "H3 cell ID at resolution 0, used as the partition key for hive-partitioned reads."},
+            {"name": "h8", "type": "ubigint",
+             "description": "H3 cell ID at resolution 8."},
+            {"name": "h9", "type": "ubigint", "description": "H3 cell ID at resolution 9."},
+            {"name": "h10", "type": "ubigint", "description": "H3 cell ID at resolution 10."},
+        ]
         lines = _format_columns(cols)
         rendered = "\n".join(lines)
-        assert "H3 index columns" in rendered
-        assert "h0" in rendered and "h8" in rendered and "h9" in rendered and "h10" in rendered
+        assert "H3 index columns:" not in rendered, "H3 columns must not be collapsed to a name-only line"
+        assert "`h0` (ubigint) — H3 cell ID at resolution 0" in rendered
+        assert "`h8` (ubigint) — H3 cell ID at resolution 8" in rendered
+        assert "`h9` (ubigint) — H3 cell ID at resolution 9" in rendered
+        assert "`h10` (ubigint) — H3 cell ID at resolution 10" in rendered
 
     def test_categorical_values_rendered(self):
         """Columns with a `values` array have those values included in output."""


### PR DESCRIPTION
## Summary

- Drop the H3 special case in `_format_columns` so `h0`/`h8`/`h9`/`h10`/`h11` render with the same `name (type) — description` shape as every other column.
- Replace `test_h3_columns_still_collapsed` with `test_h3_columns_render_with_descriptions`, which pins the new behavior.

## Why

`get_stac_details` / `get_schema` was throwing away the per-column descriptions that the source STAC carries for H3 columns (168/168 hex-bearing collections in the public catalog have them populated). The collapse was an intentional token-saving choice, but it has a measurable correctness cost: without the description, models read `h0` as a small ordinal (0..15) rather than the 64-bit cell ID + hive partition key it is.

Concrete repro on padus q2 (*"What's the average irrecoverable carbon in California's GAP 1+2 protected lands?"*): nemotron-marlin took 12 tool calls / 693s and concluded the dataset was broken (returning NaN for `WHERE h0 = 0`), then fell back to v1 and reported 155 MgC/hex instead of the correct 71.5 MgC/hex from v2-2024. qwen3 with the same prompt took 3 calls / 277s.

Cost of un-collapsing: ~80–150 tokens per hex collection in `get_schema` output — under 1% of a typical system prompt budget, and much cheaper than a 12-call loop.

## Test plan

- [x] `pytest tests/test_stac.py` — 79 passed
- [x] full suite — 166 passed
- [ ] After merge: dev rollout, then sanity-check `get_stac_details(dataset_id="pad-us-4.1-fee")` shows H3 columns inline with their descriptions

## Notes

A separate, related issue exists in `data-workflows`: some STAC collections have wrong area numbers in their H3 column descriptions (e.g. PAD-US says h10 ≈ 0.13 acres when it's 3.7). Fixing the formatter without fixing the data will surface those wrong numbers to models — worth tracking down and correcting around the same time, but out of scope for this PR.