### PR TITLE
h3-guide: cross-collection dedup key for flat+hex+hex joins

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -139,6 +139,32 @@ SELECT SUM(amount) FROM (
 
 `_cng_fid` is the universal feature ID on all CNG-processed vector hex datasets. Some datasets also carry a source-specific ID (e.g. `tpl_id`, `GEOID`) for cross-collection joins — check `get_schema`.
 
+**Cross-collection case: flat table joined to a hex table for spatial assignment**
+
+When the aggregate value lives in a flat (non-hex) table, joining it to a hex table replicates it across N hex rows. Apply the same principle — deduplicate by feature ID — but the `DISTINCT` must be on `(feature_id, geography_id)`, not on hex coordinates:
+
+```sql
+-- ❌ WRONG: DISTINCT on hex coords doesn't help — they're already unique per row
+tx_sites_hex AS (
+  SELECT DISTINCT s.h10, s.h0, f.total_federal   -- still N rows per tpl_id
+  FROM flat_funding f
+  JOIN read_parquet('<sites_hex>') s USING (tpl_id)
+)
+
+-- ✅ CORRECT: DISTINCT on (feature_id, geography_id) gives one row per assignment
+site_district AS (
+  SELECT DISTINCT s.tpl_id, c.GEOID
+  FROM read_parquet('<sites_hex>') s
+  JOIN read_parquet('<cd_hex>') c ON s.h10 = c.h10 AND s.h0 = c.h0
+)
+SELECT sd.GEOID, SUM(f.total_federal) AS total
+FROM site_district sd
+JOIN flat_funding f USING (tpl_id)
+GROUP BY sd.GEOID
+```
+
+The flat table is joined **last**, after the spatial assignment is deduplicated.
+
 ---
 
 ### Problem 2 — Overlapping polygons (vector datasets)


### PR DESCRIPTION
## Summary
- Adds a "Cross-collection case" subsection inside Problem 1 of `h3-guide.md`.
- Shows the correct `DISTINCT (feature_id, geography_id)` pattern when a flat attribute table is joined to a hex table for spatial assignment, then aggregated by geography.
- Existing Problem 1 only covered single-hex-table dedup; the cross-collection case has a different correct key.

Motivated by a 2026-04-22 prod failure on the TPL app: the agent applied `DISTINCT` to hex coordinates instead of `(tpl_id, GEOID)` and reported **$32.6B** for one Texas congressional district — roughly 1000× the truth ($29.5M).

## Relationship to data-workflows#131

Upstream `data-workflows#131` proposes splitting vector hex tables into pure tiling + flat attribute tables, which would eliminate this failure class structurally. That issue is still open with no work started, and explicitly says "Keep the h3-guide unchanged for now" while tracking #98 as the short-term doc fix. If #131 ships, the h3-guide gets a broader rewrite anyway — this PR is not in conflict with it.

Fixes #98.

## Test plan
- [x] Doc-only change; no tests
- [ ] After merge + prod rollout, re-run the TPL session ("Texas congressional district funding totals") and confirm the agent uses a `(tpl_id, GEOID)` dedup on first attempt rather than DISTINCT on hex coordinates.