### PR TITLE
tiles: async pyramid builds with per-job connection and status-poll tool

### DIFF
--- a/server.py
+++ b/server.py
@@ -239,13 +239,25 @@ mcp.tool()(query)
 # -------------------------------------------------------------------------
 # 8b. TILE ENDPOINT — dynamic MVT for H3 hex visualization (see issue #4)
 # -------------------------------------------------------------------------
+import concurrent.futures
+import threading
+import time
 from tiles.endpoint import serve_tile
 from tiles.db import build_tile_connection
-from tiles.pyramid import register_hex_tiles as _register_hex_tiles
+from tiles.pyramid import (
+    MVT_LAYER_NAME,
+    prepare_hex_tiles,
+    build_hex_tiles,
+    cached_result_dict,
+    read_existing_metadata,
+    tile_paths_for_hash,
+)
 
 
-# Module-level persistent connection. Initialized lazily at first use OR
-# at startup via the lifespan in mount_tiles().
+# Module-level persistent connection used for READS ONLY (tile-serve GETs +
+# the fast prepare-phase probes for register_hex_tiles). Pyramid builds get
+# their own connections via the executor below so a long-running COPY can't
+# block tile-serve reads.
 _tile_con = None
 
 
@@ -254,6 +266,44 @@ def _get_tile_con():
     if _tile_con is None:
         _tile_con = build_tile_connection()
     return _tile_con
+
+
+# Background pyramid builds. Each submitted job gets a fresh DuckDB
+# connection so writes don't serialise behind each other or behind reads.
+_BUILD_MAX_CONCURRENCY = int(os.environ.get("TILE_BUILD_MAX_CONCURRENCY", "2"))
+_BUILD_INLINE_WAIT_SECONDS = float(os.environ.get("TILE_BUILD_INLINE_WAIT_SECONDS", "5"))
+_build_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_BUILD_MAX_CONCURRENCY,
+    thread_name_prefix="tile-build",
+)
+_jobs_lock = threading.Lock()
+# hash -> {"future": Future, "started_at": float}. Entries persist after
+# completion so get_hex_tile_status can return "failed" with the error
+# string; "done" status reads metadata.json directly so the job dict
+# isn't authoritative for success.
+_jobs: dict = {}
+
+
+def _submit_build(plan: dict) -> concurrent.futures.Future:
+    """Submit (or join) a background pyramid build for this plan. Dedups
+    within-process: if a job for the same hash is already in flight, returns
+    that future instead of starting a duplicate build."""
+    h = plan["hash"]
+    with _jobs_lock:
+        existing = _jobs.get(h)
+        if existing is not None and not existing["future"].done():
+            return existing["future"]
+
+        def _do_build():
+            build_con = build_tile_connection()
+            try:
+                return build_hex_tiles(build_con, plan)
+            finally:
+                build_con.close()
+
+        future = _build_executor.submit(_do_build)
+        _jobs[h] = {"future": future, "started_at": time.time()}
+        return future
 
 
 # Deliberate API design: only `sql` and `agg` are documented for the LLM.
