### PR TITLE
tiles: cache tilesets at registration time + Cache-Control on tile responses

### DIFF
--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -67,6 +67,17 @@ class TestServeTile:
         if r.status_code == 200:
             assert len(r.content) < 100  # empty MVT is very small
 
+    def test_response_has_immutable_cache_control(self, app_with_tiles, registered_ca):
+        # Tile content is deterministic per (hash, z, x, y); we tell intermediate
+        # caches (browser, CDN, HAProxy) they can serve repeats without revalidation.
+        client = TestClient(app_with_tiles)
+        r = client.get(f"/tiles/hex/{registered_ca}/5/5/12.pbf")
+        assert r.status_code in (200, 204)
+        cc = r.headers.get("cache-control", "")
+        assert "immutable" in cc
+        assert "max-age=" in cc
+        assert "public" in cc
+
     def test_unknown_hash_returns_404(self, app_with_tiles):
         client = TestClient(app_with_tiles)
         r = client.get("/tiles/hex/0000000000000000/5/5/12.pbf")

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -182,6 +182,40 @@ class TestRegisterHexTiles:
         )
         assert result["finest_res"] == 6
 
+    def test_metadata_persists_bounds_and_feature_count(self, local_bucket, h3_conn):
+        # bounds and feature_count_finest must be inside metadata.json so the
+        # next call with identical inputs can short-circuit.
+        import json
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, val
+            FROM (VALUES (37.8, -122.3, 1.0), (38.0, -122.5, 2.0)) t(lat, lng, val)
+        """
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=3, agg="AVG", zoom_offset=-1,
+        )
+        meta_path = local_bucket / "hex" / result["hash"] / "metadata.json"
+        with open(meta_path) as f:
+            meta = json.loads(f.read().strip())
+        assert "bounds" in meta and len(meta["bounds"]) == 4
+        assert meta["feature_count_finest"] == 2
+
+    def test_cache_hit_short_circuits_repeat_registration(self, local_bucket, h3_conn):
+        # Second registration with identical inputs reads metadata.json and
+        # returns cache_hit=True without re-running the build.
+        user_sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        first = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=2, agg="AVG", zoom_offset=-1,
+        )
+        assert first.get("cache_hit") is not True
+        second = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=2, agg="AVG", zoom_offset=-1,
+        )
+        assert second.get("cache_hit") is True
+        # Identical observable fields across both calls.
+        for key in ("hash", "bounds", "finest_res", "min_res", "value_columns",
+                    "value_stats", "layer_name", "feature_count_finest"):
+            assert second[key] == first[key], f"{key} differs across cache hit"
+
     def test_auto_detect_raises_on_empty_sql(self, local_bucket, h3_conn):
         # SQL filters to zero rows — auto-detect can't sample a cell.
         user_sql = (

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -21,6 +21,12 @@ from tiles.tile_math import tile_xyz_to_lnglat_bounds, zoom_to_h3_res
 
 MVT_CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
 
+# Tile content is deterministic per (hash, z, x, y): the hash is content-addressed
+# from the registration inputs, so the same URL always produces the same bytes
+# unless the tileset is explicitly purged and rebuilt. "immutable" tells browsers
+# and CDNs to serve cached responses without revalidation.
+TILE_CACHE_CONTROL = "public, max-age=86400, immutable"
+
 
 def _lng_to_merc_x(lng: float) -> float:
     """Convert longitude (degrees) to Web Mercator X (EPSG:3857)."""
@@ -170,5 +176,9 @@ async def serve_tile(request: Request) -> Response:
         return Response(status_code=500)
 
     if not mvt_bytes:
-        return Response(status_code=204)
-    return Response(content=mvt_bytes, media_type=MVT_CONTENT_TYPE)
+        return Response(status_code=204, headers={"Cache-Control": TILE_CACHE_CONTROL})
+    return Response(
+        content=mvt_bytes,
+        media_type=MVT_CONTENT_TYPE,
+        headers={"Cache-Control": TILE_CACHE_CONTROL},
+    )

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -110,6 +110,25 @@ def _inspect_user_sql(con: duckdb.DuckDBPyConnection, user_sql: str):
     return columns[0], list(columns[1:])
 
 
+def _read_existing_metadata(con: duckdb.DuckDBPyConnection, output_uri: str):
+    """Return the cached metadata dict if metadata.json exists at output_uri,
+    else None. Mirrors endpoint._read_metadata for s3 vs local paths.
+    """
+    uri = f"{output_uri}metadata.json"
+    try:
+        if not uri.startswith("s3://") and not uri.startswith("http"):
+            if not os.path.exists(uri):
+                return None
+            with open(uri, "r") as f:
+                return json.loads(f.read().strip())
+        row = con.sql(f"SELECT content FROM read_text('{uri}')").fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])
+    except Exception:
+        return None
+
+
 def register_hex_tiles(
     con: duckdb.DuckDBPyConnection,
     sql: str,
@@ -166,6 +185,27 @@ def register_hex_tiles(
 
     h = content_hash(sql=sql, finest_res=finest_res, min_res=min_res, agg=agg, zoom_offset=zoom_offset)
     output_uri = f"{_bucket_base()}/hex/{h}/"
+    tile_url_template = f"{_public_base_url()}/tiles/hex/{h}/{{z}}/{{x}}/{{y}}.pbf"
+
+    # Cache short-circuit: if an identical registration already exists, skip
+    # the COPY (which would re-scan the source) and return the persisted
+    # metadata. Hash is content-addressed, so a hit means the parquet pyramid
+    # on disk reflects exactly this registration's inputs.
+    cached = _read_existing_metadata(con, output_uri)
+    if cached is not None and "bounds" in cached and "feature_count_finest" in cached:
+        return {
+            "tile_url_template": tile_url_template,
+            "hash": h,
+            "bounds": cached["bounds"],
+            "finest_res": cached["finest_res"],
+            "min_res": cached["min_res"],
+            "zoom_offset": cached["zoom_offset"],
+            "value_columns": cached["value_columns"],
+            "value_stats": cached["value_stats"],
+            "layer_name": cached.get("layer_name", MVT_LAYER_NAME),
+            "feature_count_finest": cached["feature_count_finest"],
+            "cache_hit": True,
+        }
 
     pyramid_sql = build_pyramid_sql(
         user_sql=sql,
@@ -200,21 +240,6 @@ def register_hex_tiles(
             by_res[str(res)] = {"min": _jsonable(row[0]), "max": _jsonable(row[1])}
         value_stats[col] = {"by_res": by_res}
 
-    metadata = {
-        "finest_res": finest_res,
-        "min_res": min_res,
-        "agg": agg,
-        "zoom_offset": zoom_offset,
-        "value_columns": value_columns,
-        "value_stats": value_stats,
-        "layer_name": MVT_LAYER_NAME,
-    }
-    metadata_sql = (
-        f"COPY (SELECT '{_json_dumps_escaped(metadata)}' AS j) "
-        f"TO '{output_uri}metadata.json' (FORMAT CSV, HEADER false, QUOTE '')"
-    )
-    con.sql(metadata_sql)
-
     finest_uri = f"{output_uri}res={finest_res}/*.parquet"
     bounds_row = con.sql(
         f"SELECT "
@@ -225,7 +250,25 @@ def register_hex_tiles(
     ).fetchone()
     w, s, e, n, feature_count = bounds_row[2], bounds_row[0], bounds_row[3], bounds_row[1], bounds_row[4]
 
-    tile_url_template = f"{_public_base_url()}/tiles/hex/{h}/{{z}}/{{x}}/{{y}}.pbf"
+    # bounds + feature_count_finest persisted in metadata.json so the next
+    # registration with identical inputs can short-circuit without
+    # re-aggregating the source data.
+    metadata = {
+        "finest_res": finest_res,
+        "min_res": min_res,
+        "agg": agg,
+        "zoom_offset": zoom_offset,
+        "value_columns": value_columns,
+        "value_stats": value_stats,
+        "layer_name": MVT_LAYER_NAME,
+        "bounds": [w, s, e, n],
+        "feature_count_finest": feature_count,
+    }
+    metadata_sql = (
+        f"COPY (SELECT '{_json_dumps_escaped(metadata)}' AS j) "
+        f"TO '{output_uri}metadata.json' (FORMAT CSV, HEADER false, QUOTE '')"
+    )
+    con.sql(metadata_sql)
 
     return {
         "tile_url_template": tile_url_template,


### PR DESCRIPTION
Implements both layers of caching proposed in #127.

## 1. Tileset-level short-circuit (Fix A)

Previously a repeat \`register_hex_tiles\` call with identical inputs still ran the full source-data scan and aggregation — \`OVERWRITE_OR_IGNORE\` skipped only the parquet writes, not the COPY's query plan. A hypothetical global GBIF rebuild that takes minutes would still take minutes the second time around.

After: at the top of \`register_hex_tiles\`, once the content hash is known, we try to read \`s3://public-output/hex/{hash}/metadata.json\`. If present with the required fields (\`bounds\` + \`feature_count_finest\`), we construct the return dict from cached metadata and skip the build entirely — sub-second cache hit. The build path now also persists \`bounds\` + \`feature_count_finest\` in metadata.json so the next call can short-circuit. A \`cache_hit=True\` flag in the return dict makes cache state observable.

## 2. Tile-response cacheability (Fix B)

\`/tiles/hex/<hash>/{z}/{x}/{y}.pbf\` is content-addressed (hash = sha1 of registration inputs), so tile bytes are deterministic. Added

\`\`\`
Cache-Control: public, max-age=86400, immutable
\`\`\`

to both 200 and 204 responses. Any intermediate cache (browser, CDN, HAProxy) will serve repeats without hitting the pod. 404 (unknown tileset) is deliberately not cached — the tileset may be built shortly.

\`immutable\` is honest: the only way to change tile bytes under a fixed hash is an explicit purge + rebuild, which is rare.

## Test plan

- [x] \`pytest tests/test_tile_pyramid.py tests/test_tile_endpoint.py tests/test_tile_math.py tests/test_server.py\` — 78 pass (75 prior + 3 new):
  - \`test_metadata_persists_bounds_and_feature_count\`
  - \`test_cache_hit_short_circuits_repeat_registration\`
  - \`test_response_has_immutable_cache_control\`
- [ ] After merge + dev rollout: re-call \`register_hex_tiles\` with the same SQL as an existing tileset — confirm sub-second return and \`cache_hit: true\` in the response. Verify \`Cache-Control\` header on a tile fetch with \`curl -I\`.

Closes #127.