### PR TITLE
k8s: bump prod to v0.6.3

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.6.2 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.3 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
## Summary

Bumps prod deployment to **v0.6.3**, which includes:

- **#138** — two-phase iterative pyramid build (no more OOM at GBIF / global-h8 scale; ~6 min build for irrecoverable carbon)
- **#139** — DuckDB `THREADS=48` (was 16) — expected to substantially shorten Phase 1 of the pyramid build

Release notes: https://github.com/boettiger-lab/mcp-data-server/releases/tag/v0.6.3

## Behavior changes (heads-up for prod)

- `_LAYOUT_VERSION = "v3-iterative"`. Old v2-h0 pyramids in the public S3 bucket retain their hashes but are unreachable from new code (the `h0` column shape differs slightly for AVG mode). The currently-deployed-by-content tilesets are content-addressed, so a re-registration with the same SQL will produce a new hash and a fresh pyramid; the agent layer reaches its tiles via the URL returned at registration time, so there is no client-visible breakage as long as agents re-register.
- Finest level for non-COUNT modes now aggregates by `(h, h0)` (was raw passthrough). One MVT feature per hex cell at every resolution.

## Test plan

- [x] Dev rollout (#138 then #139) — verified pyramid builds finish, tile rendering smooth
- [ ] Apply + restart prod
- [ ] Check `kubectl get pods -n biodiversity` shows 6 healthy replicas on v0.6.3
- [ ] Spot-check a tile request against the prod ingress