### PR TITLE
h3-guide: line-hex pattern + preload spatial + AGENTS.md no-❌ rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ It has no memory between requests. Its only context is what is injected at call 
 **Files it reads (injected as prompts):**
 - `query-setup.md` — required DuckDB setup SQL, must run before every query
 - `query-optimization.md` — short, actionable query-writing rules
+- `h3-guide.md` — H3 hex data model and per-problem patterns (tiling, overlap, raster, lines)
 - `datasets.md` — STAC catalog summary, dataset paths, column schemas
 - `assistant-role.md` — role and response style instructions
 
@@ -74,7 +75,9 @@ It has no memory between requests. Its only context is what is injected at call 
 - Instructions must be short, concrete, and unambiguous
 - No debugging advice, no explanation of DuckDB internals, no "check X before Y"
 - No meta-commentary about why rules exist — just the rules
-- Every example must be a correct, copy-pasteable query
+- **Every SQL example must be the correct shape. Never include ❌ / antipattern SQL blocks** — small LLMs reproduce the structure verbatim (variable names, CTE shape) regardless of the ❌ marker. Negation priming overrides the marker. State the rule in prose; show only the correct query. See PR #134 / Issue #133 for measured 2× reduction in antipattern rate after removing ❌ blocks.
+- Prefer positive framing in bullets: "Do X first, then Y" beats "❌ Don't Y before X". Existing prose "Never X" rules without SQL bodies can stay — the hazard is SQL antipatterns, not the word "never."
+- When adding guidance for a niche case (e.g., line datasets when most datasets are polygons), keep it short and gate with a "Skip if your dataset is X" header so models doing the common case skim past. Niche fixes must not displace attention from the dominant workload.
 
 ---
 
@@ -105,13 +108,30 @@ instructions.
 
 ---
 
-## Failure mode to avoid
+## Failure modes to avoid
 
-In March 2026, a small LLM generated a query omitting h0 from a join (violating the
-rule in `query-optimization.md`). The resulting slow query was diagnosed as "S3 DPP
-is broken" rather than "the query violated the h0-in-join rule." Hours of investigation
-followed, producing `optimization-design-notes.md` content that incorrectly characterized
-the rule as wrong. A subsequent Claude session read those notes and tried to remove the
+### Misdiagnosing a rule-violation as an infrastructure bug (March 2026)
+
+A small LLM generated a query omitting h0 from a join (violating the rule in
+`query-optimization.md`). The resulting slow query was diagnosed as "S3 DPP is broken"
+rather than "the query violated the h0-in-join rule." Hours of investigation followed,
+producing `optimization-design-notes.md` content that incorrectly characterized the
+rule as wrong. A subsequent Claude session read those notes and tried to remove the
 correct rule from `query-optimization.md`.
 
