### PR TITLE
pyramid: compute h0 once in src CTE

### DIFF
--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -61,18 +61,37 @@ class TestBuildPyramidSQL:
         assert "FORMAT PARQUET" in sql
 
     def test_emits_h0_column_at_every_level(self):
-        # Every SELECT in the UNION needs an h0 column so PARTITION_BY (res, h0)
-        # can route rows to per-h0 subdirectories. h0 = h3_cell_to_parent(cell, 0).
+        # Every SELECT in the UNION needs to carry h0 forward so
+        # PARTITION_BY (res, h0) can route rows to per-h0 subdirectories.
+        # h0 is computed once in src and propagated by name through each
+        # branch — verify each branch SELECT references h0.
         sql = build_pyramid_sql(
             user_sql="SELECT h8, val FROM src",
             finest_res=8, min_res=2, agg="AVG",
             value_columns=["val"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        # 7 selects (res=2..8), each must emit h0.
-        select_count = sql.count(" AS res FROM src")
-        assert select_count == 7
-        assert sql.count(" AS h0") == 7
+        # 7 selects (res=2..8), each must reference h0 as an output column.
+        # Split on UNION ALL to find branch boundaries; first chunk includes
+        # the src CTE and branch 1.
+        branches = sql.split("UNION ALL")
+        assert len(branches) == 7  # 7 branches → 6 UNION ALLs between
+        for i, b in enumerate(branches):
+            assert " h0," in b or " h0 " in b, f"branch {i} missing h0 column: {b}"
+
+    def test_h0_computed_once_in_src_cte(self):
+        # h0 must be computed once in the src CTE and reused across all UNION
+        # branches; recomputing h3_cell_to_parent(cell, 0) per row per branch
+        # is ~6× wasted work on multi-resolution pyramids and pushes large-
+        # dataset builds past MCP client timeouts.
+        sql = build_pyramid_sql(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # h0 is the res-0 parent — that exact call pattern appears exactly once.
+        assert sql.count('h3_cell_to_parent("h8", 0)') == 1
 
     def test_multiple_value_columns(self):
         sql = build_pyramid_sql(

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -51,41 +51,45 @@ def build_pyramid_sql(
         parent_values = ", ".join(f'{agg_upper}("{c}") AS "{c}"' for c in value_columns)
         finest_values = ", ".join(f'"{c}"' for c in value_columns)
 
-    # h0 = H3 base cell (res=0 parent) of every row, cast to BIGINT so it round-
-    # trips through hive partition directories. All 122 base cells fit in
-    # signed 64-bit. The column is added to PARTITION_BY so tile requests can
-    # prune to the small set of h0 partitions overlapping the tile bbox.
-    h0_expr = f"CAST(h3_cell_to_parent({qh}, 0) AS BIGINT) AS h0"
-
     selects = []
     for res in range(min_res, finest_res):
         # GROUP BY 1, 2 — h0 is functionally determined by h, so adding it to
         # the group key doesn't change cardinality.
         selects.append(
             f"  SELECT h3_cell_to_parent({qh}, {res}) AS h, "
-            f"{h0_expr}, {parent_values}, {res} AS res FROM src GROUP BY 1, 2"
+            f"h0, {parent_values}, {res} AS res FROM src GROUP BY 1, 2"
         )
     if agg_upper == "COUNT":
         # Aggregate at finest too — otherwise raw rows pass through and a cell
         # with N occurrences becomes N MVT features. Tiles balloon (e.g., 126M
         # rows for 2.3M unique cells on GBIF CA → 54× duplication).
         selects.append(
-            f"  SELECT {qh} AS h, {h0_expr}, COUNT(*) AS count, "
+            f"  SELECT {qh} AS h, h0, COUNT(*) AS count, "
             f"{finest_res} AS res FROM src GROUP BY 1, 2"
         )
     else:
         # Non-COUNT aggs preserve raw per-row values at finest by design — the
         # caller may have pre-aggregated upstream, or want per-row visibility.
         selects.append(
-            f"  SELECT {qh} AS h, {h0_expr}, {finest_values}, "
+            f"  SELECT {qh} AS h, h0, {finest_values}, "
             f"{finest_res} AS res FROM src"
         )
 
     body = "\n  UNION ALL\n".join(selects)
 
+    # h0 = H3 base cell (res=0 parent) of every row, cast to BIGINT so it round-
+    # trips through hive partition directories. All 122 base cells fit in
+    # signed 64-bit. Computed once in the src CTE and reused across every
+    # UNION ALL branch — recomputing per branch costs ~6× extra H3 calls per
+    # row on a 7-level pyramid, which pushes large-dataset builds past MCP
+    # client timeouts. PARTITION_BY (res, h0) routes rows to per-h0 sub-
+    # directories so tile requests can hive-prune to the bbox-overlapping set.
     return (
         "COPY (\n"
-        f"  WITH src AS (\n{user_sql}\n  )\n"
+        f"  WITH src AS (\n"
+        f"    SELECT *, CAST(h3_cell_to_parent({qh}, 0) AS BIGINT) AS h0\n"
+        f"    FROM (\n{user_sql}\n    )\n"
+        f"  )\n"
         f"{body}\n"
         f") TO '{output_uri}' "
         f"(FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)"


### PR DESCRIPTION
## Summary

Follow-up to #131. The h0 partition column was being recomputed in every UNION ALL branch of \`build_pyramid_sql\` — 7 redundant \`h3_cell_to_parent(qh, 0)\` calls per row. For the Irrecoverable Carbon dataset (~126M rows × 9.9 GiB), that's ~750M wasted H3 function calls, enough to push the build past the geo-agent MCP client's ~5-minute timeout (boettiger-lab/geo-agent#205).

This PR moves the cast into the \`WITH src\` CTE; each branch references the pre-computed column by name. \`PARTITION_BY (res, h0)\` is unchanged.

\`\`\`sql
-- before: cast repeated in every branch
WITH src AS ({user_sql})
SELECT h3_cell_to_parent(h8, 2) AS h,
       CAST(h3_cell_to_parent(h8, 0) AS BIGINT) AS h0,
       AVG(val) AS val, 2 AS res FROM src GROUP BY 1, 2
UNION ALL
SELECT h3_cell_to_parent(h8, 3) AS h,
       CAST(h3_cell_to_parent(h8, 0) AS BIGINT) AS h0,
       ...

-- after: cast computed once
WITH src AS (
  SELECT *, CAST(h3_cell_to_parent(h8, 0) AS BIGINT) AS h0
  FROM ({user_sql})
)
SELECT h3_cell_to_parent(h8, 2) AS h, h0, AVG(val) AS val, 2 AS res FROM src GROUP BY 1, 2
UNION ALL
SELECT h3_cell_to_parent(h8, 3) AS h, h0, AVG(val) AS val, 3 AS res FROM src GROUP BY 1, 2
...
\`\`\`

## Verification

- \`pytest\` 176/176 passing (added \`test_h0_computed_once_in_src_cte\` asserting \`h3_cell_to_parent("h8", 0)\` appears exactly once in the generated SQL).
- Existing \`test_emits_h0_column_at_every_level\` rewritten to assert the structural invariant — each UNION branch carries h0 as an output column — rather than the literal text that changed with this refactor.

## Test plan

- [x] Unit tests pass
- [ ] After merge, deploy to dev and re-run \`regenerate the carbon hex tiles\` in padus. The build should still take several minutes but ideally now fit inside the existing MCP timeout, or at least be faster.
- [ ] Independently bump the geo-agent MCP client timeout (boettiger-lab/geo-agent#205) so large pyramids that legitimately take 5–10 min don't get cancelled mid-flight.