### PR TITLE
server: re-enable register_hex_tiles MCP tool

### DIFF
--- a/server.py
+++ b/server.py
@@ -311,8 +311,7 @@ def register_hex_tiles(
     )
 
 
-# register_hex_tiles is not yet ready for production — see GitHub issue
-# mcp.tool()(register_hex_tiles)
+mcp.tool()(register_hex_tiles)
 
 
 def mount_tiles(app):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -273,12 +273,12 @@ class TestTileRouteMounted:
         paths = [getattr(r, "path", None) or getattr(r, "path_format", None) for r in app.routes]
         assert any(p and "/tiles/" in p for p in paths)
 
-    def test_register_hex_tiles_is_disabled(self):
-        """register_hex_tiles is intentionally not exposed until ready for production (#97)."""
+    def test_register_hex_tiles_is_exposed(self):
+        """register_hex_tiles is exposed as an MCP tool."""
         from server import mcp
         import anyio
         tool_names = [t.name for t in anyio.run(mcp.list_tools)]
-        assert "register_hex_tiles" not in tool_names
+        assert "register_hex_tiles" in tool_names
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Re-enables `mcp.tool()(register_hex_tiles)` (disabled in #97 pending the visible-detail issue).
- With `zoom_offset=1` default in #118, the resolution problem is addressed; re-enabling so the tool can be exercised on dev to confirm before the next prod tag.
- Inverts `test_register_hex_tiles_is_disabled` → `test_register_hex_tiles_is_exposed`.

Prod will not pick this up until a release tag is cut; dev rolls out post-merge.

## Test plan

- [x] `pytest tests/test_server.py tests/test_tile_endpoint.py tests/test_tile_pyramid.py tests/test_tile_math.py` — 73 pass
- [ ] After merge + dev rollout: call `register_hex_tiles` on dev against a real dataset, then view tiles in MapLibre to confirm visible-detail fix