### PR TITLE
pyramid: GROUP BY at finest level for COUNT mode

### DIFF
--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -85,25 +85,22 @@ class TestBuildPyramidSQL:
             value_columns=["count"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        # Parents: COUNT(*) AS count at every parent level.
+        # COUNT(*) AS count at every level — parents and finest.
         assert "COUNT(*) AS count" in sql
-        # Finest: literal 1 AS count (no aggregation at finest level).
-        assert "1 AS count" in sql
         # No stray references to user value columns (there are none).
         assert 'AVG(' not in sql and 'SUM(' not in sql
 
-    def test_count_mode_finest_level_has_literal_one(self):
+    def test_count_mode_finest_level_aggregates(self):
         sql = build_pyramid_sql(
             user_sql="SELECT h8 FROM src",
             finest_res=5, min_res=2, agg="COUNT",
             value_columns=["count"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        # Finest-level SELECT is identifiable by the "5 AS res" literal.
-        finest_select = re.search(r"SELECT[^)]*?5 AS res FROM src", sql, re.DOTALL)
-        assert finest_select is not None
-        assert "1 AS count" in finest_select.group(0)
-        assert "COUNT(*)" not in finest_select.group(0)
+        # COUNT mode must GROUP BY at finest too so duplicate source rows
+        # collapse to one row per cell with the real count. The finest
+        # SELECT uses the bare h3_column (not h3_cell_to_parent) and "5 AS res".
+        assert 'SELECT "h8" AS h, COUNT(*) AS count, 5 AS res FROM src GROUP BY 1' in sql
 
 
 import os
@@ -265,11 +262,11 @@ class TestRegisterHexTiles:
         by_res = stats["count"]["by_res"]
         # Resolutions 3, 4, 5 all present (string keys).
         assert set(by_res.keys()) == {"3", "4", "5"}
-        # Finest-res parquet carries `1 AS count` per row; MIN/MAX collapse to 1.
+        # Finest-res parquet aggregates via COUNT(*); the three clustered
+        # points share the same h5 cell, so max is 3 there too.
         assert by_res["5"]["min"] == 1
-        assert by_res["5"]["max"] == 1
-        # Coarser resolutions aggregate via COUNT(*); at least one parent cell
-        # contains 3 of the clustered points at res=4.
+        assert by_res["5"]["max"] == 3
+        # Coarser resolutions aggregate further; the same cluster at res=4.
         assert by_res["4"]["max"] >= 3
         # Coarser levels can only aggregate further — max is non-decreasing.
         assert by_res["3"]["max"] >= by_res["4"]["max"]

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -57,9 +57,20 @@ def build_pyramid_sql(
             f"  SELECT h3_cell_to_parent({qh}, {res}) AS h, "
             f"{parent_values}, {res} AS res FROM src GROUP BY 1"
         )
-    selects.append(
-        f"  SELECT {qh} AS h, {finest_values}, {finest_res} AS res FROM src"
-    )
+    if agg_upper == "COUNT":
+        # Aggregate at finest too — otherwise raw rows pass through and a cell
+        # with N occurrences becomes N MVT features. Tiles balloon (e.g., 126M
+        # rows for 2.3M unique cells on GBIF CA → 54× duplication).
+        selects.append(
+            f"  SELECT {qh} AS h, COUNT(*) AS count, "
+            f"{finest_res} AS res FROM src GROUP BY 1"
+        )
+    else:
+        # Non-COUNT aggs preserve raw per-row values at finest by design — the
+        # caller may have pre-aggregated upstream, or want per-row visibility.
+        selects.append(
+            f"  SELECT {qh} AS h, {finest_values}, {finest_res} AS res FROM src"
+        )
 
     body = "\n  UNION ALL\n".join(selects)
 


### PR DESCRIPTION
## Summary

Parent levels grouped by \`h3_cell_to_parent(...)\` with \`COUNT(*)\`; finest level did **not** group and emitted \`1 AS count\` per source row. For data with many occurrences per cell (e.g. GBIF, where one h10 cell holds dozens of observations) this stored one row per occurrence at finest_res, not one per cell — and the served tile then carried that many MVT features per cell.

**Concrete case:** GBIF CA registration. 126M source rows → 126M rows in res=10 partition for **2.3M unique cells (54× duplication)**. An SF z=10 tile pulled ~600k rows for ~11k actual cells, ballooning the MVT to **150 MB**.

**Fix:** at finest for COUNT mode, \`COUNT(*) AS count ... GROUP BY 1\`. After fix, finest holds one row per cell with the real count, tiles shrink ~50× over dense data, and the per-cell \`count\` property becomes a real density signal (previously always 1 at finest, which made paint-by-count useless at the deepest zoom).

Non-COUNT aggs (AVG/SUM/MIN/MAX) intentionally keep raw per-row values at finest — callers may have pre-aggregated upstream — unchanged here.

## Test plan

- [x] \`pytest tests/test_tile_pyramid.py tests/test_tile_endpoint.py tests/test_tile_math.py tests/test_server.py\` — 73 pass
- [ ] After merge + dev rollout: re-register GBIF CA tileset, verify res=10 partition row count ≈ unique-cell count, and confirm SF z=10 tile size drops from 150 MB to single-digit MB