### PR TITLE
k8s: bump prod to v0.6.4 (async pyramid builds + long-poll status)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.6.3 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.4 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
Bumps prod `duckdb-mcp` from v0.6.3 → v0.6.4. Covers:

- #143 — async pyramid builds with per-job connection + `get_hex_tile_status` tool
- #144 — long-poll `wait_seconds` on `get_hex_tile_status`

Verified on dev via the headless geo-agent runner against the original failure case (padus, global GBIF species count at h6): build completes (3:54), agent polls 8 times at 30–60 s each, ends with a successful `add_hex_tile_layer` call. End-to-end UX is now: no client timeouts, no retry storms, no orphaned builds.

Tag `v0.6.4` already pushed.

## Post-merge

```bash
kubectl apply -f k8s/deployment.yaml
kubectl -n biodiversity rollout status deployment/duckdb-mcp
```