### PR TITLE
docs: document the stateless MCP transport prominently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,18 @@ The MCP server runs on the NRP Nautilus Kubernetes cluster.
 - **STAC catalog:** `https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json` (set via `STAC_CATALOG_URL` env var)
 - **Ingress:** HAProxy with CORS enabled, 10-minute query timeout, 1-hour SSE tunnel timeout
 
+### MCP transport: stateless HTTP
+
+The server runs FastMCP in **stateless streamable-HTTP mode** (`server.py`: `FastMCP(..., stateless_http=True)`). Every `POST /mcp` is a complete, independent request/response. There is no `Mcp-Session-Id` pinning clients to a replica, no per-pod session cache, no in-memory state that survives across requests. The protocol's stateful SSE mode is **not** in use here.
+
+This is intentional and load-bearing. Several things depend on it:
+
+- The Service has `sessionAffinity: None` and the ingress uses `balance-algorithm: leastconn`. Both rely on the stateless premise — replicas are interchangeable on a per-request basis.
+- Each query runs in a fresh `duckdb.connect(":memory:")` (the Isolation Engine, `server.py` §4). No connection, credential, or DuckDB state survives between requests.
+- Durable cross-pod state for genuinely persistent artifacts (e.g. hex tile pyramid build markers, PRs #146–#148) lives in **S3** markers, not pod memory, for exactly this reason.
+
+**Do not** introduce per-pod in-memory caches keyed on something the client provides expecting the same pod will see the next request — under stateless HTTP it almost certainly won't, and even if it did once, scaling up replicas or a single rollout breaks the assumption silently.
+
 ### Rollout workflow
 
 **Merge to `main` → redeploy dev only:**

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ Editing these files changes what the agent is told to do. They must be written f
 
 ### Key Design Patterns
 
-1. **Isolation Engine**: Each query runs in a fresh `duckdb.connect(":memory:")` — no state or credentials survive between requests
-2. **Context Injection**: Prompt files are embedded into tool descriptions so even MCP clients that don't support `prompts/list` receive the guidance
-3. **Partition Pruning**: H3 resolution columns (`h0`) enable DuckDB to skip S3 partitions, giving 5–20× speedups on large datasets
+1. **Stateless transport**: FastMCP runs in stateless streamable-HTTP mode (`stateless_http=True` in `server.py`). Every `POST /mcp` is a complete, independent request/response — no `Mcp-Session-Id`, no per-pod session cache, no in-memory state that survives across requests. Replicas behind the load balancer are interchangeable on a per-request basis. (The protocol's stateful SSE mode is not used.)
+2. **Isolation Engine**: Each query runs in a fresh `duckdb.connect(":memory:")` — no DuckDB connection, credential, or query state survives between requests
+3. **Context Injection**: Prompt files are embedded into tool descriptions so even MCP clients that don't support `prompts/list` receive the guidance
+4. **Partition Pruning**: H3 resolution columns (`h0`) enable DuckDB to skip S3 partitions, giving 5–20× speedups on large datasets
 
 ## Kubernetes Deployment
 


### PR DESCRIPTION
The server runs FastMCP with \`stateless_http=True\` in \`server.py\`. This is intentional and load-bearing, but easy to miss looking only at deployment topology — during a recent incident I speculated about \`Mcp-Session-Id\` pinning that doesn't exist here, before the user pointed me to the source code.

## What this PR adds

**AGENTS.md** — new "MCP transport: stateless HTTP" subsection in the Deployment block. Calls out:
- \`POST /mcp\` is a complete request/response, no session-id, no per-pod state.
- The stateful SSE mode is **not** in use here.
- Several things depend on this: \`sessionAffinity: None\` on the Service, \`balance-algorithm: leastconn\` on the ingress, the Isolation Engine, and the S3-marker cross-pod state pattern established in PRs #146–#148.
- **Do not** introduce per-pod in-memory caches keyed on client-provided identifiers.

**README.md** — lifted stateless transport to the first item under "Key Design Patterns" so it's prominent for anyone reading the architecture section. Isolation Engine becomes the second item; the two are closely related (neither leaves state behind).

## Why now

This came up in an incident where a single bad query saturated one of two replicas. Claude (me) initially attributed the user-visible "MCP not responding" to session pinning, which is the standard MCP failure mode in stateful HTTP / SSE mode but is **not** how this server runs. The actual failure was at the load balancer (HAProxy \`leastconn\` doesn't distinguish a wedged backend from an idle one because it counts TCP connections, not request-readiness). Documenting the stateless premise prominently makes that misdiagnosis less likely the next time.