### PR TITLE
query-optimization: warn against DESCRIBE+LIKE schema discovery

### DIFF
--- a/query-optimization.md
+++ b/query-optimization.md
@@ -62,7 +62,22 @@ SELECT h8, h0, MODE(lc_class) AS dominant
 FROM lc_on_scope GROUP BY h8, h0;
 ```
 
-## 3. Case-insensitive text search
+## 3. Trust your schema — don't grep with DESCRIBE+LIKE
+
+For datasets already loaded in your app, the column list returned by `get_schema`
+(or `get_stac_details`) is canonical: every column, with type and description.
+Running follow-up queries like
+
+```sql
+SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet('…') LIMIT 1)
+WHERE column_name LIKE '%corridor%'
+```
+
+to grep for specific columns is wasteful — the same data is already in your
+context. Search the existing schema response instead. `DESCRIBE` is appropriate
+only for arbitrary parquet files not represented in any STAC collection.
+
+## 4. Case-insensitive text search
 
 DuckDB `LIKE` is case-sensitive by default. Name/label fields (site names, owner names,
 program names) are often stored in uppercase or mixed case. Always normalize both sides:
@@ -71,14 +86,14 @@ program names) are often stored in uppercase or mixed case. Always normalize bot
 WHERE lower(site) LIKE '%' || lower('user input') || '%'
 ```
 
-## 4. GeoParquet geometry columns
+## 5. GeoParquet geometry columns
 
 GeoParquet files contain a geometry column (usually `geom`) typed as `GEOMETRY('OGC:CRS84')`.
 This type cannot be displayed in tabular output — the server drops it automatically.
 Avoid `SELECT *` on GeoParquet files; select only the columns you need. If you need
 coordinates, cast explicitly: `ST_AsText(geom) AS geom_wkt`.
 
-## 5. Apostrophes in string literals
+## 6. Apostrophes in string literals
 
 Site names and owner names can contain apostrophes (e.g. `O'Brien Ranch`). Double any
 single quote inside a SQL string literal — do not use a backslash:


### PR DESCRIPTION
## Summary
- Adds a new section 3 to `query-optimization.md` telling agents to trust the schema already returned by `get_schema` / `get_stac_details` instead of running DESCRIBE+LIKE follow-up queries to grep for column names.
- Renumbers existing sections 3–5 → 4–6.

Motivated by a 2026-04-30 trace where qwen3 burned 16 turns instead of 3 doing exactly this on a 155-column dataset whose schema was already in its context.

`query-optimization.md` is injected into the `query` tool docstring, so the reminder appears next to every `query` invocation — exactly where the temptation to grep arises. Reaches every app at once.

The geo-agent system prompt already says "you don't need to call `get_schema` again for follow-up queries" — qwen3 ignored that. This is a complementary nudge at the SQL layer.

Fixes #108.

## Test plan
- [x] Doc-only change; no tests
- [ ] After merge, look for `DESCRIBE` in proxy logs scoped to known-affected apps to confirm the pattern decreases (per verification SQL in #108)