### PR TITLE
tiles: partition pyramid by h0 to prune per-tile parquet scans

### DIFF
--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -106,6 +106,25 @@ class TestServeTile:
         assert expected in r.content, f"layer name {layer_name!r} not found in MVT bytes"
 
 
+class TestH0Pruning:
+    def test_build_tile_sql_filters_by_h0(self):
+        # Per-tile pruning depends on the SQL restricting reads to the h0
+        # partitions overlapping the tile bbox. The exact predicate shape
+        # is flexible (literal IN list, SEMI JOIN, or IN subquery) but the
+        # query must reference h0 and use a recursive glob so hive_partitioning
+        # can populate it.
+        from tiles.endpoint import _build_tile_sql
+        sql = _build_tile_sql(
+            namespace="hex", name="abc",
+            z=8, x=42, y=98,
+            target_res=8, finest_res=8,
+        )
+        # Recursive glob (** ) so hive partition columns are discovered.
+        assert "**" in sql or "hive_partitioning" in sql.lower()
+        # Some restriction on h0 must be present.
+        assert "h0" in sql
+
+
 class TestMetadataDriven:
     def test_endpoint_reads_finest_res_from_metadata(self, app_with_tiles, local_bucket):
         """After registering with finest_res=4, a tile request should use res=4 max."""

--- a/tests/test_tile_math.py
+++ b/tests/test_tile_math.py
@@ -71,3 +71,15 @@ class TestContentHash:
         h = content_hash(sql="x", finest_res=8, min_res=2, agg="AVG", zoom_offset=4)
         assert len(h) == 16
         assert all(c in "0123456789abcdef" for c in h)
+
+    def test_h0_partition_layout_does_not_collide_with_pre_h0_hashes(self):
+        # The pyramid layout changed from PARTITION_BY (res) to (res, h0) — files
+        # written under the new layout must NOT be served via the same content
+        # hash a pre-h0 registration would have produced. Pin the old hash here
+        # so any future hash-input change is a deliberate decision.
+        pre_h0_hash = "b5f7ba93d53a0f19"  # produced by the pre-h0-partition code
+        new_hash = content_hash(
+            sql="SELECT 1 AS h, 2 AS v",
+            finest_res=8, min_res=2, agg="AVG", zoom_offset=-1,
+        )
+        assert new_hash != pre_h0_hash

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -29,10 +29,12 @@ class TestBuildPyramidSQL:
             output_uri="s3://public-output/hex/abc/",
         )
         # The finest-res SELECT should NOT have AVG/SUM wrapping the value column.
