### PR TITLE
tiles: change default zoom_offset from 4 to 1

### DIFF
--- a/server.py
+++ b/server.py
@@ -246,7 +246,7 @@ def register_hex_tiles(
     finest_res: int,
     min_res: int = 2,
     agg: str = "AVG",
-    zoom_offset: int = 4,
+    zoom_offset: int = 1,
 ) -> dict:
     """Materialize a partitioned H3 hex pyramid to public object storage and return
     a MapLibre-compatible vector tile URL template.

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -105,7 +105,7 @@ def register_hex_tiles(
     finest_res: int,
     min_res: int = 2,
     agg: str = "AVG",
-    zoom_offset: int = 4,
+    zoom_offset: int = 1,
 ) -> dict:
     """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
 

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -14,7 +14,7 @@ def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, flo
     return (west, lat_s, east, lat_n)
 
 
-def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 4) -> int:
+def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 1) -> int:
     """Clamp(z - zoom_offset, min_res, finest_res) — coarser hexes at lower zooms."""
     target = z - zoom_offset
     return max(min_res, min(finest_res, target))


### PR DESCRIPTION
## Summary

- `zoom_offset=4` mapped zoom $z$ to H3 resolution $z-4$, then clamped to `[min_res, finest_res]`. For typical tilesets (min_res=2..5, finest_res=8) this left `target_res` pinned at `min_res` across the entire low-to-mid zoom range — zooming from z=4 to z=8 returned the **same** hexes, just sliced across more tiles, with no finer detail until z ≥ min_res+4.
- `zoom_offset=1` lets `target_res` advance with zoom across the pyramid's full resolution range, giving visibly finer hexes at each zoom step.
- Defaults only — existing tilesets carry their own `zoom_offset` in `metadata.json`, so this affects **future registrations** only.

## Visual evidence of the bug (existing tilesets, zoom_offset=4)

At z=8 over California the carbon AVG tileset (min_res=5, finest_res=8) still serves res-5 hexes (~14 px edge), even though res 6 or 7 would be appropriate at that zoom. The same hex grid persists from z=4 through z=9, just split across more tiles.

## Test plan

- [x] `pytest tests/test_tile_math.py tests/test_tile_pyramid.py tests/test_tile_endpoint.py` — 43 pass
- [ ] After merge: roll out dev, re-register one tileset with the new default, view in MapLibre to confirm hexes get finer as zoom increases