### PR TITLE
README: document how to verify a production rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,17 +174,19 @@ The deployment:
 - Uses `uv` for fast dependency installation
 - Includes readiness probes for safe rollouts
 
-### Verifying a production rollout
+### Releases and production rollouts
 
-The pod image is just a runtime base; the actual application source is `git clone`d at pod startup from a tag pinned in `k8s/deployment.yaml` (`git clone --branch vX.Y.Z ...`). To confirm prod is running the latest tagged release, compare the cluster's pinned tag against the latest git tag (not `gh release`, which can lag), then confirm pods have been recreated since the bump commit:
+The pod image is just a runtime base; the actual application source is `git clone`d at pod startup from a tag pinned in `k8s/deployment.yaml` (`git clone --branch vX.Y.Z ...`). The convention is **every tag is a GitHub Release** — when you cut a new version, push the tag *and* publish a release with notes (`gh release create vX.Y.Z --title "..." --notes "..."`). The latest GitHub Release is the source of truth for "what should be running in prod."
+
+To confirm prod is on the latest release:
 
 ```bash
 # Tag the cluster is configured to clone:
 kubectl -n biodiversity get deploy duckdb-mcp \
   -o jsonpath='{.spec.template.spec.containers[0].args}' | grep -oP 'branch \K[^ ]+'
 
-# Latest tag in the repo:
-git fetch --tags && git tag --sort=-version:refname | head -1
+# Latest published release:
+gh release view -R boettiger-lab/mcp-data-server --json tagName -q .tagName
 
 # Pod ages — must be newer than the k8s/deployment.yaml bump commit:
 kubectl -n biodiversity get pods -l app=duckdb-mcp \

--- a/README.md
+++ b/README.md
@@ -174,6 +174,25 @@ The deployment:
 - Uses `uv` for fast dependency installation
 - Includes readiness probes for safe rollouts
 
+### Verifying a production rollout
+
+The pod image is just a runtime base; the actual application source is `git clone`d at pod startup from a tag pinned in `k8s/deployment.yaml` (`git clone --branch vX.Y.Z ...`). To confirm prod is running the latest tagged release, compare the cluster's pinned tag against the latest git tag (not `gh release`, which can lag), then confirm pods have been recreated since the bump commit:
+
+```bash
+# Tag the cluster is configured to clone:
+kubectl -n biodiversity get deploy duckdb-mcp \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' | grep -oP 'branch \K[^ ]+'
+
+# Latest tag in the repo:
+git fetch --tags && git tag --sort=-version:refname | head -1
+
+# Pod ages — must be newer than the k8s/deployment.yaml bump commit:
+kubectl -n biodiversity get pods -l app=duckdb-mcp \
+  -o custom-columns=NAME:.metadata.name,CREATED:.metadata.creationTimestamp
+```
+
+If the first two commands print the same tag and the pods are newer than the bump commit, prod is current.
+
 ## MCP Protocol Features
 
 ### Tools


### PR DESCRIPTION
## Summary

Adds a short "Releases and production rollouts" subsection to the Kubernetes Deployment section of the README, documenting (1) the convention that every tag is a GitHub Release, and (2) the three commands to confirm prod is on the latest release.

## Why

The pod image (`ghcr.io/boettiger-lab/mcp-data-server:latest`) is a runtime base only — the actual application source is `git clone`d at pod startup from a tag pinned in `k8s/deployment.yaml` (`git clone --branch vX.Y.Z ...`). That makes the obvious checks (image tag, image digest) misleading: prod can be on any source version while the image stays `:latest`. The right comparison is the deployment's pinned branch arg vs. the latest GitHub Release.

GitHub Releases had been allowed to lag (latest was v0.5.1 while tags ran up to v0.5.7). The missing releases (v0.5.2–v0.5.7) have now been backfilled with titles and notes, so `gh release view` is once again the authoritative answer to "what should prod be running." This PR also captures the convention in writing so future cuts publish a release alongside the tag.

## Test plan

- [x] Backfilled releases v0.5.2 through v0.5.7 with titles + notes.
- [x] `gh release view -R boettiger-lab/mcp-data-server --json tagName -q .tagName` now returns `v0.5.7`.
- [x] Ran the documented commands against current prod — confirmed prod is on v0.5.7 (matches latest release) with pods recreated 2026-04-30 after the bump commit.
- [ ] Reviewer: read the new subsection, confirm the commands are copy-pasteable.