@@ -314,15 +364,21 @@ def register_hex_tiles(
           numeric value column after the H3 index; each is aggregated by
           `agg` at every coarser level.
 
-    Returns a dict with:
-    - `tile_url_template`: MapLibre vector tile URL with {z}/{x}/{y} placeholders.
-    - `value_columns`: list of output column names available as MVT feature
-      properties. For agg="COUNT" this is ["count"]; otherwise the user's
-      value columns.
-    - `value_stats`: {<col>: {"by_res": {"<res>": {"min": <num>, "max": <num>}}}}.
-      Per-resolution min/max for each value column — pass to the map client.
-    - `layer_name`: the MVT source-layer name; use as `source-layer` in the client.
-    - `hash`, `bounds`, `finest_res`, `feature_count_finest`: tileset metadata.
+    Returns a dict with `status` ∈ {"done", "running", "failed"}:
+    - status="done" (cache hit or fast build): full metadata is included —
+      `tile_url_template` (MapLibre vector tile URL with {z}/{x}/{y}),
+      `value_columns` (MVT feature properties: ["count"] for agg="COUNT",
+      otherwise your value columns), `value_stats` ({<col>: {"by_res":
+      {"<res>": {"min", "max"}}}} for client-side palette domain),
+      `layer_name` (use as `source-layer`), plus `hash`, `bounds`,
+      `finest_res`, `feature_count_finest`.
+    - status="running": pyramid is being built in the background. You get
+      `hash` and `tile_url_template` only. Call `get_hex_tile_status(hash)`
+      to poll. Do NOT retry register_hex_tiles with different parameters —
+      the original build will still finish, and re-submitting queues more
+      work without cancelling the first one.
+    - status="failed": build raised an error inline. `error` field has the
+      exception message. Safe to re-submit with adjusted parameters.
 
     MapLibre usage:
         map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
@@ -353,14 +409,95 @@ def register_hex_tiles(
 
     Always pass hive_partitioning = true so the planner can prune h0=* files.
     """
-    con = _get_tile_con()
-    return _register_hex_tiles(
-        con=con, sql=sql, agg=agg,
+    read_con = _get_tile_con()
+    plan = prepare_hex_tiles(
+        con=read_con, sql=sql, agg=agg,
         finest_res=finest_res, min_res=min_res, zoom_offset=zoom_offset,
     )
+    if plan["cached"] is not None:
+        result = cached_result_dict(plan, plan["cached"])
+        result["status"] = "done"
+        return result
+
+    future = _submit_build(plan)
+    try:
+        result = future.result(timeout=_BUILD_INLINE_WAIT_SECONDS)
+        result["status"] = "done"
+        return result
+    except concurrent.futures.TimeoutError:
+        return {
+            "hash": plan["hash"],
+            "tile_url_template": plan["tile_url_template"],
+            "status": "running",
+        }
+    except Exception as e:
+        return {
+            "hash": plan["hash"],
+            "tile_url_template": plan["tile_url_template"],
+            "status": "failed",
+            "error": str(e),
+        }
 
 
 mcp.tool()(register_hex_tiles)
+
+
+def get_hex_tile_status(hash: str) -> dict:
+    """Poll the status of a pyramid build started by register_hex_tiles.
+
+    Call this when register_hex_tiles returned {status: "running"}. Returns
+    one of:
+    - {hash, tile_url_template, status: "done", bounds, value_stats, ...} —
+      pyramid is on disk and renderable. Use bounds + value_stats with the
+      map client (fit_bounds, palette domain).
+    - {hash, tile_url_template, status: "running", elapsed_seconds} —
+      still building; poll again in a few seconds.
+    - {hash, tile_url_template, status: "failed", error} — build raised.
+      You may re-submit register_hex_tiles with adjusted parameters.
+    - {hash, tile_url_template, status: "unknown"} — no record of this hash
+      in the current server process and no completed tileset on disk. The
+      hash may be for a different server, or the build may never have
+      started. Re-submit register_hex_tiles to (re-)start it.
+
+    Idempotent — safe to call repeatedly. Hash is the value returned by
+    register_hex_tiles.
+    """
+    paths = tile_paths_for_hash(hash)
+    base = {"hash": hash, "tile_url_template": paths["tile_url_template"]}
+
+    cached = read_existing_metadata(_get_tile_con(), paths["output_uri"])
+    if cached is not None and "bounds" in cached and "feature_count_finest" in cached:
+        return {
+            **base,
+            "status": "done",
+            "bounds": cached["bounds"],
+            "finest_res": cached["finest_res"],
+            "min_res": cached["min_res"],
+            "zoom_offset": cached["zoom_offset"],
+            "value_columns": cached["value_columns"],
+            "value_stats": cached["value_stats"],
+            "layer_name": cached.get("layer_name", MVT_LAYER_NAME),
+            "feature_count_finest": cached["feature_count_finest"],
+        }
+
+    with _jobs_lock:
+        job = _jobs.get(hash)
+    if job is None:
+        return {**base, "status": "unknown"}
+    future = job["future"]
+    if future.done():
+        exc = future.exception()
+        if exc is not None:
+            return {**base, "status": "failed", "error": str(exc)}
+        # Future done without exception, but metadata.json wasn't readable
+        # above — race or transient S3 read failure. Re-read may succeed.
+        return {**base, "status": "running",
+                "elapsed_seconds": round(time.time() - job["started_at"], 1)}
+    return {**base, "status": "running",
+            "elapsed_seconds": round(time.time() - job["started_at"], 1)}
+
+
+mcp.tool()(get_hex_tile_status)
 
 
 def mount_tiles(app):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -280,6 +280,172 @@ class TestTileRouteMounted:
         tool_names = [t.name for t in anyio.run(mcp.list_tools)]
         assert "register_hex_tiles" in tool_names
 
+    def test_get_hex_tile_status_is_exposed(self):
+        from server import mcp
+        import anyio
+        tool_names = [t.name for t in anyio.run(mcp.list_tools)]
+        assert "get_hex_tile_status" in tool_names
+
+
+@pytest.fixture
+def isolated_jobs(monkeypatch, tmp_path):
+    """Reset the module-level _jobs dict and point the tile bucket at tmp_path
+    so each test starts with a clean slate and never touches S3."""
+    import server
+    monkeypatch.setenv("TILE_BUCKET_BASE", str(tmp_path / "tiles"))
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "http://test.local")
+    # Reset the shared read connection so it picks up the env on next access.
+    monkeypatch.setattr(server, "_tile_con", None)
+    monkeypatch.setattr(server, "_jobs", {})
+    yield
+
+
+class TestRegisterHexTilesAsync:
+    def test_fast_build_returns_done_inline(self, isolated_jobs, monkeypatch):
+        """A build that finishes within the inline wait returns status=done
+        with full metadata (preserves today's UX for fast jobs)."""
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        result = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        assert result["status"] == "done"
+        assert "bounds" in result
+        assert "value_stats" in result
+        assert result["finest_res"] == 5
+
+    def test_slow_build_returns_running(self, isolated_jobs, monkeypatch):
+        """If the build doesn't finish within the inline wait, the tool
+        returns status=running with hash + tile_url_template so the agent
+        can poll."""
+        import server, tiles.pyramid as pyramid
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 0.05)
+
+        # Make the build phase slow so the inline wait expires.
+        import time
+        orig_build = pyramid.build_hex_tiles
+        def slow_build(con, plan):
+            time.sleep(0.5)
+            return orig_build(con, plan)
+        monkeypatch.setattr(server, "build_hex_tiles", slow_build)
+
+        result = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        assert result["status"] == "running"
+        assert "hash" in result
+        assert "tile_url_template" in result
+
+        # Drain the in-flight future so the test doesn't leak threads.
+        h = result["hash"]
+        server._jobs[h]["future"].result(timeout=10)
+
+    def test_cache_hit_returns_done_with_cache_hit_flag(self, isolated_jobs, monkeypatch):
+        """Second registration with identical args short-circuits via
+        metadata.json — status=done, cache_hit=True, no background job."""
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        first = server.register_hex_tiles(sql=sql, agg="AVG")
+        assert first["status"] == "done"
+
+        # Reset jobs so the second call has no in-flight future to find;
+        # the cache-hit path must work purely from metadata.json on disk.
+        server._jobs.clear()
+        second = server.register_hex_tiles(sql=sql, agg="AVG")
+        assert second["status"] == "done"
+        assert second.get("cache_hit") is True
+
+    def test_concurrent_calls_for_same_hash_dedupe(self, isolated_jobs, monkeypatch):
+        """Two register_hex_tiles calls with identical args while the first
+        is still running should share one background future, not start two
+        builds."""
+        import server, tiles.pyramid as pyramid
+        import threading, time
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 0.05)
+
+        build_calls = []
+        orig_build = pyramid.build_hex_tiles
+        def slow_counting_build(con, plan):
+            build_calls.append(plan["hash"])
+            time.sleep(0.5)
+            return orig_build(con, plan)
+        monkeypatch.setattr(server, "build_hex_tiles", slow_counting_build)
+
+        sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val"
+        r1 = server.register_hex_tiles(sql=sql, agg="AVG")
+        r2 = server.register_hex_tiles(sql=sql, agg="AVG")
+        assert r1["status"] == "running"
+        assert r2["status"] == "running"
+        assert r1["hash"] == r2["hash"]
+
+        # Drain.
+        server._jobs[r1["hash"]]["future"].result(timeout=10)
+        assert len(build_calls) == 1, f"expected one build, got {len(build_calls)}"
+
+
+class TestGetHexTileStatus:
+    def test_unknown_for_unrecognised_hash(self, isolated_jobs):
+        import server
+        result = server.get_hex_tile_status(hash="0000000000000000")
+        assert result["status"] == "unknown"
+        assert result["hash"] == "0000000000000000"
+        assert "tile_url_template" in result
+
+    def test_running_while_job_active(self, isolated_jobs, monkeypatch):
+        import server, tiles.pyramid as pyramid
+        import time
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 0.05)
+        orig_build = pyramid.build_hex_tiles
+        def slow_build(con, plan):
+            time.sleep(0.5)
+            return orig_build(con, plan)
+        monkeypatch.setattr(server, "build_hex_tiles", slow_build)
+
+        sub = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        assert sub["status"] == "running"
+        status = server.get_hex_tile_status(hash=sub["hash"])
+        assert status["status"] == "running"
+        assert "elapsed_seconds" in status
+
+        server._jobs[sub["hash"]]["future"].result(timeout=10)
+
+    def test_done_when_metadata_exists(self, isolated_jobs, monkeypatch):
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        sub = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        assert sub["status"] == "done"
+        status = server.get_hex_tile_status(hash=sub["hash"])
+        assert status["status"] == "done"
+        assert "bounds" in status
+        assert "value_stats" in status
+
+    def test_failed_when_build_raises(self, isolated_jobs, monkeypatch):
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        def boom(con, plan):
+            raise RuntimeError("boom")
+        monkeypatch.setattr(server, "build_hex_tiles", boom)
+
+        result = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        assert result["status"] == "failed"
+        assert "boom" in result["error"]
+
+        status = server.get_hex_tile_status(hash=result["hash"])
+        assert status["status"] == "failed"
+        assert "boom" in status["error"]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -23,9 +23,13 @@ def build_tile_connection() -> duckdb.DuckDBPyConnection:
     # parallel S3 readers / hash-aggregation workers to push Phase 1 of the
     # pyramid build past its previous ~30 MB/s effective S3 read ceiling
     # (the bottleneck observed on the global irrecoverable-carbon build,
