### PR TITLE
k8s: bump prod to v0.6.0 and raise CPU limit 16 → 64

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.5.7 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.0 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:
@@ -44,7 +44,7 @@ spec:
             cpu: 250m
           limits:
             memory: 160Gi
-            cpu: 16
+            cpu: 64
         ports:
         - containerPort: 8000
         readinessProbe:


### PR DESCRIPTION
Promotes the dev-tested tile-rendering work to production. v0.6.0 was tagged off current main; see the tag annotation for full change list.

## What ships

**Tile-rendering pipeline rebuild** (invisible to API, ~50–150× tile-byte reduction + sub-second responses on dense areas):
- \`zoom_offset\` default 4 → −1 (#118, #120)
- Bbox-filter pyramid scan replacing O(cells-in-tile) cell enumeration (#121)
- \`SET THREADS=16\` cap on tile DuckDB connection (#123)
- GROUP BY at finest level for COUNT mode — finest \`count\` becomes a real density signal (#124)
- Tileset registration cache short-circuit + \`Cache-Control: public, max-age=86400, immutable\` on tile responses (#128)

**Tool surface changes**:
- \`register_hex_tiles\` re-enabled (#119; was disabled in #97)
- Narrowed WHEN TO USE / WHEN NOT TO USE trigger language (#125)
- Pyramid infrastructure knobs (\`finest_res\`, \`min_res\`, \`zoom_offset\`) hidden from LLM-facing docstring; \`finest_res\` auto-detected from H3 column resolution; \`agg\` default switched \`"AVG"\` → \`"COUNT"\` (#126)

**Manifest changes** in this PR:
- \`--branch v0.5.7\` → \`v0.6.0\`
- CPU limit \`16\` → \`64\` (mirrors dev change from #123; requests unchanged at 250m so we still land in NRP's ignored bucket)

## Coordination

Coordinated with **geo-agent v3.6.0** (boettiger-lab/geo-agent#170), which ships \`add_hex_tile_layer\` to render the tile URLs that \`register_hex_tiles\` now returns. Downstream geo-agent app pins to be bumped by app owners.

## Test plan

- [x] dev has run all changes for ~24 h; tile latency, cache-hit, Cache-Control header all verified live
- [ ] After merge: \`kubectl apply -f k8s/deployment.yaml\` + \`kubectl rollout restart deployment/duckdb-mcp -n biodiversity\`; verify pods come up with v0.6.0 and 64-core limit
- [ ] Smoke-test a tile from prod (\`duckdb-mcp.nrp-nautilus.io\`) and confirm Cache-Control header is present