### PR TITLE
k8s: bring dev resource limits and node affinity to prod parity

### DIFF
--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -13,6 +13,14 @@ spec:
       labels:
         app: dev-duckdb-mcp
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values: ["us-west"]
       containers:
       - name: server
         image: ghcr.io/boettiger-lab/mcp-data-server:latest
@@ -28,12 +36,15 @@ spec:
         - name: MCP_PUBLIC_BASE_URL
           value: "https://dev-duckdb-mcp.nrp-nautilus.io"
         resources:
+          # Requests intentionally kept small (≤2 GiB memory, ≤1 CPU) to land in
+          # NRP's "Ignored" bucket for utilization violations. Limits stay high so
+          # legitimate large queries (~100 GiB memory, multi-CPU) can still burst.
           requests:
             memory: 2Gi
             cpu: 250m
           limits:
-            memory: 32Gi
-            cpu: 4
+            memory: 160Gi
+            cpu: 16
         ports:
         - containerPort: 8000
         readinessProbe:


### PR DESCRIPTION
## Summary

Dev was capped at 32 Gi memory / 4 CPU vs prod's 160 Gi / 16 CPU. A heavy query on dev (e.g. a tile request against a dense res-10 pyramid) could push the pod past its limit and OOM-kill it, taking unrelated sessions down with it.

Also adds the us-west node affinity so dev sits near the \`public-data\` S3 buckets — same latency profile as prod.

Replicas remain at 1; dev is single-instance by design. Requests already matched prod (2 Gi / 250m), only limits and affinity changed.

## Test plan

- [x] \`diff k8s/deployment.yaml k8s/dev-deployment.yaml\` shows only the expected differences (name, replicas, branch tag, public URL)
- [ ] After merge: \`kubectl apply -f k8s/dev-deployment.yaml\` + rollout restart; verify pod schedules on a us-west node and tile requests still succeed