### PR TITLE
k8s: dev to 2 replicas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Do **not** `git pull` on `main` when local `main` has commits matching the just-
 The MCP server runs on the NRP Nautilus Kubernetes cluster.
 
 - **Prod:** `https://duckdb-mcp.nrp-nautilus.io` — 2 replicas, `k8s/deployment.yaml`
-- **Dev:** `https://dev-duckdb-mcp.nrp-nautilus.io` — 1 replica, `k8s/dev-deployment.yaml`
+- **Dev:** `https://dev-duckdb-mcp.nrp-nautilus.io` — 2 replicas, `k8s/dev-deployment.yaml` (must stay ≥2 so cross-pod bugs surface here before prod)
 - **Resources:** 16 Gi RAM requested, up to 160 Gi / 16 CPU per pod
 - **STAC catalog:** `https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json` (set via `STAC_CATALOG_URL` env var)
 - **Ingress:** HAProxy with CORS enabled, 10-minute query timeout, 1-hour SSE tunnel timeout

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dev-duckdb-mcp
   namespace: biodiversity
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: dev-duckdb-mcp


### PR DESCRIPTION
## Summary
Bump dev to 2 replicas so multi-pod bugs surface here before reaching prod. Today's hex-tile cross-pod bug (PR #146) would have been caught here, not in prod's 6-replica deployment.

Also flag in AGENTS.md that ≥2 is a hard requirement for dev, not a tuning choice.

## Test plan
- [ ] Merge → `kubectl apply -f k8s/dev-deployment.yaml -n biodiversity`
- [ ] `kubectl -n biodiversity rollout restart deployment/dev-duckdb-mcp` so both pods pull current main (which already includes the PR #146 fix)
- [ ] Reproduce the original bug scenario against dev (hex-tile build that takes >5s, multiple status polls) and confirm no `status: unknown` between register and done