### PR TITLE
tiles/db: bump DuckDB THREADS from 16 to 48 for faster pyramid builds

### DIFF
--- a/tiles/db.py
+++ b/tiles/db.py
@@ -19,11 +19,14 @@ def build_tile_connection() -> duckdb.DuckDBPyConnection:
     con.sql("INSTALL spatial; LOAD spatial")
     con.sql("INSTALL h3 FROM community; LOAD h3")
 
-    # Cap per-query parallelism so several concurrent tile requests can run side
-    # by side instead of one query monopolizing the pod. With CPU limit 64 and
-    # THREADS=16, ~4 concurrent tile queries saturate cleanly; pyramid builds
-    # (which share this connection) are bandwidth-bound on S3 anyway.
-    con.sql("SET THREADS=16")
+    # Per-query parallelism. THREADS=48 gives register_hex_tiles enough
+    # parallel S3 readers / hash-aggregation workers to push Phase 1 of the
+    # pyramid build past its previous ~30 MB/s effective S3 read ceiling
+    # (the bottleneck observed on the global irrecoverable-carbon build,
+    # which took ~6 min at THREADS=16). Headroom of 16 of the 64-core
+    # CPU limit is left for concurrent tile-serving requests that hit the
+    # same connection while a pyramid build is in flight.
+    con.sql("SET THREADS=48")
     con.sql("SET preserve_insertion_order=false")
     con.sql("SET enable_object_cache=true")
     con.sql("SET temp_directory='/tmp'")


### PR DESCRIPTION
## Why

Phase 1 of `register_hex_tiles` (the source-scan-and-aggregate step) dominates pyramid build wall time. The global irrecoverable-carbon build measured ~6 min wall time for 9.9 GiB of source data — about **30 MB/s** effective S3 read throughput, far below what Ceph delivers internally with parallel readers.

`THREADS=16` was a conservative tile-serving setting: it lets ~4 concurrent tile queries saturate cleanly on the 64-core pod. But for the register_hex_tiles single-big-job case it left roughly 3/4 of the pod's CPU/I/O budget idle while a user waited 6 min and the geo-agent client hit its 5-min timeout.

## What

`tiles/db.py`: `SET THREADS=48`.

Leaves 16 cores of headroom for tile requests that hit the same connection while a pyramid build is in flight (DuckDB shares one persistent `:memory:` connection across all requests).

## Test plan

- [x] `pytest -q` — 187 / 187 passing locally
- [ ] Deploy to dev; ask the agent to re-render irrecoverable carbon at h8. Record Phase 1 wall time and compare against the previous ~5 min baseline. If we drop into the 90–180 s range, the I/O hypothesis is confirmed and this PR is the right fix; if it doesn't move, the bottleneck is elsewhere and we need to profile with `EXPLAIN ANALYZE` next.
- [ ] Concurrent-tile-serving sanity check on dev while a pyramid build is in flight (16 cores should be enough for several tiles, but worth verifying nothing thrashes).
- [ ] After dev sanity, roll to prod.

## Related

- boettiger-lab/mcp-data-server#138 — two-phase iterative pyramid build (merged); set the stage for this tuning.
- boettiger-lab/geo-agent#205 — open, bumps MCP client timeout to 10 min. Independent fix; if both land, the client never times out on a real build and the build itself runs faster.