### PR TITLE
server: hide pyramid infrastructure knobs from the LLM tool surface

### DIFF
--- a/server.py
+++ b/server.py
@@ -241,11 +241,21 @@ def _get_tile_con():
     return _tile_con
 
 
+# Deliberate API design: only `sql` and `agg` are documented for the LLM.
+# `finest_res`, `min_res`, `zoom_offset` are kept in the Python signature as
+# optional kwargs for tests / REPL overrides, but NOT mentioned in the
+# docstring — the MCP framework derives the LLM-facing tool schema from the
+# docstring, so they stay invisible to the agent. Auto-detection (in
+# tiles.pyramid.register_hex_tiles) reads the H column's resolution to set
+# finest_res; min_res=2 and zoom_offset=-1 are the only sensible values for
+# the current tile rendering. Adding `finest_res` etc. to the docstring is
+# almost certainly a mistake — see #125 for the trigger-tightening rationale
+# and the surrounding discussion about parameter surface.
 def register_hex_tiles(
     sql: str,
-    finest_res: int,
+    agg: str = "COUNT",
+    finest_res: int | None = None,
     min_res: int = 2,
-    agg: str = "AVG",
     zoom_offset: int = -1,
 ) -> dict:
     """Materialize a partitioned H3 hex pyramid to public object storage and return
@@ -277,14 +287,17 @@ def register_hex_tiles(
     If the user's intent is ambiguous, do NOT silently create a hex tileset.
     Ask whether they want a density / heatmap visualization first.
 
-    Input SQL contract:
-    - First column must be an H3 index at resolution `finest_res`.
-    - For agg="COUNT": no other columns required. Output has a single `count`
-      column (row count per hex). If the user SQL returns extra columns, they
-      are ignored.
-    - For agg in {AVG, SUM, MIN, MAX}: at least one numeric value column must
-      follow the H3 index. Each is aggregated by `agg` at each coarser
-      resolution down to `min_res`.
+    Parameters:
+    - `sql`: a SELECT whose first column is an H3 index. The tool reads that
+      column's H3 resolution and uses it as the pyramid's finest level. To get
+      a coarser tileset, project upstream in the SQL (e.g.
+      `SELECT h3_cell_to_parent(h10, 6) AS h6, ...`).
+    - `agg`: aggregation applied at each coarser pyramid level.
+        - "COUNT" (default): SQL needs only the H3 column; output property
+          is `count` (row count per hex).
+        - "AVG" / "SUM" / "MIN" / "MAX": SQL must return at least one
+          numeric value column after the H3 index; each is aggregated by
+          `agg` at every coarser level.
 
     Returns a dict with:
     - `tile_url_template`: MapLibre vector tile URL with {z}/{x}/{y} placeholders.
@@ -294,8 +307,7 @@ def register_hex_tiles(
     - `value_stats`: {<col>: {"by_res": {"<res>": {"min": <num>, "max": <num>}}}}.
       Per-resolution min/max for each value column — pass to the map client.
     - `layer_name`: the MVT source-layer name; use as `source-layer` in the client.
-    - `hash`, `bounds`, `finest_res`, `min_res`, `zoom_offset`, `feature_count_finest`:
-      tileset metadata.
+    - `hash`, `bounds`, `finest_res`, `feature_count_finest`: tileset metadata.
 
     MapLibre usage:
         map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
@@ -328,8 +340,8 @@ def register_hex_tiles(
     """
     con = _get_tile_con()
     return _register_hex_tiles(
-        con=con, sql=sql, finest_res=finest_res, min_res=min_res,
-        agg=agg, zoom_offset=zoom_offset,
+        con=con, sql=sql, agg=agg,
+        finest_res=finest_res, min_res=min_res, zoom_offset=zoom_offset,
     )
 
 

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -173,6 +173,26 @@ class TestRegisterHexTiles:
             assert partition.exists(), f"Missing res={res}"
             assert any(partition.iterdir()), f"Empty res={res}"
 