-    # which took ~6 min at THREADS=16). Headroom of 16 of the 64-core
-    # CPU limit is left for concurrent tile-serving requests that hit the
-    # same connection while a pyramid build is in flight.
+    # which took ~6 min at THREADS=16). The same setting applies to the
+    # shared read connection (tile-serve GETs + prepare-phase probes); on
+    # that connection the higher thread count is harmless because the
+    # queries are tiny (LIMIT 0 / LIMIT 1, single-tile reads). Pyramid
+    # builds run on their own connections from this factory (see
+    # server._build_executor), so a long-running COPY doesn't block tile
+    # reads.
     con.sql("SET THREADS=48")
     con.sql("SET preserve_insertion_order=false")
     con.sql("SET enable_object_cache=true")

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -165,7 +165,36 @@ def _read_existing_metadata(con: duckdb.DuckDBPyConnection, output_uri: str):
         return None
 
 
-def register_hex_tiles(
+def tile_paths_for_hash(h: str) -> dict:
+    """Return {output_uri, tile_url_template} for a content hash."""
+    return {
+        "output_uri": f"{_bucket_base()}/hex/{h}/",
+        "tile_url_template": f"{_public_base_url()}/tiles/hex/{h}/{{z}}/{{x}}/{{y}}.pbf",
+    }
+
+
+def read_existing_metadata(con: duckdb.DuckDBPyConnection, output_uri: str):
+    """Public alias for _read_existing_metadata — server.py reads this directly."""
+    return _read_existing_metadata(con, output_uri)
+
+
+def cached_result_dict(plan: dict, cached: dict) -> dict:
+    return {
+        "tile_url_template": plan["tile_url_template"],
+        "hash": plan["hash"],
+        "bounds": cached["bounds"],
+        "finest_res": cached["finest_res"],
+        "min_res": cached["min_res"],
+        "zoom_offset": cached["zoom_offset"],
+        "value_columns": cached["value_columns"],
+        "value_stats": cached["value_stats"],
+        "layer_name": cached.get("layer_name", MVT_LAYER_NAME),
+        "feature_count_finest": cached["feature_count_finest"],
+        "cache_hit": True,
+    }
+
+
+def prepare_hex_tiles(
     con: duckdb.DuckDBPyConnection,
     sql: str,
     finest_res: int | None = None,
@@ -173,7 +202,8 @@ def register_hex_tiles(
     agg: str = "AVG",
     zoom_offset: int = -1,
 ) -> dict:
-    """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
+    """Inspect user SQL, resolve finest_res, compute the content hash, and
+    check the S3 cache. Fast — no COPY runs here.
 
     The connection must have httpfs, spatial, and h3 extensions loaded.
 
@@ -189,6 +219,10 @@ def register_hex_tiles(
     - Other aggs: user SQL must return at least one value column after the H3
       index. Each is aggregated via `agg` at every resolution including the finest
       (one row per (h, h0) cell at every level).
+
+    Returns a "plan" dict with everything build_hex_tiles needs, plus a
+    `cached` field that is the persisted metadata if the tileset already
+    exists on disk (otherwise None).
     """
     h3_column, sql_value_columns = _inspect_user_sql(con, sql)
     if finest_res is None:
@@ -208,8 +242,7 @@ def register_hex_tiles(
     if finest_res < min_res:
         raise ValueError(f"finest_res ({finest_res}) must be >= min_res ({min_res})")
 
-    agg_upper = agg.upper()
-    if agg_upper == "COUNT":
+    if agg.upper() == "COUNT":
         value_columns = ["count"]
     else:
         if not sql_value_columns:
@@ -220,28 +253,46 @@ def register_hex_tiles(
         value_columns = sql_value_columns
 
     h = content_hash(sql=sql, finest_res=finest_res, min_res=min_res, agg=agg, zoom_offset=zoom_offset)
-    output_uri = f"{_bucket_base()}/hex/{h}/"
-    tile_url_template = f"{_public_base_url()}/tiles/hex/{h}/{{z}}/{{x}}/{{y}}.pbf"
+    paths = tile_paths_for_hash(h)
+    output_uri = paths["output_uri"]
 
-    # Cache short-circuit: if an identical registration already exists, skip
-    # the COPY (which would re-scan the source) and return the persisted
-    # metadata. Hash is content-addressed, so a hit means the parquet pyramid
-    # on disk reflects exactly this registration's inputs.
     cached = _read_existing_metadata(con, output_uri)
-    if cached is not None and "bounds" in cached and "feature_count_finest" in cached:
-        return {
-            "tile_url_template": tile_url_template,
-            "hash": h,
-            "bounds": cached["bounds"],
-            "finest_res": cached["finest_res"],
-            "min_res": cached["min_res"],
-            "zoom_offset": cached["zoom_offset"],
-            "value_columns": cached["value_columns"],
-            "value_stats": cached["value_stats"],
-            "layer_name": cached.get("layer_name", MVT_LAYER_NAME),
-            "feature_count_finest": cached["feature_count_finest"],
-            "cache_hit": True,
-        }
+    if cached is not None and not ("bounds" in cached and "feature_count_finest" in cached):
+        cached = None  # metadata.json is malformed — treat as miss, will rebuild.
+
+    return {
+        "hash": h,
+        "output_uri": output_uri,
+        "tile_url_template": paths["tile_url_template"],
+        "sql": sql,
+        "agg": agg,
+        "finest_res": finest_res,
+        "min_res": min_res,
+        "zoom_offset": zoom_offset,
+        "h3_column": h3_column,
+        "value_columns": value_columns,
+        "cached": cached,
+    }
+
+
+def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
+    """Run the COPY, compute per-resolution stats and bounds, and write
+    metadata.json. Returns the same shape as register_hex_tiles minus
+    cache_hit (caller decides whether to add that key).
+
+    The connection must have httpfs, spatial, and h3 extensions loaded and
+    SHOULD be exclusive to this build — DuckDB serialises queries on a
+    connection, so sharing a connection with other writers will block them
+    for the duration of the COPY.
+    """
+    sql = plan["sql"]
+    agg = plan["agg"]
+    finest_res = plan["finest_res"]
+    min_res = plan["min_res"]
+    zoom_offset = plan["zoom_offset"]
+    h3_column = plan["h3_column"]
+    value_columns = plan["value_columns"]
+    output_uri = plan["output_uri"]
 
     statements = build_pyramid_statements(
         user_sql=sql,
@@ -257,7 +308,6 @@ def register_hex_tiles(
     for stmt in statements:
         con.sql(stmt)
 
-    # Per-resolution min/max for every output value column.
     def _jsonable(v):
         # DuckDB returns DECIMAL for literal-typed numerics; coerce to float
         # so the metadata sidecar stays JSON-serializable.
@@ -288,9 +338,6 @@ def register_hex_tiles(
     ).fetchone()
     w, s, e, n, feature_count = bounds_row[2], bounds_row[0], bounds_row[3], bounds_row[1], bounds_row[4]
 
-    # bounds + feature_count_finest persisted in metadata.json so the next
-    # registration with identical inputs can short-circuit without
-    # re-aggregating the source data.
     metadata = {
         "finest_res": finest_res,
         "min_res": min_res,
@@ -309,8 +356,8 @@ def register_hex_tiles(
     con.sql(metadata_sql)
 
     return {
-        "tile_url_template": tile_url_template,
-        "hash": h,
+        "tile_url_template": plan["tile_url_template"],
+        "hash": plan["hash"],
         "bounds": [w, s, e, n],
         "finest_res": finest_res,
         "min_res": min_res,
@@ -320,3 +367,40 @@ def register_hex_tiles(
         "layer_name": MVT_LAYER_NAME,
         "feature_count_finest": feature_count,
     }
+
+
+def register_hex_tiles(
+    con: duckdb.DuckDBPyConnection,
+    sql: str,
+    finest_res: int | None = None,
+    min_res: int = 2,
+    agg: str = "AVG",
+    zoom_offset: int = -1,
+) -> dict:
+    """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
+
+    Synchronous: prepare → (cached return | full build) on the calling thread.
+    The MCP server wraps this with a background-executor pattern so the agent
+    sees a quick "running" response on long jobs; library callers (tests,
+    REPL) keep the simple sync semantics.
+
+    The connection must have httpfs, spatial, and h3 extensions loaded.
+
+    When finest_res is None (the LLM-facing path), it's auto-detected from the
+    H3 column's actual resolution via h3_get_resolution on a one-row probe.
+
+    Value-column contract:
+    - agg="COUNT": user SQL needs only the H3 index column. Output has a single
+      `count` column (row count per hex at parent resolutions; 1 at finest).
+      Any extra columns in the user SQL are ignored.
+    - Other aggs: user SQL must return at least one value column after the H3
+      index. Each is aggregated via `agg` at parent resolutions and passed
+      through raw at the finest level.
+    """
+    plan = prepare_hex_tiles(
+        con=con, sql=sql, finest_res=finest_res,
+        min_res=min_res, agg=agg, zoom_offset=zoom_offset,
+    )
+    if plan["cached"] is not None:
+        return cached_result_dict(plan, plan["cached"])
+    return build_hex_tiles(con, plan)


### PR DESCRIPTION
## Summary

`register_hex_tiles` is now a fire-and-poll API. When a build finishes within the inline wait window (default 5 s) the response is identical to today's; longer builds return `status: \"running\"` with a hash, and the agent calls the new `get_hex_tile_status(hash)` tool to claim the result when ready. Per-job DuckDB connections decouple pyramid builds from each other and from tile-serve reads.

Fixes #141 and #142.

## Background

On 2026-05-12 the padus app asked for a global GBIF species-richness pyramid. The agent submitted h6, h5, h3 in sequence:

- h6 returned `MCP error -32001: Request timed out` at the client, but the COPY ran to completion 8 min later — `s3://public-output/hex/75ff2fb412fa2851/` exists with full metadata.json. The agent never found out.
- h5 was queued behind h6 on the shared `_tile_con` and produced no S3 output (cancelled by the time the connection freed up).
- h3 finally ran and succeeded after h6 released the connection.

Two structural issues: client-timeout → orphan work, and single-connection serialisation → queued retries that compete with the original job.

## Changes

**`tiles/pyramid.py`** — split the monolithic `register_hex_tiles` internals:
- `prepare_hex_tiles(con, sql, agg, ...)` — H3 probe, hash compute, cache check. Fast.
- `build_hex_tiles(con, plan)` — runs the COPY, value_stats, bounds, metadata.json write. Slow.
- `register_hex_tiles(con, sql, ...)` — orchestrator. Public sync API unchanged; tests + REPL keep working.
- New public helpers `tile_paths_for_hash(h)`, `read_existing_metadata`, `cached_result_dict` for server.py to compose.

**`server.py`** — async wrapping at the MCP layer:
- `_build_executor`: bounded `ThreadPoolExecutor` (default 2 concurrent builds, env `TILE_BUILD_MAX_CONCURRENCY`).
- `_jobs`: in-process dict tracking active futures by hash; `_submit_build` dedupes concurrent calls for the same hash.
- `register_hex_tiles` tool: prepare on shared read connection → if cached, return `done` immediately → else `_submit_build` with a **fresh** `build_tile_connection()` and `future.result(timeout=5)`. Returns `done` / `running` / `failed` (with `error`).
- New `get_hex_tile_status(hash)` tool: reads metadata.json from S3 for `done`; falls back to the in-process job dict for `running` / `failed`; `unknown` if neither.

**`tiles/db.py`** — comment fix: the shared connection is for reads only now; pyramid builds use their own.

## Configuration

| Env var | Default | Meaning |
|---|---|---|
| `TILE_BUILD_MAX_CONCURRENCY` | 2 | Max concurrent pyramid builds. |
| `TILE_BUILD_INLINE_WAIT_SECONDS` | 5 | How long `register_hex_tiles` blocks for a fast finish before returning `running`. |

## Agent-facing contract change

`register_hex_tiles` returns either `status: \"done\"` (full metadata) or `status: \"running\"` (hash + tile_url_template only). Geo-agent will need to handle the `running` case by calling `get_hex_tile_status(hash)` and waiting for `done` before passing bounds / value_stats to the map. Filing a paired issue in `boettiger-lab/geo-agent` for that change.

## Test plan

- [x] 171 existing unit tests pass unchanged
- [x] New tests in `tests/test_server.py`:
  - `test_fast_build_returns_done_inline` — backwards-compat for fast jobs
  - `test_slow_build_returns_running` — new running-status path
  - `test_cache_hit_returns_done_with_cache_hit_flag` — cache short-circuit still works
  - `test_concurrent_calls_for_same_hash_dedupe` — two concurrent calls share one future, build runs once
  - `test_unknown_for_unrecognised_hash` — get_hex_tile_status edge case
  - `test_running_while_job_active`, `test_done_when_metadata_exists`, `test_failed_when_build_raises`
- [ ] Deploy to `dev-duckdb-mcp` and re-run the global GBIF species-count case from 2026-05-12; verify register returns `running` quickly and `get_hex_tile_status` eventually returns `done`
- [ ] Verify tile-serve GETs aren't blocked while a pyramid build is in progress (companion check on #142)