### PR TITLE
k8s: bump prod to v0.6.5 (cross-pod state for hex tile builds)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.6.4 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.5 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
## Summary
Points prod's `git clone --branch` to `v0.6.5`, which includes the cross-pod state fix from #146 (S3-shared lock.json / failed.json markers, cross-pod dedup in register, S3 long-poll fallback in status).

Verified on dev (2 replicas, post-#147): heavy build (genus=Lynx global, ~140s) returned `running` consistently across 6 rapid `wait_seconds=0` polls — no `unknown`. Pre-fix, ~half would have returned `unknown`. Full sequence completed with `done` from a final long-poll.

## Rollout plan after merge
```
kubectl apply -f k8s/deployment.yaml -n biodiversity
kubectl -n biodiversity rollout restart deployment/duckdb-mcp
```

## Test plan
- [x] dev (2 replicas) — verified register + 6 polls + long-poll round-trip returns running/done with no unknown
- [ ] After prod rollout: re-run the wyoming-public-demo "elk and bear sightings as hexes" prompt and confirm no `status: unknown` interruptions in open-llm-proxy logs