+    def test_auto_detects_finest_res_from_h3_column(self, local_bucket, h3_conn):
+        # No finest_res passed — should be detected via h3_get_resolution
+        # on the H3 column. h3_latlng_to_cell at res 6 → finest_res=6.
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 6) AS h6, 1.0 AS val"
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, min_res=3, agg="AVG", zoom_offset=-1,
+        )
+        assert result["finest_res"] == 6
+
+    def test_auto_detect_raises_on_empty_sql(self, local_bucket, h3_conn):
+        # SQL filters to zero rows — auto-detect can't sample a cell.
+        user_sql = (
+            "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val "
+            "WHERE 1 = 0"
+        )
+        with pytest.raises(ValueError, match="auto-detect"):
+            register_hex_tiles(
+                con=h3_conn, sql=user_sql, min_res=2, agg="COUNT",
+            )
+
     def test_tile_url_template_uses_public_base(self, local_bucket, h3_conn):
         user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
         result = register_hex_tiles(

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -113,7 +113,7 @@ def _inspect_user_sql(con: duckdb.DuckDBPyConnection, user_sql: str):
 def register_hex_tiles(
     con: duckdb.DuckDBPyConnection,
     sql: str,
-    finest_res: int,
+    finest_res: int | None = None,
     min_res: int = 2,
     agg: str = "AVG",
     zoom_offset: int = -1,
@@ -121,6 +121,11 @@ def register_hex_tiles(
     """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
 
     The connection must have httpfs, spatial, and h3 extensions loaded.
+
+    When finest_res is None (the LLM-facing path), it's auto-detected from the
+    H3 column's actual resolution via h3_get_resolution on a one-row probe.
+    Pass an explicit finest_res only from test / REPL code where you need to
+    force a specific value.
 
     Value-column contract:
     - agg="COUNT": user SQL needs only the H3 index column. Output has a single
@@ -130,10 +135,24 @@ def register_hex_tiles(
       index. Each is aggregated via `agg` at parent resolutions and passed
       through raw at the finest level.
     """
+    h3_column, sql_value_columns = _inspect_user_sql(con, sql)
+    if finest_res is None:
+        # Read one cell from the user SQL and ask H3 what its resolution is.
+        # Avoids forcing the LLM to invent a finest_res — the data already knows.
+        probe = con.sql(
+            f'SELECT h3_get_resolution("{h3_column}") FROM ({sql}) LIMIT 1'
+        ).fetchone()
+        if probe is None or probe[0] is None:
+            raise ValueError(
+                "Cannot auto-detect finest_res: user SQL returned no rows, or "
+                f"the first column ({h3_column!r}) is not an H3 cell. Narrow "
+                "the SQL until it returns at least one row whose first column "
+                "is an H3 index."
+            )
+        finest_res = int(probe[0])
     if finest_res < min_res:
         raise ValueError(f"finest_res ({finest_res}) must be >= min_res ({min_res})")
 
-    h3_column, sql_value_columns = _inspect_user_sql(con, sql)
     agg_upper = agg.upper()
     if agg_upper == "COUNT":
         value_columns = ["count"]


### PR DESCRIPTION
## Summary

\`register_hex_tiles\` previously required the LLM to choose \`finest_res\` and nudged it toward picking \`min_res\` / \`zoom_offset\` — three "infrastructure" parameters the model has no basis to reason about. In testing, the agent picked \`finest_res\` essentially at random, which created tilesets that wouldn't zoom-in usefully and surfaced bad UX downstream (see boettiger-lab/geo-agent#170 discussion).

Two coordinated changes:

1. **\`tiles/pyramid.py\`** — \`finest_res\` becomes optional (default \`None\`) and is auto-detected via \`h3_get_resolution\` on a one-row probe of the user SQL's first column. The data already knows its H3 resolution; the LLM shouldn't have to guess. Explicit values still accepted for tests / REPL overrides.

2. **\`server.py\`** — the MCP wrapper now documents only \`sql\` and \`agg\`. \`finest_res\`, \`min_res\`, \`zoom_offset\` remain in the Python signature (so tests and REPL callers can override) but are deliberately **absent from the docstring** — the MCP framework derives the LLM-facing schema from it, so they stay invisible to the agent. An explanatory comment above the wrapper notes this is intentional, not an oversight. \`agg\` default switched from \`"AVG"\` to \`"COUNT"\` — the most common case (density visualization).

To register a tileset at a coarser resolution than the data supports, project upstream in the SQL: \`SELECT h3_cell_to_parent(h10, 6) AS h6\`. The detector then sees \`h6\` and registers at \`h6\`. No need for a \`finest_res\` override.

## Behavior change recap (LLM-facing)

Before:
\`\`\`
register_hex_tiles(sql, finest_res, min_res=2, agg="AVG", zoom_offset=-1)
\`\`\`

After (LLM sees):
\`\`\`
register_hex_tiles(sql, agg="COUNT")
\`\`\`

Power users (REPL, tests) keep access to the full param surface via direct calls to \`tiles.pyramid.register_hex_tiles\`.

## Test plan

- [x] \`pytest tests/test_tile_pyramid.py tests/test_tile_endpoint.py tests/test_tile_math.py tests/test_server.py\` — 75 pass (73 prior + 2 new auto-detect cases)
- [ ] After merge + dev rollout: call \`register_hex_tiles\` from an MCP client with only \`sql\` (no other params) and confirm finest_res is auto-detected; verify the tool schema in \`tools/list\` shows only \`sql\` + \`agg\`