### PR TITLE
k8s: bump prod to v0.6.2

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.6.1 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.2 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
Bumps prod deployment from v0.6.1 → v0.6.2 to pick up the docstring DPP-rule hoist (#134).

See tag v0.6.2 for release notes and A/B/C testing results.