### PR TITLE
k8s: bump prod to v0.6.1

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.6.0 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.1 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
## Summary
- Pin prod deployment's `git clone --branch` to v0.6.1 (per-tile h0 pruning in pyramid).
- No other manifest changes; CPU 16→64 was already set in #129.

## Test plan
- [ ] `kubectl apply -f k8s/deployment.yaml`
- [ ] `kubectl -n biodiversity rollout status deployment/duckdb-mcp`
- [ ] Smoke-test a hex tile query against https://duckdb-mcp.nrp-nautilus.io