### PR TITLE
tiles: lower default zoom_offset from 1 to -1

### DIFF
--- a/server.py
+++ b/server.py
@@ -246,7 +246,7 @@ def register_hex_tiles(
     finest_res: int,
     min_res: int = 2,
     agg: str = "AVG",
-    zoom_offset: int = 1,
+    zoom_offset: int = -1,
 ) -> dict:
     """Materialize a partitioned H3 hex pyramid to public object storage and return
     a MapLibre-compatible vector tile URL template.

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -105,7 +105,7 @@ def register_hex_tiles(
     finest_res: int,
     min_res: int = 2,
     agg: str = "AVG",
-    zoom_offset: int = 1,
+    zoom_offset: int = -1,
 ) -> dict:
     """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
 

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -14,7 +14,7 @@ def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, flo
     return (west, lat_s, east, lat_n)
 
 
-def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 1) -> int:
+def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = -1) -> int:
     """Clamp(z - zoom_offset, min_res, finest_res) — coarser hexes at lower zooms."""
     target = z - zoom_offset
     return max(min_res, min(finest_res, target))


### PR DESCRIPTION
## Summary

- Follows #118. With `zoom_offset=1`, mid-zoom views still rendered hexes at ~2 px edge (e.g. z=8 → res 7, edge ~1.2 km, m/px ≈ 611 → ~2 px). Empirically users want denser visible detail.
- `zoom_offset=-1` maps z → z+1, so at z=8 target_res=9 (~0.5 km edge ≈ 0.8 px at z=8). Tiny at mid-zoom but detail kicks in quickly when zooming further.
- Tradeoff: pyramid runs out sooner at high zoom. Tilesets that need fine detail at z=10+ should register with a higher `finest_res` (10–11).

Defaults only; per-tileset `zoom_offset` is stored in metadata.json.

## Test plan

- [x] `pytest tests/test_tile_math.py tests/test_tile_pyramid.py tests/test_tile_endpoint.py tests/test_server.py` — 73 pass
- [ ] After merge + dev rollout: re-register the CA test tileset, view in MapLibre to confirm "way more hexes" per tile