### PR TITLE
k8s: bump prod to v0.6.6 (WDPA URL fix)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.6.5 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.6 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
## Summary
- Pin prod to `v0.6.6` so the MCP tool description serves the corrected `public-wdpa/wdpa-december-2025/...` path (fix from #150).

## Test plan
- [ ] Merge → kubectl apply + rollout restart → grep server.py in prod pod for new path