### PR TITLE
pyramid: two-phase iterative build (finest from source, then rollups)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 memory/
 docs/superpowers/*
 !docs/superpowers/specs/
+!docs/superpowers/plans/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 # Claude Code / superpowers tooling
 .claude/
 memory/
-docs/superpowers/
+docs/superpowers/*
+!docs/superpowers/specs/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/superpowers/plans/2026-05-11-hex-pyramid-two-phase.md
+++ b/docs/superpowers/plans/2026-05-11-hex-pyramid-two-phase.md
@@ -1,0 +1,717 @@
+# Two-phase iterative hex pyramid build — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `build_pyramid_sql`'s single COPY with UNION ALL across 7 resolutions with a two-phase build — one COPY from source → finest, then iterative parent rollups from the previous res — so global high-cardinality datasets (GBIF-scale) build without OOM.
+
+**Architecture:** `tiles/pyramid.py` exposes a new function `build_pyramid_statements` returning an ordered list of `COPY` statements; `register_hex_tiles` executes them sequentially via existing `con.sql(...)`. Phase 1 is one finest-from-source COPY; Phase 2 is N-1 small COPYs each reading the previous res partition. Output schema and on-disk layout (`res=N/h0=X/`) are unchanged for COUNT/SUM/MIN/MAX; AVG mode adds an internal `count` column for correct weighted parent averages. Layout version bumped to `v3-iterative` so old hashes don't collide.
+
+**Tech Stack:** DuckDB 1.4+ with h3 community extension, Python 3.10+, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-hex-pyramid-two-phase-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `tiles/tile_math.py` | Bump `_LAYOUT_VERSION` from `"v2-h0"` to `"v3-iterative"` |
+| `tiles/pyramid.py` | Rename `build_pyramid_sql` → `build_pyramid_statements`; new return type `list[str]`; rewrite body for two-phase output. Update `register_hex_tiles` to loop over statements |
+| `tests/test_tile_math.py` | Add v3-hash collision test alongside the existing v2 pin |
+| `tests/test_tile_pyramid.py` | Add `TestBuildPyramidStatements` class; update or remove tests in `TestBuildPyramidSQL` that assert single-string return / UNION ALL shape |
+
+No changes to: `tiles/endpoint.py`, `server.py`, the `register_hex_tiles` MCP signature, tile-serving SQL, or the on-disk pyramid layout for non-AVG modes.
+
+---
+
+## Task 1: Bump `_LAYOUT_VERSION` to `v3-iterative`
+
+**Files:**
+- Modify: `tiles/tile_math.py`
+- Test: `tests/test_tile_math.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_tile_math.py` inside `class TestContentHash`:
+
+```python
+    def test_two_phase_layout_does_not_collide_with_v2_h0_hashes(self):
+        # v3-iterative layout (PR for two-phase pyramid) writes a different
+        # on-disk pyramid for the same user inputs. Bump the layout version
+        # so the new hash never overlaps a v2-h0 pyramid on S3.
+        v2_h0_hash = "31aff79f1d3a9b6f"  # fill in actual value after step 3
+        new_hash = content_hash(
+            sql="SELECT 1 AS h, 2 AS v",
+            finest_res=8, min_res=2, agg="AVG", zoom_offset=-1,
+        )
+        assert new_hash != v2_h0_hash
+```
+
+- [ ] **Step 2: Find the actual current (v2-h0) hash so the test is meaningful**
+
+Run from the worktree root:
+
+```bash
+.venv/bin/python -c "from tiles.tile_math import content_hash; print(content_hash(sql='SELECT 1 AS h, 2 AS v', finest_res=8, min_res=2, agg='AVG', zoom_offset=-1))"
+```
+
+Replace the placeholder `"31aff79f1d3a9b6f"` in the test with the printed value. Save.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_tile_math.py::TestContentHash::test_two_phase_layout_does_not_collide_with_v2_h0_hashes -v
+```
+
+Expected: FAIL with `assert <same-hash> != "<same-hash>"`.
+
+- [ ] **Step 4: Bump the layout version**
+
+In `tiles/tile_math.py` change:
+
+```python
+_LAYOUT_VERSION = "v2-h0"
+```
+
+to:
+
+```python
+_LAYOUT_VERSION = "v3-iterative"
+```
+
+- [ ] **Step 5: Run all tile_math tests to verify**
+
+```bash
+.venv/bin/python -m pytest tests/test_tile_math.py -v
+```
+
+Expected: all pass, including the new collision test and the existing `test_h0_partition_layout_does_not_collide_with_pre_h0_hashes` (which pins the pre-h0 hash and is unaffected by the v2→v3 bump).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tiles/tile_math.py tests/test_tile_math.py
+git commit -m "tiles: bump layout version to v3-iterative for two-phase pyramid"
+```
+
+---
+
+## Task 2: Implement `build_pyramid_statements` and update `register_hex_tiles`
+
+**Files:**
+- Modify: `tiles/pyramid.py:21-96` (replace `build_pyramid_sql`), `tiles/pyramid.py:223-234` (update `register_hex_tiles` to loop)
+- Test: `tests/test_tile_pyramid.py`
+
+This is the bulk of the work. The new function returns a list — one statement per resolution, ordered from finest to coarsest.
+
+- [ ] **Step 1: Write the failing unit tests for the new builder**
+
+Add a new test class at the top of `tests/test_tile_pyramid.py` (immediately after the imports), and the existing `TestBuildPyramidSQL` class will be updated in Step 6. New class:
+
+```python
+from tiles.pyramid import build_pyramid_statements
+
+
+class TestBuildPyramidStatements:
+    def test_returns_list_with_one_statement_per_resolution(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # finest_res=8, min_res=2 → res=8,7,6,5,4,3,2 = 7 statements.
+        assert isinstance(stmts, list)
+        assert len(stmts) == 7
+
+    def test_first_statement_is_phase_1_finest_from_source(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="SUM",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        s = stmts[0]
+        assert "FROM src" in s
+        assert "8 AS res" in s
+        assert "GROUP BY 1, 2" in s
+        assert "PARTITION_BY (res, h0)" in s
+        assert "OVERWRITE_OR_IGNORE" in s
+        # h0 is computed from the h3 column in the src CTE once.
+        assert 'h3_cell_to_parent("h8", 0)' in s
+
+    def test_phase_2_reads_from_previous_resolution(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="SUM",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Index 1 is res=7, reading res=8.
+        s = stmts[1]
+        assert "res=8/**/*.parquet" in s
+        assert "7 AS res" in s
+        assert "h3_cell_to_parent(h, 7)" in s
+        assert "hive_partitioning=true" in s
+        # Phase 2 must not re-scan the source.
+        assert "FROM src" not in s
+
+    def test_phase_2_iterates_down_to_min_res(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h8, val FROM src",
+            finest_res=8, min_res=2, agg="SUM",
+            value_columns=["val"], h3_column="h8",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # res=7 reads res=8, res=6 reads res=7, ..., res=2 reads res=3.
+        for i, parent_res in enumerate(range(7, 1, -1), start=1):
+            s = stmts[i]
+            assert f"res={parent_res + 1}/**/*.parquet" in s
+            assert f"{parent_res} AS res" in s
+
+    def test_min_res_equals_finest_res_single_statement(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=5, agg="AVG",
+            value_columns=["val"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert len(stmts) == 1
+        # Only Phase 1, no Phase 2.
+        assert "FROM src" in stmts[0]
+        assert "5 AS res" in stmts[0]
+
+    def test_count_mode_phase_1_uses_count_star(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5 FROM src",
+            finest_res=5, min_res=2, agg="COUNT",
+            value_columns=["count"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert "COUNT(*) AS count" in stmts[0]
+
+    def test_count_mode_phase_2_rolls_up_with_sum(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5 FROM src",
+            finest_res=5, min_res=2, agg="COUNT",
+            value_columns=["count"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # COUNT at parent = SUM(child count).
+        for s in stmts[1:]:
+            assert "SUM(count) AS count" in s
+
+    def test_sum_mode_uses_sum_at_every_level(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=2, agg="SUM",
+            value_columns=["val"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Finest: SUM at Phase 1 to collapse duplicate source rows into the cell.
+        assert 'SUM("val") AS "val"' in stmts[0]
+        # Parents: SUM rolls up.
+        for s in stmts[1:]:
+            assert 'SUM("val") AS "val"' in s
+
+    def test_min_max_modes_use_min_max_at_every_level(self):
+        for agg in ("MIN", "MAX"):
+            stmts = build_pyramid_statements(
+                user_sql="SELECT h5, val FROM src",
+                finest_res=5, min_res=2, agg=agg,
+                value_columns=["val"], h3_column="h5",
+                output_uri="s3://public-output/hex/abc/",
+            )
+            assert f'{agg}("val") AS "val"' in stmts[0]
+            for s in stmts[1:]:
+                assert f'{agg}("val") AS "val"' in s
+
+    def test_avg_mode_phase_1_includes_count_alongside_avg(self):
+        # AVG mode needs COUNT(*) at finest so parent rollups can compute
+        # weighted averages — `AVG of AVGs` is wrong when child cardinalities differ.
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert 'AVG("val") AS "val"' in stmts[0]
+        assert "COUNT(*) AS count" in stmts[0]
+
+    def test_avg_mode_phase_2_uses_weighted_average(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        for s in stmts[1:]:
+            assert 'SUM("val" * count) / SUM(count) AS "val"' in s
+            # count must propagate so further rollups can keep weighting correctly.
+            assert "SUM(count) AS count" in s
+
+    def test_avg_mode_with_multiple_value_columns(self):
+        # Single shared `count` for all value columns at every level.
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, v1, v2 FROM src",
+            finest_res=5, min_res=2, agg="AVG",
+            value_columns=["v1", "v2"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert 'AVG("v1") AS "v1"' in stmts[0]
+        assert 'AVG("v2") AS "v2"' in stmts[0]
+        assert "COUNT(*) AS count" in stmts[0]
+        # Parent rollup weights each value column by the same count.
+        assert 'SUM("v1" * count) / SUM(count) AS "v1"' in stmts[1]
+        assert 'SUM("v2" * count) / SUM(count) AS "v2"' in stmts[1]
+        assert "SUM(count) AS count" in stmts[1]
+
+    def test_invalid_agg_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="agg must be one of"):
+            build_pyramid_statements(
+                user_sql="SELECT h5, val FROM src",
+                finest_res=5, min_res=2, agg="MEDIAN",
+                value_columns=["val"], h3_column="h5",
+                output_uri="s3://public-output/hex/abc/",
+            )
+
+    def test_non_count_requires_value_columns(self):
+        # Empty value_columns list is only valid for COUNT (which uses
+        # a synthetic ["count"]). Other aggs must reject it.
+        import pytest
+        with pytest.raises(ValueError, match="value column"):
+            build_pyramid_statements(
+                user_sql="SELECT h5 FROM src",
+                finest_res=5, min_res=2, agg="SUM",
+                value_columns=[], h3_column="h5",
+                output_uri="s3://public-output/hex/abc/",
+            )
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_tile_pyramid.py::TestBuildPyramidStatements -v
+```
+
+Expected: All FAIL with `ImportError` or `AttributeError: build_pyramid_statements`.
+
+- [ ] **Step 3: Implement `build_pyramid_statements` in `tiles/pyramid.py`**
+
+Replace the entire `build_pyramid_sql` function (lines 21-96) with the following. Keep the imports (`json`, `os`, `Decimal`, `List`, `duckdb`, `content_hash`) and the `MVT_LAYER_NAME` constant unchanged.
+
+```python
+def build_pyramid_statements(
+    user_sql: str,
+    finest_res: int,
+    min_res: int,
+    agg: str,
+    value_columns: List[str],
+    h3_column: str,
+    output_uri: str,
+) -> List[str]:
+    """Return the ordered list of COPY statements that build a partitioned pyramid.
+
+    Two-phase design:
+      Phase 1 (first statement): one COPY reads user_sql, aggregates by (h, h0),
+        and writes only res=finest_res partitioned by (res, h0).
+      Phase 2 (remaining statements): for res = finest_res - 1 down to min_res,
+        each COPY reads the previously written res+1 partition (already aggregated,
+        small) and writes res. Working set per Phase 2 step is bounded by the
+        cardinality of the previous res, which shrinks ~7x per step.
+
+    AVG mode stores an internal `count` column alongside the aggregate so
+    parent rollups produce correctly weighted averages instead of an
+    unweighted mean-of-means.
+    """
+    _VALID_AGG = {"AVG", "SUM", "MIN", "MAX", "COUNT"}
+    agg_upper = agg.upper()
+    if agg_upper not in _VALID_AGG:
+        raise ValueError(f"agg must be one of {_VALID_AGG}, got {agg!r}")
+    if agg_upper != "COUNT" and not value_columns:
+        raise ValueError(
+            "user SQL must return at least one value column after the H3 index "
+            "(or use agg='COUNT')"
+        )
+
+    qh = f'"{h3_column}"'
+
+    # Per-agg expressions at finest (Phase 1, aggregating raw source rows)
+    # and at parent levels (Phase 2, rolling up the previous resolution).
+    if agg_upper == "COUNT":
+        phase1_values = "COUNT(*) AS count"
+        phase2_values = "SUM(count) AS count"
+    elif agg_upper == "SUM":
+        phase1_values = ", ".join(f'SUM("{c}") AS "{c}"' for c in value_columns)
+        phase2_values = ", ".join(f'SUM("{c}") AS "{c}"' for c in value_columns)
+    elif agg_upper == "MIN":
+        phase1_values = ", ".join(f'MIN("{c}") AS "{c}"' for c in value_columns)
+        phase2_values = ", ".join(f'MIN("{c}") AS "{c}"' for c in value_columns)
+    elif agg_upper == "MAX":
+        phase1_values = ", ".join(f'MAX("{c}") AS "{c}"' for c in value_columns)
+        phase2_values = ", ".join(f'MAX("{c}") AS "{c}"' for c in value_columns)
+    else:  # AVG
+        # Phase 1: average raw source rows + carry COUNT for weighted parents.
+        phase1_values = (
+            ", ".join(f'AVG("{c}") AS "{c}"' for c in value_columns)
+            + ", COUNT(*) AS count"
+        )
+        # Phase 2: weighted average = SUM(v*count) / SUM(count). Propagate count.
+        phase2_values = (
+            ", ".join(
+                f'SUM("{c}" * count) / SUM(count) AS "{c}"' for c in value_columns
+            )
+            + ", SUM(count) AS count"
+        )
+
+    # Phase 1: scan user_sql, derive h0 once in the src CTE, aggregate at finest.
+    phase_1 = (
+        "COPY (\n"
+        f"  WITH src AS (\n"
+        f"    SELECT *, CAST(h3_cell_to_parent({qh}, 0) AS BIGINT) AS h0\n"
+        f"    FROM (\n{user_sql}\n    )\n"
+        f"  )\n"
+        f"  SELECT {qh} AS h,\n"
+        f"         h0,\n"
+        f"         {phase1_values},\n"
+        f"         {finest_res} AS res\n"
+        f"  FROM src\n"
+        f"  GROUP BY 1, 2\n"
+        f") TO '{output_uri}' "
+        f"(FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)"
+    )
+
+    statements = [phase_1]
+
+    # Phase 2: each parent res reads from the previously written res+1.
+    for res in range(finest_res - 1, min_res - 1, -1):
+        src_uri = f"{output_uri}res={res + 1}/**/*.parquet"
+        stmt = (
+            "COPY (\n"
+            f"  SELECT h3_cell_to_parent(h, {res}) AS h,\n"
+            f"         h0,\n"
+            f"         {phase2_values},\n"
+            f"         {res} AS res\n"
+            f"  FROM read_parquet('{src_uri}', hive_partitioning=true)\n"
+            f"  GROUP BY 1, 2\n"
+            f") TO '{output_uri}' "
+            f"(FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)"
+        )
+        statements.append(stmt)
+
+    return statements
+```
+
+- [ ] **Step 4: Update `register_hex_tiles` to loop over the new statement list**
+
+In `tiles/pyramid.py`, replace lines 223-234 (the block that calls `build_pyramid_sql` and runs it once) with:
+
+```python
+    statements = build_pyramid_statements(
+        user_sql=sql,
+        finest_res=finest_res,
+        min_res=min_res,
+        agg=agg,
+        value_columns=value_columns,
+        h3_column=h3_column,
+        output_uri=output_uri,
+    )
+    if not output_uri.startswith("s3://"):
+        os.makedirs(output_uri, exist_ok=True)
+    for stmt in statements:
+        con.sql(stmt)
+```
+
+Also remove the `build_pyramid_sql` import / reference from the top of the file if any remain after replacing the function.
+
+- [ ] **Step 5: Run the new test class to verify GREEN**
+
+```bash
+.venv/bin/python -m pytest tests/test_tile_pyramid.py::TestBuildPyramidStatements -v
+```
+
+Expected: all pass (13 tests).
+
+- [ ] **Step 6: Update or remove obsolete tests in `TestBuildPyramidSQL`**
+
+The existing class `TestBuildPyramidSQL` in `tests/test_tile_pyramid.py` asserts the old single-string return type and the UNION ALL shape. Delete it entirely (and any `from tiles.pyramid import build_pyramid_sql` import that becomes unused) — `TestBuildPyramidStatements` covers the same surface in a way that's consistent with the new return type.
+
+After deletion, run:
+
+```bash
+.venv/bin/python -m pytest tests/test_tile_pyramid.py -v
+```
+
+Expected: All remaining `TestBuildPyramidStatements`, `TestInspectUserSQL`, `TestRegisterHexTiles`, `TestTilesetMetadata`, and `TestBuildTileConnection` tests pass. If any `TestRegisterHexTiles` tests fail, that signals an actual regression in `register_hex_tiles` from the loop change — debug those (most likely a path string / S3 URL issue) before continuing.
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+.venv/bin/python -m pytest -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tiles/pyramid.py tests/test_tile_pyramid.py
+git commit -m "pyramid: two-phase iterative build (finest from source, then rollups)"
+```
+
+---
+
+## Task 3: End-to-end mathematical correctness tests
+
+**Files:**
+- Test: `tests/test_tile_pyramid.py`
+
+The unit tests in Task 2 cover SQL shape. This task adds tests that build an actual pyramid against synthetic data and assert the aggregations are mathematically correct.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_tile_pyramid.py` after the existing `TestRegisterHexTiles` class:
+
+```python
+class TestPyramidMathCorrectness:
+    """Assert mathematical invariants on built pyramids — independent of
+    SQL shape. Each test registers a small multi-h0 synthetic dataset and
+    checks that parent values are correct rollups of child values.
+    """
+
+    def _seed_sql(self, points):
+        """Build a user_sql VALUES clause from a list of (lat, lng, val) tuples."""
+        rows = ", ".join(f"({lat}, {lng}, {val})" for lat, lng, val in points)
+        return f"""
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, val
+            FROM (VALUES {rows}) t(lat, lng, val)
+        """
+
+    def test_count_total_at_parent_equals_total_at_finest(self, local_bucket, h3_conn):
+        # COUNT mode: SUM of all count values at any res equals the total
+        # number of source rows (the dataset's true count).
+        points = [
+            (37.8, -122.3, 1.0), (37.80001, -122.30001, 2.0),  # same cluster
+            (38.0, -122.5, 3.0),
+            (40.0, -100.0, 4.0),
+            (-30.0, 140.0, 5.0),  # different h0
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=2, agg="COUNT", zoom_offset=-1,
+        )
+        for res in (2, 3, 4, 5):
+            uri = str(local_bucket / "hex" / result["hash"] / f"res={res}" / "**" / "*.parquet")
+            total = h3_conn.sql(
+                f"SELECT SUM(count) FROM read_parquet('{uri}', hive_partitioning=true)"
+            ).fetchone()[0]
+            assert total == len(points), f"res={res}: SUM(count)={total}, expected {len(points)}"
+
+    def test_sum_total_at_parent_equals_total_at_finest(self, local_bucket, h3_conn):
+        # SUM mode: conservation across resolutions.
+        points = [
+            (37.8, -122.3, 10.0), (37.80001, -122.30001, 5.0),
+            (38.0, -122.5, 7.0),
+            (40.0, -100.0, 3.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=2, agg="SUM", zoom_offset=-1,
+        )
+        for res in (2, 3, 4, 5):
+            uri = str(local_bucket / "hex" / result["hash"] / f"res={res}" / "**" / "*.parquet")
+            total = h3_conn.sql(
+                f'SELECT SUM("val") FROM read_parquet(\'{uri}\', hive_partitioning=true)'
+            ).fetchone()[0]
+            assert total == 25.0, f"res={res}: SUM(val)={total}, expected 25.0"
+
+    def test_min_at_parent_is_min_of_children(self, local_bucket, h3_conn):
+        # MIN mode: per-cell parent.MIN equals MIN over its res+1 children.
+        points = [
+            (37.8, -122.3, 10.0), (37.80001, -122.30001, 2.0),
+            (37.80002, -122.30002, 7.0),
+            (40.0, -100.0, 3.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=3, agg="MIN", zoom_offset=-1,
+        )
+        # For each (h@res=4) cell, the parent MIN should equal MIN of children.
+        child_uri = str(local_bucket / "hex" / result["hash"] / "res=5" / "**" / "*.parquet")
+        parent_uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
+        children_min_by_parent = h3_conn.sql(
+            f"""
+            SELECT h3_cell_to_parent(h, 4) AS ph, MIN("val") AS min_v
+            FROM read_parquet('{child_uri}', hive_partitioning=true)
+            GROUP BY 1
+            """
+        ).fetchdf()
+        parents = h3_conn.sql(
+            f'SELECT h AS ph, "val" AS min_v FROM read_parquet(\'{parent_uri}\', hive_partitioning=true)'
+        ).fetchdf()
+        merged = parents.merge(children_min_by_parent, on="ph", suffixes=("_p", "_c"))
+        assert (merged["min_v_p"] == merged["min_v_c"]).all()
+
+    def test_max_at_parent_is_max_of_children(self, local_bucket, h3_conn):
+        # Mirror of the MIN test.
+        points = [
+            (37.8, -122.3, 10.0), (37.80001, -122.30001, 2.0),
+            (37.80002, -122.30002, 7.0),
+            (40.0, -100.0, 3.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=3, agg="MAX", zoom_offset=-1,
+        )
+        child_uri = str(local_bucket / "hex" / result["hash"] / "res=5" / "**" / "*.parquet")
+        parent_uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
+        children_max_by_parent = h3_conn.sql(
+            f"""
+            SELECT h3_cell_to_parent(h, 4) AS ph, MAX("val") AS max_v
+            FROM read_parquet('{child_uri}', hive_partitioning=true)
+            GROUP BY 1
+            """
+        ).fetchdf()
+        parents = h3_conn.sql(
+            f'SELECT h AS ph, "val" AS max_v FROM read_parquet(\'{parent_uri}\', hive_partitioning=true)'
+        ).fetchdf()
+        merged = parents.merge(children_max_by_parent, on="ph", suffixes=("_p", "_c"))
+        assert (merged["max_v_p"] == merged["max_v_c"]).all()
+
+    def test_avg_at_parent_is_weighted_source_mean(self, local_bucket, h3_conn):
+        # AVG mode: parent.val equals the row-weighted mean of source rows
+        # falling under that parent. Two cells with different cardinalities
+        # produce different parent means under correct weighting; an
+        # unweighted mean-of-means would give a wrong answer here.
+        # Cluster A: 4 rows mapping to one h5 cell, values [10, 20, 30, 40] (mean 25).
+        # Cluster B: 1 row mapping to a sibling h5 cell, value [100] (mean 100).
+        # Both share the same h4 parent.
+        # Unweighted mean-of-means = (25 + 100) / 2 = 62.5  ← WRONG
+        # Correctly weighted mean = (10+20+30+40+100) / 5 = 40.0
+        points = [
+            (37.80000, -122.30000, 10.0),
+            (37.80001, -122.30001, 20.0),
+            (37.80002, -122.30002, 30.0),
+            (37.80003, -122.30003, 40.0),
+            (37.80100, -122.30100, 100.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=4, agg="AVG", zoom_offset=-1,
+        )
+        # All 5 points share the same h4 parent — find it and check its AVG.
+        parent_uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
+        rows = h3_conn.sql(
+            f'SELECT h, "val" FROM read_parquet(\'{parent_uri}\', hive_partitioning=true)'
+        ).fetchall()
+        # All five points map to the same (lat, lng) area at h4 → one parent row.
+        assert len(rows) == 1, f"expected 1 parent cell, got {len(rows)}: {rows}"
+        parent_val = rows[0][1]
+        assert abs(parent_val - 40.0) < 1e-9, (
+            f"parent AVG = {parent_val}, expected weighted mean 40.0 "
+            f"(unweighted mean-of-means would be 62.5)"
+        )
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_tile_pyramid.py::TestPyramidMathCorrectness -v
+```
+
+Expected: all pass (5 tests). If `test_avg_at_parent_is_weighted_source_mean` returns 62.5 instead of 40.0, the Phase 2 AVG SQL is using `AVG(child.val)` instead of `SUM(val*count)/SUM(count)` — re-check Task 2 Step 3.
+
+If any MIN/MAX test fails on a `merged["min_v_p"] == merged["min_v_c"]` comparison due to floating-point not exactly matching, that means parent isn't reading purely from children — it's a structural bug, not a numerical one. Fix at the source rather than relaxing the assertion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_tile_pyramid.py
+git commit -m "test: end-to-end mathematical invariants for two-phase pyramid"
+```
+
+---
+
+## Task 4: Run full suite, push, open PR
+
+- [ ] **Step 1: Full test run**
+
+```bash
+.venv/bin/python -m pytest -q
+```
+
+Expected: all pass. Note the total count for the PR description.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin worktree-hex-pyramid-two-phase
+```
+
+(The current branch is `worktree-hex-pyramid-two-phase`. Substitute if you renamed it.)
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "pyramid: two-phase iterative build (finest from source, then rollups)" --body "$(cat <<'EOF'
+## Summary
+
+Replaces \`build_pyramid_sql\`'s single COPY-with-7-branch-UNION-ALL with a two-phase build:
+
+1. **Phase 1** — one COPY scans \`user_sql\`, aggregates by \`(h, h0)\`, writes only \`res=finest_res\` partitioned by \`(res, h0)\`.
+2. **Phase 2** — for \`res = finest_res - 1\` down to \`min_res\`, each COPY reads the previously written \`res+1\` partition (already aggregated, small) and writes the next level.
+
+Each step's working set is bounded by its **output** cardinality, not by the full source. Global high-cardinality datasets (GBIF-scale: billions of points → ~50M h8 cells) no longer have to hold seven simultaneous aggregations plus the source CTE in memory at once.
+
+Spec: \`docs/superpowers/specs/2026-05-11-hex-pyramid-two-phase-design.md\`.
+
+## Behavior changes
+
+- **Finest level for non-COUNT modes is now aggregated** (was raw passthrough). One MVT feature per hex cell at every res, in every mode — fixes the overlapping-features bug at finest for SUM/MIN/MAX/AVG.
+- **AVG mode carries an internal \`count\` column** at every resolution so parent rollups produce correctly weighted averages. Stored alongside the AVG value in parquet; not exposed in \`value_stats\` or to the LLM (\`value_columns\` is unchanged).
+- **Layout version bumped to \`v3-iterative\`.** Old v2-h0 pyramids on S3 retain their hashes; new registrations write to fresh content addresses.
+
+## Public API
+
+Unchanged: \`register_hex_tiles\` MCP tool signature, the on-disk pyramid layout (\`res=N/h0=X/\`), the tile-serving SQL, the \`metadata.json\` schema, the cache short-circuit.
+
+## Verification
+
+- \`pytest\` — full suite passing (count: TBD — fill in from Step 1).
+- Math correctness end-to-end tests assert: COUNT total is conserved across resolutions; SUM total is conserved; parent MIN/MAX equals MIN/MAX of children; **parent AVG equals the source-row weighted mean** (the unweighted mean-of-means would give a wrong answer on the test fixture).
+
+## Out of scope
+
+- Per-h0 outer loop at Phase 1. If GBIF still OOMs after this change, chunk Phase 1 by h0.
+- Geo-agent client timeout bump (boettiger-lab/geo-agent#205, already open).
+
+## Test plan
+
+- [x] All unit + integration tests passing locally.
+- [ ] Deploy to dev, re-register Irrecoverable Carbon, confirm metadata.json appears and the URL renders.
+- [ ] Same for a GBIF-scale dataset that previously OOMed.
+- [ ] After dev sanity check, roll out to prod.
+EOF
+)"
+```
+
+- [ ] **Step 4: Report PR URL**
+
+Return the URL printed by `gh pr create` so the user can review.
+
+---
+
+## Self-Review Notes
+
+Coverage check against the spec:
+- ✅ Phase 1 finest-from-source COPY → Task 2 Step 3
+- ✅ Phase 2 iterative parent rollups → Task 2 Step 3
+- ✅ AVG with shared count column → Task 2 Steps 1, 3 and Task 3 Step 1 (`test_avg_at_parent_is_weighted_source_mean`)
+- ✅ Layout version bump → Task 1
+- ✅ Behavior change at finest level documented → covered by `test_sum_mode_uses_sum_at_every_level` (which asserts SUM at finest where the old code did raw passthrough) and by Task 3's invariant tests
+- ✅ `metadata.json` + cache short-circuit unchanged → Task 2 Step 4 (only the COPY loop changes; stats/bounds/metadata code below it is untouched)
+- ✅ End-to-end math invariants for each agg mode → Task 3 Step 1
+
+No placeholder text, no unreferenced types, no "similar to Task N" cross-references. Function name `build_pyramid_statements` used consistently. Test class name `TestBuildPyramidStatements` used consistently. The pre-bump v2-h0 hash is filled in at Task 1 Step 2 from a real `content_hash` invocation rather than being left as a placeholder.

--- a/docs/superpowers/specs/2026-05-11-hex-pyramid-two-phase-design.md
+++ b/docs/superpowers/specs/2026-05-11-hex-pyramid-two-phase-design.md
@@ -1,0 +1,151 @@
+# Hex pyramid build: two-phase iterative construction
+
+**Date:** 2026-05-11
+**Status:** Draft design, pending implementation
+**Tracking issue:** boettiger-lab/mcp-data-server (TBD — file alongside the implementation PR)
+**Builds on:** #131 (h0 partitioning) and #132 (h0 computed once in src CTE)
+
+## Problem
+
+`build_pyramid_sql` currently emits one `COPY` whose body is a 7-branch `UNION ALL` from a CTE that materializes the entire user-supplied source query. For global high-cardinality datasets (GBIF: billions of points → ~50M h8 cells, irrecoverable carbon: ~126M h8 cells), DuckDB must hold simultaneously:
+
+- The materialized `src` CTE.
+- Seven parallel `HASH_GROUP_BY` aggregations (one per resolution).
+- The per-(res, h0) hash bucketing that `PARTITION_BY (res, h0)` performs before writing partition files.
+
+This combined working set OOMs at GBIF scale and was already pushing memory pressure on the irrecoverable carbon dataset.
+
+The source data and the output are both h0-partitioned. The build path should leverage that and never need the whole globe in flight at once.
+
+## Solution
+
+Replace the one-shot `COPY` with two phases, each a smaller `COPY` whose memory footprint is bounded by its output cardinality rather than the source.
+
+### Phase 1 — finest from source
+
+One `COPY` reads `user_sql`, aggregates by `(h, h0)`, and writes only the finest resolution.
+
+```sql
+WITH src AS (
+  SELECT *, CAST(h3_cell_to_parent({qh}, 0) AS BIGINT) AS h0
+  FROM ({user_sql})
+)
+COPY (
+  SELECT {qh} AS h,
+         h0,
+         {finest_value_exprs},
+         {finest_res} AS res
+  FROM src
+  GROUP BY 1, 2
+) TO '{output_uri}' (FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)
+```
+
+`{finest_value_exprs}` depends on `agg`:
+
+| Agg | Expression(s) at finest |
+|---|---|
+| COUNT | `COUNT(*) AS count` |
+| SUM | `SUM("v") AS "v"` per value column |
+| MIN | `MIN("v") AS "v"` per value column |
+| MAX | `MAX("v") AS "v"` per value column |
+| AVG | `AVG("v1") AS "v1", AVG("v2") AS "v2", …, COUNT(*) AS count` (single shared count for the parent rollup) |
+
+### Phase 2 — iterative parents
+
+For each `res` from `finest_res - 1` down to `min_res`, a separate `COPY` reads from the previously written resolution and writes the next coarser level.
+
+```sql
+COPY (
+  SELECT h3_cell_to_parent(h, {res}) AS h,
+         h0,
+         {parent_value_exprs},
+         {res} AS res
+  FROM read_parquet('{output_uri}res={res+1}/**/*.parquet', hive_partitioning=true)
+  GROUP BY 1, 2
+) TO '{output_uri}' (FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)
+```
+
+`{parent_value_exprs}` rolls up the previous level:
+
+| Agg | Expression(s) at parent |
+|---|---|
+| COUNT | `SUM(count) AS count` |
+| SUM | `SUM("v") AS "v"` |
+| MIN | `MIN("v") AS "v"` |
+| MAX | `MAX("v") AS "v"` |
+| AVG | `SUM("v1" * count) / SUM(count) AS "v1", …, SUM(count) AS count` (single shared count, weighted per value column) |
+
+Each Phase 2 step's working set is bounded by the cardinality of the *previous* resolution, which shrinks by a factor of ~7 per step. The expensive scan is Phase 1; every Phase 2 step thereafter is small.
+
+## Output schema per resolution
+
+| Agg mode | Columns |
+|---|---|
+| COUNT | `h, h0, count` |
+| SUM / MIN / MAX | `h, h0, <value_col>` (one per user value column) |
+| AVG | `h, h0, <value_col>, count` |
+
+`h0` and `res` only live in the hive path (`res=N/h0=X/data.parquet`) — DuckDB's `PARTITION_BY (res, h0)` strips them from file content, and `hive_partitioning=true` re-adds them on read.
+
+The `count` column for AVG mode is an internal build aid. It is not reported in `value_stats`. The tile endpoint sees the schema it always saw (`value_columns` from registration metadata).
+
+## Behavior change at the finest level
+
+The current code passes raw source rows through at the finest level for non-COUNT modes:
+
+```python
+# Current (non-COUNT):
+finest_values = ", ".join(f'"{c}"' for c in value_columns)
+selects.append(
+    f"  SELECT {qh} AS h, h0, {finest_values}, {finest_res} AS res FROM src"
+)  # no GROUP BY
+```
+
+If `user_sql` returned multiple rows per `(h, h0)`, the tile endpoint rendered each as a separate MVT feature — producing overlapping hexagons. The new design always aggregates at the finest level by `(h, h0)`, so each cell renders as exactly one feature in every tile, in every mode.
+
+Callers that were intentionally relying on raw passthrough (none observed in production) would see one feature per cell instead.
+
+Knock-on effect on registration metadata: `feature_count_finest` is currently `COUNT(*)` from the finest-resolution parquet. Under the old layout that was the number of *source rows* for non-COUNT modes; under the new layout it's the number of unique `(h, h0)` cells at finest in every mode. This is the value the agent actually wanted — the previous semantics were a side effect of the raw-passthrough quirk.
+
+## Layout version
+
+Bump `_LAYOUT_VERSION` in `tiles/tile_math.py` from `"v2-h0"` to `"v3-iterative"`. Old pyramids written under the single-COPY layout retain their hashes and parquet on S3; new registrations get fresh content addresses and write to fresh directories.
+
+The pin in `test_h0_partition_layout_does_not_collide_with_pre_h0_hashes` should be extended (or a new test added) to also assert the new hash differs from a known `v2-h0` hash.
+
+## Atomicity and resumability
+
+`metadata.json` remains the single success marker, written only after both phases complete. The cache short-circuit (read `metadata.json`, return its contents) is unchanged.
+
+If a build is interrupted mid-flight, `metadata.json` is absent and the next call falls through to rebuild from scratch. `OVERWRITE_OR_IGNORE` on each phase tolerates pre-existing partial files. True per-h0 resumability (skipping h0 partitions already written) is out of scope for this iteration.
+
+## Implementation footprint
+
+Files changed:
+
+- `tiles/pyramid.py` — `build_pyramid_sql` returns a list of statements instead of a single string; `register_hex_tiles` executes them sequentially with the existing `con.sql(...)` loop. The post-build stats query (per-resolution min/max) keeps its current shape since the output paths and column names haven't changed for non-AVG modes.
+- `tiles/tile_math.py` — `_LAYOUT_VERSION` bump.
+- `tests/test_tile_pyramid.py` — assert Phase 1 SQL has finest-only `GROUP BY 1, 2`, Phase 2 SQLs reference `read_parquet('.../res={N+1}/**/*.parquet')` and the correct per-agg parent expression. Existing `test_finest_level_is_ungrouped` for AVG mode flips to `test_finest_level_is_grouped_in_all_modes`.
+- `tests/test_tile_math.py` — new collision-check test for `v3-iterative` vs `v2-h0`.
+
+Files unchanged:
+
+- `tiles/endpoint.py` — tile-serving SQL is unaffected; it still reads `res=N/**/*.parquet` and joins to `bbox_h0`.
+- `server.py` — `register_hex_tiles` public docstring and signature unchanged.
+
+## Testing
+
+- **Unit:** Phase 1 SQL shape per agg mode (COUNT, SUM, MIN, MAX, AVG). Phase 2 SQL shape per agg mode, including the weighted-average expression for AVG.
+- **End-to-end correctness:** register a multi-h0 synthetic dataset (the existing `test_writes_h0_subpartitions` fixture suffices). Assert mathematical invariants directly rather than diffing against the old output:
+  - COUNT: `SUM(parent.count) == COUNT(*)` from source for each h0.
+  - SUM: `SUM(parent.v) == SUM(child.v)` between adjacent resolutions.
+  - MIN/MAX: parent `MIN` equals `MIN` of children's `MIN`; parent `MAX` equals `MAX` of children's `MAX`.
+  - AVG: parent `v` equals the source-rows weighted mean within that parent cell, computed independently.
+- **No memory benchmark required for unit tests.** The OOM evidence will come from a real GBIF rebuild in dev after deploy.
+
+## Out of scope
+
+- Per-h0 outer loop at Phase 1. If GBIF still OOMs after this change, revisit by chunking Phase 1 by h0 — but the expected output cardinality of Phase 1 (~50M cells for GBIF) is bounded enough that a single streaming `COPY` should fit.
+- Resumable builds (detect and skip already-written h0 partitions on restart).
+- Any change to the tile endpoint or the `register_hex_tiles` public API.
+- Geo-agent client timeout (boettiger-lab/geo-agent#205, already open).

--- a/tests/test_tile_math.py
+++ b/tests/test_tile_math.py
@@ -83,3 +83,14 @@ class TestContentHash:
             finest_res=8, min_res=2, agg="AVG", zoom_offset=-1,
         )
         assert new_hash != pre_h0_hash
+
+    def test_two_phase_layout_does_not_collide_with_v2_h0_hashes(self):
+        # v3-iterative layout (PR for two-phase pyramid) writes a different
+        # on-disk pyramid for the same user inputs. Bump the layout version
+        # so the new hash never overlaps a v2-h0 pyramid on S3.
+        v2_h0_hash = "847ee176a3fd805e"  # v2-h0 layout hash
+        new_hash = content_hash(
+            sql="SELECT 1 AS h, 2 AS v",
+            finest_res=8, min_res=2, agg="AVG", zoom_offset=-1,
+        )
+        assert new_hash != v2_h0_hash

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -104,6 +104,21 @@ class TestBuildPyramidStatements:
         for s in stmts[1:]:
             assert 'SUM("val") AS "val"' in s
 
+    def test_sum_mode_with_multiple_value_columns(self):
+        # Verify the join across multiple value columns produces well-formed SQL
+        # for SUM mode (analogous to the existing AVG multi-column test).
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, v1, v2 FROM src",
+            finest_res=5, min_res=2, agg="SUM",
+            value_columns=["v1", "v2"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert 'SUM("v1") AS "v1"' in stmts[0]
+        assert 'SUM("v2") AS "v2"' in stmts[0]
+        for s in stmts[1:]:
+            assert 'SUM("v1") AS "v1"' in s
+            assert 'SUM("v2") AS "v2"' in s
+
     def test_min_max_modes_use_min_max_at_every_level(self):
         for agg in ("MIN", "MAX"):
             stmts = build_pyramid_statements(
@@ -116,7 +131,7 @@ class TestBuildPyramidStatements:
             for s in stmts[1:]:
                 assert f'{agg}("val") AS "val"' in s
 
-    def test_avg_mode_phase_1_includes_count_alongside_avg(self):
+    def test_avg_mode_phase_1_includes_weight_alongside_avg(self):
         # AVG mode needs COUNT(*) at finest so parent rollups can compute
         # weighted averages — `AVG of AVGs` is wrong when child cardinalities differ.
         stmts = build_pyramid_statements(
@@ -126,7 +141,7 @@ class TestBuildPyramidStatements:
             output_uri="s3://public-output/hex/abc/",
         )
         assert 'AVG("val") AS "val"' in stmts[0]
-        assert "COUNT(*) AS count" in stmts[0]
+        assert "COUNT(*) AS __pyramid_weight" in stmts[0]
 
     def test_avg_mode_phase_2_uses_weighted_average(self):
         stmts = build_pyramid_statements(
@@ -136,12 +151,12 @@ class TestBuildPyramidStatements:
             output_uri="s3://public-output/hex/abc/",
         )
         for s in stmts[1:]:
-            assert 'SUM("val" * count) / SUM(count) AS "val"' in s
-            # count must propagate so further rollups can keep weighting correctly.
-            assert "SUM(count) AS count" in s
+            assert 'SUM("val" * __pyramid_weight) / SUM(__pyramid_weight) AS "val"' in s
+            # weight must propagate so further rollups can keep weighting correctly.
+            assert "SUM(__pyramid_weight) AS __pyramid_weight" in s
 
     def test_avg_mode_with_multiple_value_columns(self):
-        # Single shared `count` for all value columns at every level.
+        # Single shared `__pyramid_weight` for all value columns at every level.
         stmts = build_pyramid_statements(
             user_sql="SELECT h5, v1, v2 FROM src",
             finest_res=5, min_res=2, agg="AVG",
@@ -150,11 +165,11 @@ class TestBuildPyramidStatements:
         )
         assert 'AVG("v1") AS "v1"' in stmts[0]
         assert 'AVG("v2") AS "v2"' in stmts[0]
-        assert "COUNT(*) AS count" in stmts[0]
-        # Parent rollup weights each value column by the same count.
-        assert 'SUM("v1" * count) / SUM(count) AS "v1"' in stmts[1]
-        assert 'SUM("v2" * count) / SUM(count) AS "v2"' in stmts[1]
-        assert "SUM(count) AS count" in stmts[1]
+        assert "COUNT(*) AS __pyramid_weight" in stmts[0]
+        # Parent rollup weights each value column by the same weight.
+        assert 'SUM("v1" * __pyramid_weight) / SUM(__pyramid_weight) AS "v1"' in stmts[1]
+        assert 'SUM("v2" * __pyramid_weight) / SUM(__pyramid_weight) AS "v2"' in stmts[1]
+        assert "SUM(__pyramid_weight) AS __pyramid_weight" in stmts[1]
 
     def test_invalid_agg_raises(self):
         import pytest

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -639,31 +639,40 @@ class TestPyramidMathCorrectness:
 
     def test_avg_at_parent_is_weighted_source_mean(self, local_bucket, h3_conn):
         # AVG mode: parent.val equals the row-weighted mean of source rows
-        # falling under that parent. Two cells with different cardinalities
-        # produce different parent means under correct weighting; an
-        # unweighted mean-of-means would give a wrong answer here.
-        # Cluster A: 4 rows mapping to one h5 cell, values [10, 20, 30, 40] (mean 25).
-        # Cluster B: 1 row mapping to a sibling h5 cell, value [100] (mean 100).
-        # Both share the same h4 parent.
-        # Unweighted mean-of-means = (25 + 100) / 2 = 62.5  ← WRONG
-        # Correctly weighted mean = (10+20+30+40+100) / 5 = 40.0
+        # falling under that parent. The test is meaningful only when the
+        # parent has TWO OR MORE distinct children at finest res — otherwise
+        # the Phase-2 SUM(v*w)/SUM(w) collapses to the single child's mean
+        # and an incorrect formula like AVG(v) would also pass.
+        #
+        # (37.0, -122.0) and (37.2, -122.0) map to two distinct h5 cells
+        # that share the same h4 parent.
+        # Cluster A: 4 rows at h5 cell A, values [10, 20, 30, 40] (cell mean 25, count 4).
+        # Cluster B: 1 row at h5 cell B, value [100] (cell mean 100, count 1).
+        # Unweighted mean-of-means at h4 = (25 + 100) / 2 = 62.5  ← WRONG
+        # Correctly weighted mean       = (4*25 + 1*100) / 5 = 40.0
         points = [
-            (37.80000, -122.30000, 10.0),
-            (37.80001, -122.30001, 20.0),
-            (37.80002, -122.30002, 30.0),
-            (37.80003, -122.30003, 40.0),
-            (37.80100, -122.30100, 100.0),
+            (37.0, -122.0, 10.0),
+            (37.0, -122.0, 20.0),
+            (37.0, -122.0, 30.0),
+            (37.0, -122.0, 40.0),
+            (37.2, -122.0, 100.0),
         ]
         result = register_hex_tiles(
             con=h3_conn, sql=self._seed_sql(points),
             finest_res=5, min_res=4, agg="AVG", zoom_offset=-1,
         )
-        # All 5 points share the same h4 parent — find it and check its AVG.
+        # Sanity: confirm the finest level really has 2 distinct h5 cells
+        # under one h4 parent — otherwise the test is checking nothing useful.
+        finest_uri = str(local_bucket / "hex" / result["hash"] / "res=5" / "**" / "*.parquet")
+        child_count = h3_conn.sql(
+            f"SELECT COUNT(DISTINCT h) FROM read_parquet('{finest_uri}', hive_partitioning=true)"
+        ).fetchone()[0]
+        assert child_count == 2, f"fixture must produce 2 distinct h5 cells, got {child_count}"
+
         parent_uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
         rows = h3_conn.sql(
             f'SELECT h, "val" FROM read_parquet(\'{parent_uri}\', hive_partitioning=true)'
         ).fetchall()
-        # All five points map to the same (lat, lng) area at h4 → one parent row.
         assert len(rows) == 1, f"expected 1 parent cell, got {len(rows)}: {rows}"
         parent_val = rows[0][1]
         assert abs(parent_val - 40.0) < 1e-9, (

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -530,3 +530,143 @@ class TestBuildTileConnection:
             assert "client_s3" not in names
         finally:
             con.close()
+
+
+class TestPyramidMathCorrectness:
+    """Assert mathematical invariants on built pyramids — independent of
+    SQL shape. Each test registers a small multi-h0 synthetic dataset and
+    checks that parent values are correct rollups of child values.
+    """
+
+    def _seed_sql(self, points):
+        """Build a user_sql VALUES clause from a list of (lat, lng, val) tuples."""
+        rows = ", ".join(f"({lat}, {lng}, {val})" for lat, lng, val in points)
+        return f"""
+            SELECT h3_latlng_to_cell(lat, lng, 5) AS h5, val
+            FROM (VALUES {rows}) t(lat, lng, val)
+        """
+
+    def test_count_total_at_parent_equals_total_at_finest(self, local_bucket, h3_conn):
+        # COUNT mode: SUM of all count values at any res equals the total
+        # number of source rows (the dataset's true count).
+        points = [
+            (37.8, -122.3, 1.0), (37.80001, -122.30001, 2.0),  # same cluster
+            (38.0, -122.5, 3.0),
+            (40.0, -100.0, 4.0),
+            (-30.0, 140.0, 5.0),  # different h0
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=2, agg="COUNT", zoom_offset=-1,
+        )
+        for res in (2, 3, 4, 5):
+            uri = str(local_bucket / "hex" / result["hash"] / f"res={res}" / "**" / "*.parquet")
+            total = h3_conn.sql(
+                f"SELECT SUM(count) FROM read_parquet('{uri}', hive_partitioning=true)"
+            ).fetchone()[0]
+            assert total == len(points), f"res={res}: SUM(count)={total}, expected {len(points)}"
+
+    def test_sum_total_at_parent_equals_total_at_finest(self, local_bucket, h3_conn):
+        # SUM mode: conservation across resolutions.
+        points = [
+            (37.8, -122.3, 10.0), (37.80001, -122.30001, 5.0),
+            (38.0, -122.5, 7.0),
+            (40.0, -100.0, 3.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=2, agg="SUM", zoom_offset=-1,
+        )
+        for res in (2, 3, 4, 5):
+            uri = str(local_bucket / "hex" / result["hash"] / f"res={res}" / "**" / "*.parquet")
+            total = h3_conn.sql(
+                f'SELECT SUM("val") FROM read_parquet(\'{uri}\', hive_partitioning=true)'
+            ).fetchone()[0]
+            assert total == 25.0, f"res={res}: SUM(val)={total}, expected 25.0"
+
+    def test_min_at_parent_is_min_of_children(self, local_bucket, h3_conn):
+        # MIN mode: per-cell parent.MIN equals MIN over its res+1 children.
+        points = [
+            (37.8, -122.3, 10.0), (37.80001, -122.30001, 2.0),
+            (37.80002, -122.30002, 7.0),
+            (40.0, -100.0, 3.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=3, agg="MIN", zoom_offset=-1,
+        )
+        # For each (h@res=4) cell, the parent MIN should equal MIN of children.
+        child_uri = str(local_bucket / "hex" / result["hash"] / "res=5" / "**" / "*.parquet")
+        parent_uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
+        children_min_by_parent = h3_conn.sql(
+            f"""
+            SELECT h3_cell_to_parent(h, 4) AS ph, MIN("val") AS min_v
+            FROM read_parquet('{child_uri}', hive_partitioning=true)
+            GROUP BY 1
+            """
+        ).fetchdf()
+        parents = h3_conn.sql(
+            f'SELECT h AS ph, "val" AS min_v FROM read_parquet(\'{parent_uri}\', hive_partitioning=true)'
+        ).fetchdf()
+        merged = parents.merge(children_min_by_parent, on="ph", suffixes=("_p", "_c"))
+        assert (merged["min_v_p"] == merged["min_v_c"]).all()
+
+    def test_max_at_parent_is_max_of_children(self, local_bucket, h3_conn):
+        # Mirror of the MIN test.
+        points = [
+            (37.8, -122.3, 10.0), (37.80001, -122.30001, 2.0),
+            (37.80002, -122.30002, 7.0),
+            (40.0, -100.0, 3.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=3, agg="MAX", zoom_offset=-1,
+        )
+        child_uri = str(local_bucket / "hex" / result["hash"] / "res=5" / "**" / "*.parquet")
+        parent_uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
+        children_max_by_parent = h3_conn.sql(
+            f"""
+            SELECT h3_cell_to_parent(h, 4) AS ph, MAX("val") AS max_v
+            FROM read_parquet('{child_uri}', hive_partitioning=true)
+            GROUP BY 1
+            """
+        ).fetchdf()
+        parents = h3_conn.sql(
+            f'SELECT h AS ph, "val" AS max_v FROM read_parquet(\'{parent_uri}\', hive_partitioning=true)'
+        ).fetchdf()
+        merged = parents.merge(children_max_by_parent, on="ph", suffixes=("_p", "_c"))
+        assert (merged["max_v_p"] == merged["max_v_c"]).all()
+
+    def test_avg_at_parent_is_weighted_source_mean(self, local_bucket, h3_conn):
+        # AVG mode: parent.val equals the row-weighted mean of source rows
+        # falling under that parent. Two cells with different cardinalities
+        # produce different parent means under correct weighting; an
+        # unweighted mean-of-means would give a wrong answer here.
+        # Cluster A: 4 rows mapping to one h5 cell, values [10, 20, 30, 40] (mean 25).
+        # Cluster B: 1 row mapping to a sibling h5 cell, value [100] (mean 100).
+        # Both share the same h4 parent.
+        # Unweighted mean-of-means = (25 + 100) / 2 = 62.5  ← WRONG
+        # Correctly weighted mean = (10+20+30+40+100) / 5 = 40.0
+        points = [
+            (37.80000, -122.30000, 10.0),
+            (37.80001, -122.30001, 20.0),
+            (37.80002, -122.30002, 30.0),
+            (37.80003, -122.30003, 40.0),
+            (37.80100, -122.30100, 100.0),
+        ]
+        result = register_hex_tiles(
+            con=h3_conn, sql=self._seed_sql(points),
+            finest_res=5, min_res=4, agg="AVG", zoom_offset=-1,
+        )
+        # All 5 points share the same h4 parent — find it and check its AVG.
+        parent_uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
+        rows = h3_conn.sql(
+            f'SELECT h, "val" FROM read_parquet(\'{parent_uri}\', hive_partitioning=true)'
+        ).fetchall()
+        # All five points map to the same (lat, lng) area at h4 → one parent row.
+        assert len(rows) == 1, f"expected 1 parent cell, got {len(rows)}: {rows}"
+        parent_val = rows[0][1]
+        assert abs(parent_val - 40.0) < 1e-9, (
+            f"parent AVG = {parent_val}, expected weighted mean 40.0 "
+            f"(unweighted mean-of-means would be 62.5)"
+        )

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -1,145 +1,182 @@
-import re
 import pytest
-from tiles.pyramid import build_pyramid_sql
+from tiles.pyramid import build_pyramid_statements
 
 
-class TestBuildPyramidSQL:
-    def test_contains_one_select_per_resolution(self):
-        sql = build_pyramid_sql(
-            user_sql="SELECT h8, val FROM src",
-            finest_res=8,
-            min_res=2,
-            agg="AVG",
-            value_columns=["val"],
-            h3_column="h8",
-            output_uri="s3://public-output/hex/abc/",
-        )
-        # Parents at res 2..7, plus finest level at res 8. 7 SELECTs total.
-        union_alls = len(re.findall(r"\bUNION ALL\b", sql, re.IGNORECASE))
-        assert union_alls == 6  # 7 selects → 6 UNION ALLs
-
-    def test_finest_level_is_ungrouped(self):
-        sql = build_pyramid_sql(
-            user_sql="SELECT h8, val FROM src",
-            finest_res=8,
-            min_res=2,
-            agg="AVG",
-            value_columns=["val"],
-            h3_column="h8",
-            output_uri="s3://public-output/hex/abc/",
-        )
-        # The finest-res SELECT should NOT have AVG/SUM wrapping the value column.
-        # The finest SELECT for a non-COUNT agg has no GROUP BY (preserves raw values).
-        # Take the substring after the last "UNION ALL" — that's the finest level.
-        finest_select = sql.rsplit("UNION ALL", 1)[-1]
-        assert "8 AS res FROM src" in finest_select
-        assert "AVG" not in finest_select
-        assert "GROUP BY" not in finest_select
-
-    def test_parent_levels_aggregate(self):
-        sql = build_pyramid_sql(
-            user_sql="SELECT h8, val FROM src",
-            finest_res=8,
-            min_res=2,
-            agg="SUM",
-            value_columns=["val"],
-            h3_column="h8",
-            output_uri="s3://public-output/hex/abc/",
-        )
-        # Parent selects use SUM("val") — column names are quoted
-        assert 'SUM("val")' in sql
-
-    def test_partitions_by_res_and_h0(self):
-        sql = build_pyramid_sql(
+class TestBuildPyramidStatements:
+    def test_returns_list_with_one_statement_per_resolution(self):
+        stmts = build_pyramid_statements(
             user_sql="SELECT h8, val FROM src",
             finest_res=8, min_res=2, agg="AVG",
             value_columns=["val"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        assert "PARTITION_BY (res, h0)" in sql
-        assert "OVERWRITE_OR_IGNORE" in sql
-        assert "FORMAT PARQUET" in sql
+        # finest_res=8, min_res=2 → res=8,7,6,5,4,3,2 = 7 statements.
+        assert isinstance(stmts, list)
+        assert len(stmts) == 7
 
-    def test_emits_h0_column_at_every_level(self):
-        # Every SELECT in the UNION needs to carry h0 forward so
-        # PARTITION_BY (res, h0) can route rows to per-h0 subdirectories.
-        # h0 is computed once in src and propagated by name through each
-        # branch — verify each branch SELECT references h0.
-        sql = build_pyramid_sql(
+    def test_first_statement_is_phase_1_finest_from_source(self):
+        stmts = build_pyramid_statements(
             user_sql="SELECT h8, val FROM src",
-            finest_res=8, min_res=2, agg="AVG",
+            finest_res=8, min_res=2, agg="SUM",
             value_columns=["val"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        # 7 selects (res=2..8), each must reference h0 as an output column.
-        # Split on UNION ALL to find branch boundaries; first chunk includes
-        # the src CTE and branch 1.
-        branches = sql.split("UNION ALL")
-        assert len(branches) == 7  # 7 branches → 6 UNION ALLs between
-        for i, b in enumerate(branches):
-            assert " h0," in b or " h0 " in b, f"branch {i} missing h0 column: {b}"
+        s = stmts[0]
+        assert "FROM src" in s
+        assert "8 AS res" in s
+        assert "GROUP BY 1, 2" in s
+        assert "PARTITION_BY (res, h0)" in s
+        assert "OVERWRITE_OR_IGNORE" in s
+        # h0 is computed from the h3 column in the src CTE once.
+        assert 'h3_cell_to_parent("h8", 0)' in s
 
-    def test_h0_computed_once_in_src_cte(self):
-        # h0 must be computed once in the src CTE and reused across all UNION
-        # branches; recomputing h3_cell_to_parent(cell, 0) per row per branch
-        # is ~6× wasted work on multi-resolution pyramids and pushes large-
-        # dataset builds past MCP client timeouts.
-        sql = build_pyramid_sql(
+    def test_phase_2_reads_from_previous_resolution(self):
+        stmts = build_pyramid_statements(
             user_sql="SELECT h8, val FROM src",
-            finest_res=8, min_res=2, agg="AVG",
+            finest_res=8, min_res=2, agg="SUM",
             value_columns=["val"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        # h0 is the res-0 parent — that exact call pattern appears exactly once.
-        assert sql.count('h3_cell_to_parent("h8", 0)') == 1
+        # Index 1 is res=7, reading res=8.
+        s = stmts[1]
+        assert "res=8/**/*.parquet" in s
+        assert "7 AS res" in s
+        assert "h3_cell_to_parent(h, 7)" in s
+        assert "hive_partitioning=true" in s
+        # Phase 2 must not re-scan the source.
+        assert "FROM src" not in s
 
-    def test_multiple_value_columns(self):
-        sql = build_pyramid_sql(
-            user_sql="SELECT h8, v1, v2 FROM src",
-            finest_res=8, min_res=2, agg="AVG",
-            value_columns=["v1", "v2"], h3_column="h8",
-            output_uri="s3://public-output/hex/abc/",
-        )
-        assert 'AVG("v1")' in sql
-        assert 'AVG("v2")' in sql
-
-    def test_min_res_equals_finest_res_single_level(self):
-        sql = build_pyramid_sql(
+    def test_phase_2_iterates_down_to_min_res(self):
+        stmts = build_pyramid_statements(
             user_sql="SELECT h8, val FROM src",
-            finest_res=8, min_res=8, agg="AVG",
+            finest_res=8, min_res=2, agg="SUM",
             value_columns=["val"], h3_column="h8",
             output_uri="s3://public-output/hex/abc/",
         )
-        # Only the finest level — no UNION ALL.
-        assert "UNION ALL" not in sql
+        # res=7 reads res=8, res=6 reads res=7, ..., res=2 reads res=3.
+        for i, parent_res in enumerate(range(7, 1, -1), start=1):
+            s = stmts[i]
+            assert f"res={parent_res + 1}/**/*.parquet" in s
+            assert f"{parent_res} AS res" in s
 
-    def test_count_mode_emits_count_column_no_value_cols(self):
-        sql = build_pyramid_sql(
-            user_sql="SELECT h8 FROM src",
-            finest_res=8, min_res=2, agg="COUNT",
-            value_columns=["count"], h3_column="h8",
+    def test_min_res_equals_finest_res_single_statement(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=5, agg="AVG",
+            value_columns=["val"], h3_column="h5",
             output_uri="s3://public-output/hex/abc/",
         )
-        # COUNT(*) AS count at every level — parents and finest.
-        assert "COUNT(*) AS count" in sql
-        # No stray references to user value columns (there are none).
-        assert 'AVG(' not in sql and 'SUM(' not in sql
+        assert len(stmts) == 1
+        # Only Phase 1, no Phase 2.
+        assert "FROM src" in stmts[0]
+        assert "5 AS res" in stmts[0]
 
-    def test_count_mode_finest_level_aggregates(self):
-        sql = build_pyramid_sql(
-            user_sql="SELECT h8 FROM src",
+    def test_count_mode_phase_1_uses_count_star(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5 FROM src",
             finest_res=5, min_res=2, agg="COUNT",
-            value_columns=["count"], h3_column="h8",
+            value_columns=["count"], h3_column="h5",
             output_uri="s3://public-output/hex/abc/",
         )
-        # COUNT mode must GROUP BY at finest too so duplicate source rows
-        # collapse to one row per cell with the real count. The finest SELECT
-        # uses the bare h3_column (not h3_cell_to_parent), emits h0 alongside
-        # h, and groups by both (h0 is functionally determined by h).
-        finest_select = sql.rsplit("UNION ALL", 1)[-1]
-        assert '"h8" AS h' in finest_select
-        assert "COUNT(*) AS count" in finest_select
-        assert "5 AS res FROM src GROUP BY 1, 2" in finest_select
+        assert "COUNT(*) AS count" in stmts[0]
+
+    def test_count_mode_phase_2_rolls_up_with_sum(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5 FROM src",
+            finest_res=5, min_res=2, agg="COUNT",
+            value_columns=["count"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # COUNT at parent = SUM(child count).
+        for s in stmts[1:]:
+            assert "SUM(count) AS count" in s
+
+    def test_sum_mode_uses_sum_at_every_level(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=2, agg="SUM",
+            value_columns=["val"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Finest: SUM at Phase 1 to collapse duplicate source rows into the cell.
+        assert 'SUM("val") AS "val"' in stmts[0]
+        # Parents: SUM rolls up.
+        for s in stmts[1:]:
+            assert 'SUM("val") AS "val"' in s
+
+    def test_min_max_modes_use_min_max_at_every_level(self):
+        for agg in ("MIN", "MAX"):
+            stmts = build_pyramid_statements(
+                user_sql="SELECT h5, val FROM src",
+                finest_res=5, min_res=2, agg=agg,
+                value_columns=["val"], h3_column="h5",
+                output_uri="s3://public-output/hex/abc/",
+            )
+            assert f'{agg}("val") AS "val"' in stmts[0]
+            for s in stmts[1:]:
+                assert f'{agg}("val") AS "val"' in s
+
+    def test_avg_mode_phase_1_includes_count_alongside_avg(self):
+        # AVG mode needs COUNT(*) at finest so parent rollups can compute
+        # weighted averages — `AVG of AVGs` is wrong when child cardinalities differ.
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert 'AVG("val") AS "val"' in stmts[0]
+        assert "COUNT(*) AS count" in stmts[0]
+
+    def test_avg_mode_phase_2_uses_weighted_average(self):
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, val FROM src",
+            finest_res=5, min_res=2, agg="AVG",
+            value_columns=["val"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        for s in stmts[1:]:
+            assert 'SUM("val" * count) / SUM(count) AS "val"' in s
+            # count must propagate so further rollups can keep weighting correctly.
+            assert "SUM(count) AS count" in s
+
+    def test_avg_mode_with_multiple_value_columns(self):
+        # Single shared `count` for all value columns at every level.
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, v1, v2 FROM src",
+            finest_res=5, min_res=2, agg="AVG",
+            value_columns=["v1", "v2"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        assert 'AVG("v1") AS "v1"' in stmts[0]
+        assert 'AVG("v2") AS "v2"' in stmts[0]
+        assert "COUNT(*) AS count" in stmts[0]
+        # Parent rollup weights each value column by the same count.
+        assert 'SUM("v1" * count) / SUM(count) AS "v1"' in stmts[1]
+        assert 'SUM("v2" * count) / SUM(count) AS "v2"' in stmts[1]
+        assert "SUM(count) AS count" in stmts[1]
+
+    def test_invalid_agg_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="agg must be one of"):
+            build_pyramid_statements(
+                user_sql="SELECT h5, val FROM src",
+                finest_res=5, min_res=2, agg="MEDIAN",
+                value_columns=["val"], h3_column="h5",
+                output_uri="s3://public-output/hex/abc/",
+            )
+
+    def test_non_count_requires_value_columns(self):
+        # Empty value_columns list is only valid for COUNT (which uses
+        # a synthetic ["count"]). Other aggs must reject it.
+        import pytest
+        with pytest.raises(ValueError, match="value column"):
+            build_pyramid_statements(
+                user_sql="SELECT h5 FROM src",
+                finest_res=5, min_res=2, agg="SUM",
+                value_columns=[], h3_column="h5",
+                output_uri="s3://public-output/hex/abc/",
+            )
 
 
 import os

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -18,7 +18,7 @@ from tiles.tile_math import content_hash
 MVT_LAYER_NAME = "layer"
 
 
-def build_pyramid_sql(
+def build_pyramid_statements(
     user_sql: str,
     finest_res: int,
     min_res: int,
@@ -26,74 +26,97 @@ def build_pyramid_sql(
     value_columns: List[str],
     h3_column: str,
     output_uri: str,
-) -> str:
-    """Return the COPY ... TO SQL that writes a partitioned pyramid.
+) -> List[str]:
+    """Return the ordered list of COPY statements that build a partitioned pyramid.
 
-    The finest-resolution level stores raw per-row values; parent resolutions
-    aggregate via the chosen `agg` function.
+    Two-phase design:
+      Phase 1 (first statement): one COPY reads user_sql, aggregates by (h, h0),
+        and writes only res=finest_res partitioned by (res, h0).
+      Phase 2 (remaining statements): for res = finest_res - 1 down to min_res,
+        each COPY reads the previously written res+1 partition (already aggregated,
+        small) and writes res. Working set per Phase 2 step is bounded by the
+        cardinality of the previous res, which shrinks ~7x per step.
 
-    When agg="COUNT", `value_columns` must be exactly ["count"] and the SQL
-    emits `COUNT(*) AS count` at parent levels and `1 AS count` at the finest
-    level. Any value columns from the user SQL are ignored — callers requesting
-    COUNT get row-count semantics, nothing else.
+    AVG mode stores an internal `count` column alongside the aggregate so
+    parent rollups produce correctly weighted averages instead of an
+    unweighted mean-of-means.
     """
     _VALID_AGG = {"AVG", "SUM", "MIN", "MAX", "COUNT"}
     agg_upper = agg.upper()
     if agg_upper not in _VALID_AGG:
         raise ValueError(f"agg must be one of {_VALID_AGG}, got {agg!r}")
+    if agg_upper != "COUNT" and not value_columns:
+        raise ValueError(
+            "user SQL must return at least one value column after the H3 index "
+            "(or use agg='COUNT')"
+        )
 
     qh = f'"{h3_column}"'
 
+    # Per-agg expressions at finest (Phase 1, aggregating raw source rows)
+    # and at parent levels (Phase 2, rolling up the previous resolution).
     if agg_upper == "COUNT":
-        parent_values = "COUNT(*) AS count"
-        finest_values = "1 AS count"
-    else:
-        parent_values = ", ".join(f'{agg_upper}("{c}") AS "{c}"' for c in value_columns)
-        finest_values = ", ".join(f'"{c}"' for c in value_columns)
-
-    selects = []
-    for res in range(min_res, finest_res):
-        # GROUP BY 1, 2 — h0 is functionally determined by h, so adding it to
-        # the group key doesn't change cardinality.
-        selects.append(
-            f"  SELECT h3_cell_to_parent({qh}, {res}) AS h, "
-            f"h0, {parent_values}, {res} AS res FROM src GROUP BY 1, 2"
+        phase1_values = "COUNT(*) AS count"
+        phase2_values = "SUM(count) AS count"
+    elif agg_upper == "SUM":
+        phase1_values = ", ".join(f'SUM("{c}") AS "{c}"' for c in value_columns)
+        phase2_values = ", ".join(f'SUM("{c}") AS "{c}"' for c in value_columns)
+    elif agg_upper == "MIN":
+        phase1_values = ", ".join(f'MIN("{c}") AS "{c}"' for c in value_columns)
+        phase2_values = ", ".join(f'MIN("{c}") AS "{c}"' for c in value_columns)
+    elif agg_upper == "MAX":
+        phase1_values = ", ".join(f'MAX("{c}") AS "{c}"' for c in value_columns)
+        phase2_values = ", ".join(f'MAX("{c}") AS "{c}"' for c in value_columns)
+    else:  # AVG
+        # Phase 1: average raw source rows + carry COUNT for weighted parents.
+        phase1_values = (
+            ", ".join(f'AVG("{c}") AS "{c}"' for c in value_columns)
+            + ", COUNT(*) AS count"
         )
-    if agg_upper == "COUNT":
-        # Aggregate at finest too — otherwise raw rows pass through and a cell
-        # with N occurrences becomes N MVT features. Tiles balloon (e.g., 126M
-        # rows for 2.3M unique cells on GBIF CA → 54× duplication).
-        selects.append(
-            f"  SELECT {qh} AS h, h0, COUNT(*) AS count, "
-            f"{finest_res} AS res FROM src GROUP BY 1, 2"
-        )
-    else:
-        # Non-COUNT aggs preserve raw per-row values at finest by design — the
-        # caller may have pre-aggregated upstream, or want per-row visibility.
-        selects.append(
-            f"  SELECT {qh} AS h, h0, {finest_values}, "
-            f"{finest_res} AS res FROM src"
+        # Phase 2: weighted average = SUM(v*count) / SUM(count). Propagate count.
+        phase2_values = (
+            ", ".join(
+                f'SUM("{c}" * count) / SUM(count) AS "{c}"' for c in value_columns
+            )
+            + ", SUM(count) AS count"
         )
 
-    body = "\n  UNION ALL\n".join(selects)
-
-    # h0 = H3 base cell (res=0 parent) of every row, cast to BIGINT so it round-
-    # trips through hive partition directories. All 122 base cells fit in
-    # signed 64-bit. Computed once in the src CTE and reused across every
-    # UNION ALL branch — recomputing per branch costs ~6× extra H3 calls per
-    # row on a 7-level pyramid, which pushes large-dataset builds past MCP
-    # client timeouts. PARTITION_BY (res, h0) routes rows to per-h0 sub-
-    # directories so tile requests can hive-prune to the bbox-overlapping set.
-    return (
+    # Phase 1: scan user_sql, derive h0 once in the src CTE, aggregate at finest.
+    phase_1 = (
         "COPY (\n"
         f"  WITH src AS (\n"
         f"    SELECT *, CAST(h3_cell_to_parent({qh}, 0) AS BIGINT) AS h0\n"
         f"    FROM (\n{user_sql}\n    )\n"
         f"  )\n"
-        f"{body}\n"
+        f"  SELECT {qh} AS h,\n"
+        f"         h0,\n"
+        f"         {phase1_values},\n"
+        f"         {finest_res} AS res\n"
+        f"  FROM src\n"
+        f"  GROUP BY 1, 2\n"
         f") TO '{output_uri}' "
         f"(FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)"
     )
+
+    statements = [phase_1]
+
+    # Phase 2: each parent res reads from the previously written res+1.
+    for res in range(finest_res - 1, min_res - 1, -1):
+        src_uri = f"{output_uri}res={res + 1}/**/*.parquet"
+        stmt = (
+            "COPY (\n"
+            f"  SELECT h3_cell_to_parent(h, {res}) AS h,\n"
+            f"         h0,\n"
+            f"         {phase2_values},\n"
+            f"         {res} AS res\n"
+            f"  FROM read_parquet('{src_uri}', hive_partitioning=true)\n"
+            f"  GROUP BY 1, 2\n"
+            f") TO '{output_uri}' "
+            f"(FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)"
+        )
+        statements.append(stmt)
+
+    return statements
 
 
 def _bucket_base() -> str:
@@ -220,7 +243,7 @@ def register_hex_tiles(
             "cache_hit": True,
         }
 
-    pyramid_sql = build_pyramid_sql(
+    statements = build_pyramid_statements(
         user_sql=sql,
         finest_res=finest_res,
         min_res=min_res,
@@ -231,7 +254,8 @@ def register_hex_tiles(
     )
     if not output_uri.startswith("s3://"):
         os.makedirs(output_uri, exist_ok=True)
-    con.sql(pyramid_sql)
+    for stmt in statements:
+        con.sql(stmt)
 
     # Per-resolution min/max for every output value column.
     def _jsonable(v):

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -37,8 +37,8 @@ def build_pyramid_statements(
         small) and writes res. Working set per Phase 2 step is bounded by the
         cardinality of the previous res, which shrinks ~7x per step.
 
-    AVG mode stores an internal `count` column alongside the aggregate so
-    parent rollups produce correctly weighted averages instead of an
+    AVG mode stores an internal `__pyramid_weight` column alongside the aggregate
+    so parent rollups produce correctly weighted averages instead of an
     unweighted mean-of-means.
     """
     _VALID_AGG = {"AVG", "SUM", "MIN", "MAX", "COUNT"}
@@ -71,14 +71,14 @@ def build_pyramid_statements(
         # Phase 1: average raw source rows + carry COUNT for weighted parents.
         phase1_values = (
             ", ".join(f'AVG("{c}") AS "{c}"' for c in value_columns)
-            + ", COUNT(*) AS count"
+            + ", COUNT(*) AS __pyramid_weight"
         )
-        # Phase 2: weighted average = SUM(v*count) / SUM(count). Propagate count.
+        # Phase 2: weighted average = SUM(v*weight) / SUM(weight). Propagate weight.
         phase2_values = (
             ", ".join(
-                f'SUM("{c}" * count) / SUM(count) AS "{c}"' for c in value_columns
+                f'SUM("{c}" * __pyramid_weight) / SUM(__pyramid_weight) AS "{c}"' for c in value_columns
             )
-            + ", SUM(count) AS count"
+            + ", SUM(__pyramid_weight) AS __pyramid_weight"
         )
 
     # Phase 1: scan user_sql, derive h0 once in the src CTE, aggregate at finest.
@@ -187,8 +187,8 @@ def register_hex_tiles(
       `count` column (row count per hex at parent resolutions; 1 at finest).
       Any extra columns in the user SQL are ignored.
     - Other aggs: user SQL must return at least one value column after the H3
-      index. Each is aggregated via `agg` at parent resolutions and passed
-      through raw at the finest level.
+      index. Each is aggregated via `agg` at every resolution including the finest
+      (one row per (h, h0) cell at every level).
     """
     h3_column, sql_value_columns = _inspect_user_sql(con, sql)
     if finest_res is None:

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -23,7 +23,7 @@ def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = -1)
 # Bump when the pyramid on-disk layout changes in a way that the tile endpoint
 # can't read with the old logic — forces a fresh registration directory so old
 # parquet files written under a previous layout are never served by new code.
-_LAYOUT_VERSION = "v2-h0"
+_LAYOUT_VERSION = "v3-iterative"
 
 
 def content_hash(sql: str, finest_res: int, min_res: int, agg: str, zoom_offset: int) -> str:


### PR DESCRIPTION
## Summary

Replaces `build_pyramid_sql`'s single COPY-with-7-branch-UNION-ALL with a two-phase build:

1. **Phase 1** — one COPY scans `user_sql`, aggregates by `(h, h0)`, writes only `res=finest_res` partitioned by `(res, h0)`.
2. **Phase 2** — for `res = finest_res - 1` down to `min_res`, each COPY reads the previously written `res+1` partition (already aggregated, small) and writes the next level.

Each step's working set is bounded by its **output** cardinality, not by the full source. Global high-cardinality datasets (GBIF-scale: billions of points → ~50M h8 cells) no longer need to hold seven simultaneous aggregations plus the source CTE in memory at once.

Spec: `docs/superpowers/specs/2026-05-11-hex-pyramid-two-phase-design.md`
Plan: `docs/superpowers/plans/2026-05-11-hex-pyramid-two-phase.md`

## Behavior changes

- **Finest level for non-COUNT modes is now aggregated** (was raw passthrough). One MVT feature per hex cell at every res, in every mode — fixes the overlapping-features bug at finest for SUM/MIN/MAX/AVG.
- **AVG mode carries an internal `__pyramid_weight` column** at every resolution so parent rollups produce correctly weighted averages. Stored alongside the AVG value in parquet; not exposed in `value_stats` and not in the `value_columns` list returned to the LLM. (Renamed from `count` during review to avoid colliding with a user value column named `count`.)
- **Layout version bumped to `v3-iterative`.** Old v2-h0 pyramids on S3 retain their hashes; new registrations write to fresh content addresses.

## Public API

Unchanged: `register_hex_tiles` MCP tool signature, the on-disk pyramid layout (`res=N/h0=X/`), the tile-serving SQL, the `metadata.json` schema, the cache short-circuit.

## Verification

- `pytest` — **187 passed, 0 failed**.
- Unit tests cover Phase 1 / Phase 2 SQL shape per agg mode (COUNT, SUM, MIN, MAX, AVG) including the weighted-average expression.
- New `TestPyramidMathCorrectness` end-to-end tests assert mathematical invariants:
  - COUNT total conserved across resolutions.
  - SUM total conserved across resolutions.
  - Parent MIN equals MIN of children; parent MAX equals MAX of children.
  - **Parent AVG equals the source-row weighted mean** (the test fixture uses a 4-row cluster of values [10,20,30,40] and a 1-row cluster of [100] sharing one h4 parent; the test asserts 40.0 — an unweighted mean-of-means would give 62.5, catching any regression in weighted-average correctness).

## Out of scope

- Per-h0 outer loop at Phase 1. If GBIF still OOMs after this change, chunk Phase 1 by h0.
- Geo-agent client timeout bump (boettiger-lab/geo-agent#205, already open).
- Filtering `__pyramid_weight` out of MVT feature properties at the tile endpoint. The column ships as an extra property in AVG-mode tiles; clients style by the explicit `value_columns` from registration metadata, so the noise is cosmetic. Worth a follow-up if it confuses clients in practice.

## Test plan

- [x] All unit + integration tests passing locally (187 / 187).
- [ ] Deploy to dev, re-register Irrecoverable Carbon, confirm metadata.json appears and the URL renders.
- [ ] Same for a GBIF-scale dataset that previously OOMed.
- [ ] After dev sanity check, roll out to prod.