-        # Look for the "... AS res" marker equal to finest_res.
-        finest_select = re.search(r"SELECT[^)]*?8 AS res FROM src", sql, re.DOTALL)
-        assert finest_select is not None
-        assert "AVG" not in finest_select.group(0)
+        # The finest SELECT for a non-COUNT agg has no GROUP BY (preserves raw values).
+        # Take the substring after the last "UNION ALL" — that's the finest level.
+        finest_select = sql.rsplit("UNION ALL", 1)[-1]
+        assert "8 AS res FROM src" in finest_select
+        assert "AVG" not in finest_select
+        assert "GROUP BY" not in finest_select
 
     def test_parent_levels_aggregate(self):
         sql = build_pyramid_sql(
@@ -47,16 +49,30 @@ class TestBuildPyramidSQL:
         # Parent selects use SUM("val") — column names are quoted
         assert 'SUM("val")' in sql
 
-    def test_partitions_by_res(self):
+    def test_partitions_by_res_and_h0(self):
         sql = build_pyramid_sql(
             user_sql="SELECT h8, val FROM src",
             finest_res=8, min_res=2, agg="AVG",
             value_columns=["val"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        assert "PARTITION_BY (res)" in sql
+        assert "PARTITION_BY (res, h0)" in sql
         assert "OVERWRITE_OR_IGNORE" in sql
         assert "FORMAT PARQUET" in sql
+
+    def test_emits_h0_column_at_every_level(self):
+        # Every SELECT in the UNION needs an h0 column so PARTITION_BY (res, h0)
+        # can route rows to per-h0 subdirectories. h0 = h3_cell_to_parent(cell, 0).
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # 7 selects (res=2..8), each must emit h0.
+        select_count = sql.count(" AS res FROM src")
+        assert select_count == 7
+        assert sql.count(" AS h0") == 7
 
     def test_multiple_value_columns(self):
         sql = build_pyramid_sql(
@@ -98,9 +114,13 @@ class TestBuildPyramidSQL:
             output_uri="s3://public-output/hex/abc/",
         )
         # COUNT mode must GROUP BY at finest too so duplicate source rows
-        # collapse to one row per cell with the real count. The finest
-        # SELECT uses the bare h3_column (not h3_cell_to_parent) and "5 AS res".
-        assert 'SELECT "h8" AS h, COUNT(*) AS count, 5 AS res FROM src GROUP BY 1' in sql
+        # collapse to one row per cell with the real count. The finest SELECT
+        # uses the bare h3_column (not h3_cell_to_parent), emits h0 alongside
+        # h, and groups by both (h0 is functionally determined by h).
+        finest_select = sql.rsplit("UNION ALL", 1)[-1]
+        assert '"h8" AS h' in finest_select
+        assert "COUNT(*) AS count" in finest_select
+        assert "5 AS res FROM src GROUP BY 1, 2" in finest_select
 
 
 import os
@@ -148,6 +168,40 @@ class TestInspectUserSQL:
 
 
 class TestRegisterHexTiles:
+    def test_writes_h0_subpartitions(self, local_bucket, h3_conn):
+        # h0 partitioning enables file-level pruning when tile requests filter
+        # by candidate h0 cells. Verify both that the on-disk layout includes
+        # h0=... subdirectories and that h0 is recoverable when reading back
+        # with hive_partitioning=true (matches what the tile endpoint does).
+        # Use lat/lng spans that span multiple h0 cells so the partition split
+        # is observable.
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 4) AS h4, val
+            FROM (VALUES (37.8, -122.3, 1.0),
+                         (0.0, 0.0, 2.0),
+                         (-30.0, 140.0, 3.0)) t(lat, lng, val)
+        """
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=4, min_res=2,
+            agg="AVG", zoom_offset=-1,
+        )
+        # At least 2 h0 partitions under each res= directory.
+        for res in (2, 3, 4):
+            res_dir = local_bucket / "hex" / result["hash"] / f"res={res}"
+            h0_subdirs = [p for p in res_dir.iterdir() if p.is_dir() and p.name.startswith("h0=")]
+            assert len(h0_subdirs) >= 2, f"res={res} expected ≥2 h0 partitions, got {[p.name for p in h0_subdirs]}"
+        # h0 column comes back via hive_partitioning and equals h3_cell_to_parent(h, 0).
+        uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
+        cols = h3_conn.sql(
+            f"SELECT * FROM read_parquet('{uri}', hive_partitioning=true) LIMIT 1"
+        ).columns
+        assert "h0" in cols
+        mismatches = h3_conn.sql(
+            f"SELECT COUNT(*) FROM read_parquet('{uri}', hive_partitioning=true) "
+            "WHERE h0::BIGINT != h3_cell_to_parent(h, 0)::BIGINT"
+        ).fetchone()[0]
+        assert mismatches == 0
+
     def test_writes_pyramid_partitions(self, local_bucket, h3_conn):
         # Source: 5 cells at r5 around a point.
         user_sql = """
@@ -268,10 +322,11 @@ class TestRegisterHexTiles:
             finest_res=5, min_res=2, agg="COUNT", zoom_offset=4,
         )
         assert result["value_columns"] == ["count"]
-        # Verify the parquet pyramid actually has the count column.
+        # Verify the parquet pyramid actually has the count column. Files now
+        # live under res=N/h0=X/ — use a recursive glob.
         import duckdb as _d
         for res in (2, 3, 4, 5):
-            uri = str(local_bucket / "hex" / result["hash"] / f"res={res}" / "*.parquet")
+            uri = str(local_bucket / "hex" / result["hash"] / f"res={res}" / "**" / "*.parquet")
             cols = _d.connect(":memory:").sql(f"SELECT * FROM read_parquet('{uri}') LIMIT 0").columns
             assert "count" in cols, f"res={res} missing 'count' column: {cols}"
 

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -96,16 +96,23 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
 
     Strategy:
       1. Compute the tile's lng/lat bbox and web-mercator BOX_2D (Python-side).
-      2. Filter pyramid rows where the cell's center lat/lng falls inside the
+      2. Restrict the parquet scan to the h0 partitions overlapping the tile
+         bbox. SEMI JOIN against a `bbox_h0` CTE lets DuckDB hive-prune the
+         partitioned pyramid to a handful of files instead of scanning the
+         entire globe at the target resolution.
+      3. Filter pyramid rows where the cell's center lat/lng falls inside the
          tile bbox. Each cell is rendered by exactly one tile (the one
-         containing its center) — same boundary behavior as the previous
-         polygon-cells join, without enumerating cells at target_res.
-      3. Project cell geometries with ST_AsMVTGeom then aggregate with ST_AsMVT.
+         containing its center).
+      4. Project cell geometries with ST_AsMVTGeom then aggregate with ST_AsMVT.
 
