### PR TITLE
tiles: cap THREADS at 16, bump dev CPU limit to 64

### DIFF
--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             cpu: 250m
           limits:
             memory: 160Gi
-            cpu: 16
+            cpu: 64
         ports:
         - containerPort: 8000
         readinessProbe:

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -19,8 +19,11 @@ def build_tile_connection() -> duckdb.DuckDBPyConnection:
     con.sql("INSTALL spatial; LOAD spatial")
     con.sql("INSTALL h3 FROM community; LOAD h3")
 
-    # Performance tuning — match the query tool settings.
-    con.sql("SET THREADS=100")
+    # Cap per-query parallelism so several concurrent tile requests can run side
+    # by side instead of one query monopolizing the pod. With CPU limit 64 and
+    # THREADS=16, ~4 concurrent tile queries saturate cleanly; pyramid builds
+    # (which share this connection) are bandwidth-bound on S3 anyway.
+    con.sql("SET THREADS=16")
     con.sql("SET preserve_insertion_order=false")
     con.sql("SET enable_object_cache=true")
     con.sql("SET temp_directory='/tmp'")


### PR DESCRIPTION
## Summary

Two coordinated knobs for tile-endpoint smoothness under bursty browser loads:

1. **\`tiles/db.py\`**: \`SET THREADS=100\` → \`SET THREADS=16\` on the persistent tile connection. 100 was wildly over-subscribed for a 16-CPU pod; one tile query asked for more workers than the kernel could schedule and concurrent tile requests fought for CPU. Capping at 16 means ~4 concurrent tile queries saturate a 64-core ceiling cleanly. Tile-only — the \`query\` tool uses fresh per-request connections and is untouched. Separate from the DNS-exhaustion ceiling in #103 (which is about the query path's HTTP fan-out, not tile rendering).
2. **\`k8s/dev-deployment.yaml\`**: CPU limit 16 → 64. CPU is compressible, and most us-west nodes have 48–128 cores at 0–30 % utilization. Requests stay at 250m so the pod still lands in NRP's "ignored" bucket.

Prod manifest unchanged; promote via release tag once verified.

## Test plan

- [x] \`pytest tests/test_tile_endpoint.py tests/test_tile_pyramid.py tests/test_tile_math.py tests/test_server.py\` — 73 pass
- [ ] After merge + dev rollout: pan/zoom over the GBIF CA tileset and confirm the pod no longer pegs at its CPU limit; verify deep-zoom tiles still return in single-digit seconds under concurrent load