-The fix is this document: keep the two processes and their files clearly separated.
+The fix is this document: keep the two processes and their files clearly separated, and
+diagnose rule violations before infrastructure.
+
+### ❌ examples in prompts get reproduced verbatim (May 2026)
+
+Baseline matrix runs (issue #133) showed small LLMs reproducing the ❌-marked DPP
+antipattern CTE — same variable names, same shape — at a 50% first-query rate.
+The ❌ marker did not suppress reuse; if anything the named, copy-pasteable SQL
+primed it. PR #134 removed the ❌ blocks and hoisted the rule into the CRITICAL
+SQL RULES header, halving the antipattern rate.
+
+When extending the prompt artifacts (e.g., adding a new "Problem N" section to
+`h3-guide.md`), the temptation to mirror the structure of the existing problems —
+which already showed ❌/✅ pairs — is high. Resist it. Even on guidance covering a
+new failure mode (lines, sparse rasters, etc.), include only the ✅ form. Past sections
+that still carry ❌ blocks are the next thing to migrate, not a pattern to copy.

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -3,7 +3,7 @@
 **Most datasets have H3 hex versions.** Always use them for spatial operations instead of GeoParquet geometry columns.
 
 **Always use H3 hex datasets for filtering and joining — never spatial predicates on GeoParquet.**
-When a dataset appears in the STAC catalog as GeoParquet, a hex-indexed version almost always exists alongside it. Find and use the hex version. Never use `ST_Within`, `ST_Intersects`, `ST_Contains`, or similar predicates to filter or join large datasets — on global data these run 10+ minutes and return nothing useful.
+When a dataset appears in the STAC catalog as GeoParquet, a hex-indexed version almost always exists alongside it. Find and use the hex version. Never use `ST_Within`, `ST_Intersects`, `ST_Contains`, or similar predicates to filter or join large datasets — on global data these run 10+ minutes and return nothing useful. (Narrow exception: line datasets where exact mileage at AOI boundaries is required — see Problem 4.)
 
 If you browse the catalog and only find a GeoParquet with no hex equivalent, **say so** rather than falling back to spatial predicates. A missing hex version is a data pipeline gap (not something to work around silently).
 
@@ -29,7 +29,7 @@ All spatial operations are hex joins — two datasets overlap wherever their hex
 
 - Always report **areas** (km², acres, etc.), never raw hex counts
 - For nationwide/global aggregates over millions of cells, `APPROX_COUNT_DISTINCT(hN)` is fast and accurate to ~1–2%. For per-group breakdowns (per-state, per-class, per-county, per-district) where each group has fewer than ~1M distinct cells, use `COUNT(DISTINCT hN)` instead — DuckDB's HLL error grows steeply at smaller cardinalities and compounds inside `GROUP BY` (real-world per-group errors of +30% have been observed). Total scan size matters less than per-group cell count.
-- **Never SUM area columns** (ACRES, GIS_Acres, area_ha, etc.) on hex data. These store the source polygon's total area repeated on every hex row. `SUM(ACRES)` = polygon_area × num_hex_cells — wrong by 10³–10⁶×. Always compute area from hex cells instead. Note: `DISTINCT` deduplication removes duplicate rows for the same feature but does not resolve overlapping features — two features covering the same ground still sum their acreages independently. Counting distinct hex cells × `area_per_cell` is the only method immune to this, since it counts physical cells rather than feature declarations (see the previous bullet for `APPROX` vs exact `COUNT DISTINCT`).
+- **Never SUM area columns** (ACRES, GIS_Acres, area_ha, etc.) on hex data. These store the source polygon's total area repeated on every hex row. `SUM(ACRES)` = polygon_area × num_hex_cells — wrong by 10³–10⁶×. Always compute area from hex cells instead. Note: `DISTINCT` deduplication removes duplicate rows for the same feature but does not resolve overlapping features — two features covering the same ground still sum their acreages independently. Counting distinct hex cells × `area_per_cell` is the only method immune to this, since it counts physical cells rather than feature declarations (see the previous bullet for `APPROX` vs exact `COUNT DISTINCT`). The same row-replication problem applies to `length_*` columns on line hex at smaller scale — see Problem 4.
 
 ## Area Conversion
 
@@ -113,9 +113,9 @@ JOIN gfw ON h3_cell_to_parent(wdpa.h8, 6) = gfw.h6
 
 When one side lacks h0, omit it from that side. Prefer hex-partitioned variants (with h0) when available for partition pruning.
 
-## Multiple Rows per Hex: Three Different Problems
+## Multiple Rows per Hex: Four Different Problems
 
-There are **three distinct reasons** a dataset can have multiple rows with the same `h8` value, and they require different fixes:
+There are **four distinct reasons** a dataset can have multiple rows with the same `h8` value, and they require different fixes:
 
 ---
 
@@ -236,6 +236,28 @@ GROUP BY a.h8;
 
 ---
 
+### Problem 4 — Lines: per-segment columns and AOI boundaries
+
+*(Applies only to line-derived hex: source geometry is `LineString`/`MultiLineString`, columns like `length_miles`, `length_km`. Skip if your dataset has area/acres columns or is raster-derived.)*
+
+Each segment tiles into ~2–6 hex rows at h8, with per-segment values (length, owner, agency) repeated on every row.
+
+- **Sum `length_*` only after deduplicating by feature** — apply the Problem 1 pattern: `SELECT DISTINCT _cng_fid, length_miles, ...` first, then `SUM`. Per-segment attributes are repeated on every hex row the segment occupies.
+- **For segment counts or presence ("which trails cross this AOI"), use the hex SEMI JOIN with `COUNT(DISTINCT _cng_fid)`** — fast and accurate.
+- **For mileage *inside* an AOI (state, county, fire perimeter), use the GeoParquet**, not a hex JOIN. A hex match tells you *which* segments touch the AOI; the segment's full length is carried on every hex row, so summing through the JOIN credits each segment's whole length to every AOI it touches. Compute the intersected length directly:
+
+```sql
+SELECT p.STUSPS, SUM(ST_Length(ST_Intersection(t.geom, p.geom)) / 1609.344) AS miles
+FROM read_parquet('<line_geoparquet>') t
+JOIN read_parquet('<aoi_geoparquet>') p
+  ON ST_Intersects(t.geom, p.geom)
+GROUP BY p.STUSPS
+```
+
+For large AOI sets (counties, tracts, fire perimeters), pre-filter with a hex `SEMI JOIN` on `_cng_fid` to a candidate list, then run `ST_Intersection` on the GeoParquet for those candidates only.
+
+---
+
 ### Diagnostic: check rows-per-hex before writing queries
 
 When uncertain, run this check on a single h0 partition first:
@@ -251,7 +273,7 @@ FROM read_parquet('<STAC_HEX_PATH_SINGLE_PARTITION>');
 | avg_rows_per_hex | Meaning |
 |---|---|
 | ≈ 1 | One row per hex — check `_cng_fid` presence; if vector, tiling dedup still applies to attribute sums |
-| > 1, integer-ish | Overlapping polygons — use DISTINCT |
+| > 1, integer-ish | Overlapping polygons — use DISTINCT (or Problem 4 if `length_*` columns / no area columns) |
 | >> 1, non-integer | Raster pixels — use GROUP BY + SUM/AVG/MODE |
 
 ## Generating Output Files

--- a/query-setup.md
+++ b/query-setup.md
@@ -9,6 +9,7 @@ SET enable_object_cache=true;
 SET temp_directory='/tmp';
 INSTALL httpfs; LOAD httpfs;
 INSTALL h3 FROM community; LOAD h3;
+INSTALL spatial; LOAD spatial;
 CREATE OR REPLACE SECRET s3 (TYPE S3, ENDPOINT 'rook-ceph-rgw-nautiluss3.rook', URL_STYLE 'path', USE_SSL 'false', KEY_ID '', SECRET '');
 ```
 
@@ -19,6 +20,7 @@ CREATE OR REPLACE SECRET s3 (TYPE S3, ENDPOINT 'rook-ceph-rgw-nautiluss3.rook', 
 - `enable_object_cache=true` - Reduces S3 requests
 - `httpfs` - Required for S3 access
 - `h3` - Required for H3 functions
+- `spatial` - Required for `ST_*` functions (line-data exact mileage, GeoParquet inspection)
 
 **Note:** `rook-ceph-rgw-nautiluss3.rook` is an internal endpoint that only your tool running on k8s can access. The publicly accessible external endpoint is `s3-west.nrp-nautilus.io`, which requires `USE_SSL true` and `SET THREADS=2`. Always use the internal endpoint to run queries.
 


### PR DESCRIPTION
## Summary

Fixes #152.

- **`h3-guide.md`**: new Problem 4 covering line-derived hex (`length_*` columns, AOI-boundary mileage). Written in positive-only framing — three "do X" bullets, one ✅-only SQL block showing the `ST_Intersection` recipe. Section is gated with a "Skip if your dataset is X" header so polygon-focused queries can skim past. Two minor edits in the polygon guidance: a narrow exception in the no-spatial-predicates rule pointing to Problem 4, and a one-line pointer from the polygon `Never SUM area columns` bullet.
- **`query-setup.md`**: preload `spatial` alongside `httpfs` and `h3` so `ST_*` functions are ready on first call (no first-call error → retry round trip the LLM has to absorb).
- **`AGENTS.md`**: codify the lesson from PR #134 / issue #133 so future Claude sessions don't reintroduce ❌ SQL blocks when extending these prompt artifacts.
  - Three new "Rules for editing these files" bullets: no ❌ SQL blocks (with PR/issue cite); prefer positive bullet framing; gate niche-case guidance with a Skip header.
  - Second "Failure modes to avoid" entry mirroring the existing March 2026 format, noting that Problems 1–2 still carry legacy ❌ blocks (migration backlog, not template).
  - `h3-guide.md` added to Process 1's file list (was missing despite being injected into the tool docstring).

## Why no ❌ blocks

Per the measured baseline in #133, small LLMs reproduce ❌-marked CTEs verbatim (variable names + structure) — the marker primes reuse rather than suppressing it. PR #134 removed the DPP ❌ blocks from Problem 3 and the parallel one in `query-optimization.md`, halving the antipattern rate. New guidance must follow the same discipline.

## Test plan

- [x] `pytest tests/` — 218 passed
- [x] Parsed `query-setup.md` setup SQL executes cleanly in a fresh `:memory:` connection; `ST_Length(ST_GeomFromText(...))` works after the new `LOAD spatial`
- [ ] Smoke-test against a line-data question (`federal-trails-2026`) on dev: verify the model picks the mileage recipe and produces the correct state ranking (CA > MT) instead of the boundary-overcounted hex-JOIN ranking (MT > CA)