### PR TITLE
docstring: hoist DPP mask-before-aggregate rule into CRITICAL SQL block

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -226,15 +226,7 @@ post-aggregation mask forces every h0 partition of the value dataset to
 be scanned — turning a small masked query into a global one.
 
 ```sql
--- ❌ Mask after aggregation → scans every h0 file
-WITH lc_agg AS (
-    SELECT h8, h0, MODE(lc_class) AS dominant
-    FROM read_parquet('<raster_hex>', hive_partitioning = true)
-    GROUP BY h8, h0
-)
-SELECT m.h8, l.dominant FROM mask m JOIN lc_agg l USING (h8, h0);
-
--- ✅ Mask first → only matching h0 files scanned
+-- Mask first: only matching h0 files scanned
 SELECT a.h8, MODE(a.lc_class) AS dominant
 FROM read_parquet('<raster_hex>', hive_partitioning = true) a
 SEMI JOIN mask m USING (h8, h0)

--- a/query-optimization.md
+++ b/query-optimization.md
@@ -43,15 +43,7 @@ You must read parquet datasets from S3 using read_parquet(). There are no local 
 **Aggregate after the join, never before.** When joining a small scope to a large hex dataset, do the join against the raw `read_parquet(...)` of the large side. Wrapping the large side in a pre-aggregation CTE (`GROUP BY`, `MODE`, `SUM`) before the join forces DuckDB to scan every h0 partition of it — the small scope's h0 values cannot prune through an aggregation operator.
 
 ```sql
--- ❌ WRONG: large side aggregated first → scans all h0 partitions
-WITH lc_agg AS (
-  SELECT h8, h0, MODE(lc_class) AS dominant
-  FROM read_parquet('<large_hex>') GROUP BY h8, h0
-)
-SELECT s.h8, a.dominant
-FROM scope s JOIN lc_agg a USING (h8, h0);
-
--- ✅ RIGHT: join first, aggregate after → only scope's h0 partitions opened
+-- Join first, aggregate after → only scope's h0 partitions opened
 WITH lc_on_scope AS (
   SELECT s.h8, s.h0, l.lc_class
   FROM scope s

--- a/server.py
+++ b/server.py
@@ -72,6 +72,21 @@ TOOL_INJECTED_CONTEXT = f"""
    - `read_parquet('s3://public-padus/padus-4-1/fee/hex/h0=*/data_0.parquet')` — nested path, partition glob
 
    Both are correct. Copy-paste the path from get_stac_details. In SQL examples below, `<STAC_HEX_PATH>` means "insert the exact path from get_stac_details here."
+4. **MASK BEFORE AGGREGATE (DPP rule).** When joining a small hex mask
+   (e.g. state, district, county, protected-areas hexes) against a globally
+   `h0`-partitioned hex dataset (land cover, climate, biomass — anything
+   under `hex/h0=*/`), the `SEMI JOIN` against the mask MUST appear directly
+   on the raw `read_parquet(...)` BEFORE `GROUP BY`. Aggregating the global
+   side first scans every `h0` partition and will hit the 300-second MCP
+   timeout. DuckDB dynamic partition pruning cannot push filters through
+   `HASH_GROUP_BY`.
+   ```sql
+   SELECT a.h8, MODE(a.lc_class) AS dominant
+   FROM read_parquet('<global_hex>', hive_partitioning = true) a
+   SEMI JOIN <mask> m USING (h8, h0)
+   WHERE a.lc_class IS NOT NULL
+   GROUP BY a.h8;
+   ```
 
 ### ⚡ OPTIMIZATION RULES
 {OPTIM_RAW}


### PR DESCRIPTION
## Summary

- Add rule 4 (MASK BEFORE AGGREGATE / DPP) to the small `CRITICAL SQL RULES` block at the top of the `query` tool docstring (`server.py`).
- Remove the ❌ counter-example blocks from `h3-guide.md` §Problem 3 and `query-optimization.md` §2. Prose rules and ✅ examples are unchanged.

## Why

LLMs were reproducing the ❌ block's `lc_agg` CTE verbatim (often as `lc_dominant`) when composing mask-against-global-hex queries — the syntax dominates the ❌ marker (negation priming), and the DPP rule sat at ~char 10k of a 19k-char docstring, too deep for reliable attention.

A/B/C testing on q2 ("land cover composition of areas protected in the Conservation Almanac nationwide") across 7 models × 2 trials:

| Metric | Baseline (n=12) | Variant C (n=14) |
|---|---|---|
| First-LC-query antipattern | 50% | 25% |
| Self-correction when wrong | 25% | 100% |
| Ever wrote antipattern in cell | 67% | 21% |

Variant A (just remove ❌, no hoist) didn't move the needle on its own — both interventions are load-bearing.

Closes #133

## Test plan

- [x] All 176 unit tests pass against modified docs
- [ ] Post-merge: dev rollout (`kubectl apply -f k8s/dev-deployment.yaml && kubectl rollout restart deployment/dev-duckdb-mcp -n biodiversity`)
- [ ] Smoke-test q2 against dev with the standard model fleet; expect first-LC-query antipattern ≤30% and self-correction ≥80%