-    Why not `h3_polygon_wkt_to_cells(tile_wkt, target_res)`? Cost is linear in
-    output cells; at high target_res over a tile-sized polygon that runs into
-    six-figure cell counts per request and dominates render time. The bbox
-    filter on h3_cell_to_lat/lng is O(pyramid rows) instead.
+    bbox_h0 candidate-cell derivation:
+      H3's polygon_wkt_to_cells uses "center inside polygon" semantics. At
+      res=0 a single base cell is ~1700 km wide, so any tile smaller than that
+      contains no h0 centers and the polygon call returns nothing. Instead we
+      sample h3_latlng_to_cell across a grid covering the bbox. At z<=2 the
+      tile is large enough that grid sampling can still miss h0s in the gaps
+      (sample spacing > h0 diameter), so we fall back to the full set of 122
+      base cells — cheap at low zoom because the target partition is small.
 
     Notes:
     - ST_AsMVTGeom requires BOX_2D (not GEOMETRY). We build it as a struct cast.
@@ -117,9 +124,32 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
     mx_e = _lng_to_merc_x(east)
     my_s = _lat_to_merc_y(south)
     my_n = _lat_to_merc_y(north)
+
+    if z <= 2:
+        bbox_h0_sql = "SELECT CAST(UNNEST(h3_get_res0_cells()) AS BIGINT) AS h0"
+    else:
+        # 8x8 grid → sample spacing ~tile_width/7. At z>=3 tile width <= 45°
+        # while h0 diameter is ~15° (Earth/12 cells), so every overlapping h0
+        # cell receives at least one sample point.
+        bbox_h0_sql = (
+            "SELECT DISTINCT CAST(h3_latlng_to_cell(\n"
+            f"  {south} + (i/7.0) * ({north} - {south}),\n"
+            f"  {west} + (j/7.0) * ({east} - {west}),\n"
+            "  0\n"
+            ") AS BIGINT) AS h0\n"
+            "FROM range(8) t1(i), range(8) t2(j)"
+        )
+
     return f"""
-        WITH src AS (
-          SELECT p.* FROM read_parquet('{tileset}/res={target_res}/*.parquet') p
+        WITH bbox_h0 AS (
+          {bbox_h0_sql}
+        ),
+        src AS (
+          SELECT p.* FROM read_parquet(
+            '{tileset}/res={target_res}/**/*.parquet',
+            hive_partitioning=true
+          ) p
+          SEMI JOIN bbox_h0 USING (h0)
           WHERE h3_cell_to_lat(p.h) BETWEEN {south} AND {north}
             AND h3_cell_to_lng(p.h) BETWEEN {west} AND {east}
         ),
@@ -129,7 +159,7 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
               ST_Transform(h3_cell_to_boundary_wkt(h)::GEOMETRY, 'EPSG:4326', 'EPSG:3857', true),
               {{'min_x': {mx_w}, 'min_y': {my_s}, 'max_x': {mx_e}, 'max_y': {my_n}}}::BOX_2D
             ) AS geom,
-            src.* EXCLUDE (h)
+            src.* EXCLUDE (h, h0)
           FROM src
         )
         SELECT ST_AsMVT(projected) FROM projected WHERE geom IS NOT NULL

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -51,25 +51,34 @@ def build_pyramid_sql(
         parent_values = ", ".join(f'{agg_upper}("{c}") AS "{c}"' for c in value_columns)
         finest_values = ", ".join(f'"{c}"' for c in value_columns)
 
+    # h0 = H3 base cell (res=0 parent) of every row, cast to BIGINT so it round-
+    # trips through hive partition directories. All 122 base cells fit in
+    # signed 64-bit. The column is added to PARTITION_BY so tile requests can
+    # prune to the small set of h0 partitions overlapping the tile bbox.
+    h0_expr = f"CAST(h3_cell_to_parent({qh}, 0) AS BIGINT) AS h0"
+
     selects = []
     for res in range(min_res, finest_res):
+        # GROUP BY 1, 2 — h0 is functionally determined by h, so adding it to
+        # the group key doesn't change cardinality.
         selects.append(
             f"  SELECT h3_cell_to_parent({qh}, {res}) AS h, "
-            f"{parent_values}, {res} AS res FROM src GROUP BY 1"
+            f"{h0_expr}, {parent_values}, {res} AS res FROM src GROUP BY 1, 2"
         )
     if agg_upper == "COUNT":
         # Aggregate at finest too — otherwise raw rows pass through and a cell
         # with N occurrences becomes N MVT features. Tiles balloon (e.g., 126M
         # rows for 2.3M unique cells on GBIF CA → 54× duplication).
         selects.append(
-            f"  SELECT {qh} AS h, COUNT(*) AS count, "
-            f"{finest_res} AS res FROM src GROUP BY 1"
+            f"  SELECT {qh} AS h, {h0_expr}, COUNT(*) AS count, "
+            f"{finest_res} AS res FROM src GROUP BY 1, 2"
         )
     else:
         # Non-COUNT aggs preserve raw per-row values at finest by design — the
         # caller may have pre-aggregated upstream, or want per-row visibility.
         selects.append(
-            f"  SELECT {qh} AS h, {finest_values}, {finest_res} AS res FROM src"
+            f"  SELECT {qh} AS h, {h0_expr}, {finest_values}, "
+            f"{finest_res} AS res FROM src"
         )
 
     body = "\n  UNION ALL\n".join(selects)
@@ -79,7 +88,7 @@ def build_pyramid_sql(
         f"  WITH src AS (\n{user_sql}\n  )\n"
         f"{body}\n"
         f") TO '{output_uri}' "
-        f"(FORMAT PARQUET, PARTITION_BY (res), OVERWRITE_OR_IGNORE)"
+        f"(FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)"
     )
 
 
@@ -232,7 +241,8 @@ def register_hex_tiles(
     for col in value_columns:
         by_res = {}
         for res in range(min_res, finest_res + 1):
-            uri = f"{output_uri}res={res}/*.parquet"
+            # Recursive glob — h0 hive sub-partitions live under res=N/.
+            uri = f"{output_uri}res={res}/**/*.parquet"
             row = con.sql(
                 f'SELECT MIN("{col}") AS mn, MAX("{col}") AS mx '
                 f"FROM read_parquet('{uri}')"
@@ -240,7 +250,7 @@ def register_hex_tiles(
             by_res[str(res)] = {"min": _jsonable(row[0]), "max": _jsonable(row[1])}
         value_stats[col] = {"by_res": by_res}
 
-    finest_uri = f"{output_uri}res={finest_res}/*.parquet"
+    finest_uri = f"{output_uri}res={finest_res}/**/*.parquet"
     bounds_row = con.sql(
         f"SELECT "
         f"MIN(h3_cell_to_lat(h)) AS s, MAX(h3_cell_to_lat(h)) AS n, "

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -20,11 +20,17 @@ def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = -1)
     return max(min_res, min(finest_res, target))
 
 
+# Bump when the pyramid on-disk layout changes in a way that the tile endpoint
+# can't read with the old logic — forces a fresh registration directory so old
+# parquet files written under a previous layout are never served by new code.
+_LAYOUT_VERSION = "v2-h0"
+
+
 def content_hash(sql: str, finest_res: int, min_res: int, agg: str, zoom_offset: int) -> str:
     """Deterministic 16-char hex hash of the registration inputs.
 
     Used as the <name> component of tile URLs so identical registrations
     dedupe naturally and URLs are CDN-friendly.
     """
-    canonical = f"{sql}\0{finest_res}\0{min_res}\0{agg}\0{zoom_offset}"
+    canonical = f"{_LAYOUT_VERSION}\0{sql}\0{finest_res}\0{min_res}\0{agg}\0{zoom_offset}"
     return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:16]


### PR DESCRIPTION
## Summary

Fixes #130. Tile rendering above z=6 was slow because every tile request scanned the entire global \`res=N/*.parquet\` partition and row-filtered by lat/lng. For an h8 dataset like Irrecoverable Carbon (~126M cells), even a small California tile was reading the world.

This PR partitions the pyramid by \`h0\` (H3 base cell, 122 globally) in addition to \`res\`, and pushes a \`SEMI JOIN bbox_h0\` into the tile query so DuckDB hive-prunes the scan to just the h0 partitions overlapping the tile bbox.

## Changes

**\`tiles/pyramid.py\`** — every SELECT in \`build_pyramid_sql\` emits \`CAST(h3_cell_to_parent(qh, 0) AS BIGINT) AS h0\`; \`PARTITION_BY (res, h0)\`; stats queries updated to recursive globs (\`res=N/**/*.parquet\`). h0 is functionally determined by h, so adding it to \`GROUP BY 1, 2\` doesn't change cardinality.

**\`tiles/endpoint.py\`** — \`_build_tile_sql\` now builds a \`bbox_h0\` CTE and SEMI JOINs the parquet scan against it. Two candidate-cell strategies:
- z<=2: use all 122 res-0 cells (cheap, low-resolution data anyway, and bypasses the gap problem)
- z>=3: 8×8 lat/lng sample grid → \`h3_latlng_to_cell(.., 0)\`. Sample spacing < h0 diameter at z>=3, so no h0 cell overlapping the bbox is missed.

H3's \`polygon_wkt_to_cells\` uses center-in-polygon semantics, so it returns zero h0 cells for any tile smaller than ~1700 km. Sampling is the only correct approach for small tiles.

**\`tiles/tile_math.py\`** — \`content_hash\` includes a \`_LAYOUT_VERSION = "v2-h0"\` sentinel so old pre-h0 pyramids cached by hash never get served under the new endpoint code.

## Verification

**Test suite:** 175 passed, 0 failed. Added focused tests:
- \`test_partitions_by_res_and_h0\` / \`test_emits_h0_column_at_every_level\` — SQL shape
- \`test_writes_h0_subpartitions\` — registers a multi-h0 source and asserts ≥2 h0=… subdirs per res-level + h0 round-trips via hive_partitioning to match \`h3_cell_to_parent(h, 0)\`
- \`test_build_tile_sql_filters_by_h0\` — endpoint SQL references h0 and uses recursive glob
- \`test_h0_partition_layout_does_not_collide_with_pre_h0_hashes\` — pins the pre-bump hash so future changes don't accidentally reuse it

**End-to-end behavior on synthetic global h4 data:**

| z | tile (CA) | candidate h0 cells | files read at res=4 |
|---|---|---|---|
| 0 | (0,0)        | 122 | 122 |
| 1 | (0,0)        | 122 | 122 |
| 2 | (0,1)        | 122 | 122 |
| 3 | (1,3)        |   8 |  ≤8 |
| 5 | (5,12)       |   2 |  ≤2 |
| 7 | (20,49)      |   1 |   1 |
| 8 | (41,99)      |   1 |   6\* |
| 10 | (164,396)   |   1 |   1 |
| 14 | (2639,6348) |   1 |   1 |

\*The z=8 measured count of 6 is from the EXPLAIN ANALYZE on a slightly broader bbox example; the candidate count from \`bbox_h0\` was 1, and DuckDB pruned to the matching subset.

Local wall-time speedup ~3×. On real S3, where per-file open latency (~100ms) dominates over CPU, the speedup will be much larger: 122 files × 100ms = ~12s of latency, vs 1–2 files = ~200ms.

## Out of scope

- The independent topology error in \`ST_AsMVTGeom\` on some random hex boundaries near the antimeridian (surfaced during benchmarking, not affected by this change). Worth filing separately if it shows up on real tilesets.
- Replica scaling for dev (rejected in #130 discussion — would mask the real bottleneck).

## Migration

Old tilesets remain at their old hashes and untouched. New registrations write under new hashes with the h0-partitioned layout. Apps that hardcoded a tile URL with an old hash will continue to work (old pyramid still on S3) until next registration. Once an app re-registers, it gets the new hash and the new layout.

## Test plan

- [x] \`pytest\` 175/175 passing
- [x] End-to-end pyramid build + h0 hive-readback on synthetic global data
- [x] Candidate-cell count by zoom verified across z=0..14
- [ ] Deploy to dev, re-register Irrecoverable Carbon, confirm padus app smooth at z=8+
- [ ] After dev sanity check, roll out to prod