### PR TITLE
k8s: /healthz endpoint + httpGet readiness/liveness probes

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -47,10 +47,29 @@ spec:
             cpu: 64
         ports:
         - containerPort: 8000
+        # Probes exercise an actual HTTP request (GET /healthz) rather than a
+        # bare TCP accept. Under a TCP-only probe a pod whose uvicorn event loop
+        # is starved (e.g. by a runaway DuckDB query saturating CPU/memory) still
+        # passes — the kernel accepts the connection regardless of whether the
+        # app writes a response — and HAProxy keeps routing ~50% of traffic to a
+        # wedged backend. See issue #157.
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /healthz
             port: 8000
           initialDelaySeconds: 15
           periodSeconds: 5
-          failureThreshold: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+        # Liveness restarts a chronically wedged pod (3 minutes of unresponsive
+        # /healthz). Longer than readiness so a temporarily slow pod gets pulled
+        # from the Service first; only a deeply stuck one is killed.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6
 

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -47,9 +47,28 @@ spec:
             cpu: 64
         ports:
         - containerPort: 8000
+        # Probes exercise an actual HTTP request (GET /healthz) rather than a
+        # bare TCP accept. Under a TCP-only probe a pod whose uvicorn event loop
+        # is starved (e.g. by a runaway DuckDB query saturating CPU/memory) still
+        # passes — the kernel accepts the connection regardless of whether the
+        # app writes a response — and HAProxy keeps routing ~50% of traffic to a
+        # wedged backend. See issue #157.
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /healthz
             port: 8000
           initialDelaySeconds: 15
           periodSeconds: 5
-          failureThreshold: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+        # Liveness restarts a chronically wedged pod (3 minutes of unresponsive
+        # /healthz). Longer than readiness so a temporarily slow pod gets pulled
+        # from the Service first; only a deeply stuck one is killed.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6

--- a/server.py
+++ b/server.py
@@ -619,11 +619,22 @@ _MCP_AUTH_TOKEN = os.environ.get("MCP_AUTH_TOKEN", "").strip()
 
 class _BearerAuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
+        # /healthz must remain reachable to the kubelet probe even with auth on.
+        if request.url.path == "/healthz":
+            return await call_next(request)
         auth = request.headers.get("Authorization", "")
         supplied = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
         if not hmac.compare_digest(supplied.encode(), _MCP_AUTH_TOKEN.encode()):
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
         return await call_next(request)
+
+
+async def _healthz(_request):
+    # Async, no executor work — fails fast if uvicorn's event loop is starved
+    # (e.g. a runaway DuckDB query saturating CPU/memory on the pod). That's the
+    # signal we want: a wedged pod becomes NotReady within ~15s and HAProxy
+    # stops routing to it. See issue #157.
+    return JSONResponse({"ok": True})
 
 # -------------------------------------------------------------------------
 # 10. SERVER START
@@ -645,6 +656,7 @@ if __name__ == "__main__":
     app = mcp.streamable_http_app()
     app.router.redirect_slashes = False
     mount_tiles(app)
+    app.add_route("/healthz", _healthz, methods=["GET"])
 
     if _MCP_AUTH_TOKEN:
         app.add_middleware(_BearerAuthMiddleware)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -287,6 +287,57 @@ class TestTileRouteMounted:
         assert "get_hex_tile_status" in tool_names
 
 
+class TestHealthz:
+    """The /healthz endpoint is the kubelet probe target (see issue #157).
+    Replaces a TCP-only probe so a wedged uvicorn event loop fails fast."""
+
+    def _build_app(self, with_auth_middleware=False):
+        from server import mcp, _healthz, _BearerAuthMiddleware, mount_tiles
+        app = mcp.streamable_http_app()
+        app.router.redirect_slashes = False
+        mount_tiles(app)
+        app.add_route("/healthz", _healthz, methods=["GET"])
+        if with_auth_middleware:
+            app.add_middleware(_BearerAuthMiddleware)
+        return app
+
+    def test_healthz_route_registered(self):
+        """After app construction, /healthz appears in the route table."""
+        app = self._build_app()
+        paths = [getattr(r, "path", None) for r in app.routes]
+        assert "/healthz" in paths
+
+    def test_healthz_returns_ok_fast(self):
+        """GET /healthz returns 200 with {"ok": true}. Async handler does no I/O
+        and no executor work — fails only if the event loop itself is starved."""
+        from starlette.testclient import TestClient
+        client = TestClient(self._build_app())
+        r = client.get("/healthz")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+    def test_healthz_bypasses_auth_middleware(self):
+        """When MCP_AUTH_TOKEN is set, the kubelet still needs to probe — but the
+        kubelet doesn't carry the token. The middleware must let /healthz through
+        unauthenticated. If a future edit drops the path bypass, this test fails."""
+        import server
+        from starlette.testclient import TestClient
+        original = server._MCP_AUTH_TOKEN
+        server._MCP_AUTH_TOKEN = "test-token"
+        try:
+            client = TestClient(self._build_app(with_auth_middleware=True))
+            # /healthz works with no auth header.
+            r = client.get("/healthz")
+            assert r.status_code == 200, r.text
+            assert r.json() == {"ok": True}
+            # /mcp without a valid token is rejected — confirms the middleware
+            # IS installed and gating other paths.
+            r2 = client.post("/mcp", json={"jsonrpc": "2.0", "method": "ping", "id": 1})
+            assert r2.status_code == 401
+        finally:
+            server._MCP_AUTH_TOKEN = original
+
+
 @pytest.fixture
 def isolated_jobs(monkeypatch, tmp_path):
     """Reset the module-level _jobs dict and point the tile bucket at tmp_path


### PR DESCRIPTION
Fixes #157.

## Why

During the 2026-05-29 incident, one runaway DuckDB query saturated a pod (~40 cores / 67 GiB), and the app appeared completely broken — even though the second replica was sitting idle. The TCP-only readiness probe passed regardless of whether uvicorn could respond, so the wedged pod stayed in the Service endpoints and HAProxy's \`leastconn\` balanced ~50% of new connections to it. Clients timed out at random.

5-probe trace from the incident:
\`\`\`
probe1: HTTP 000  15.001s   ← TIMEOUT
probe2: HTTP 200   0.117s
probe3: HTTP 000  15.002s   ← TIMEOUT
probe4: HTTP 200   0.123s
probe5: HTTP 000  15.002s   ← TIMEOUT
\`\`\`

## What this PR adds

- **\`server.py\`**: tiny async \`_healthz\` handler returning \`{\"ok\": true}\`, registered as \`GET /healthz\` on the Starlette app after \`mount_tiles(app)\`. The handler does no I/O and no executor work, so it succeeds only when the event loop is responsive — exactly the property the probe should verify.
- **\`_BearerAuthMiddleware\`**: bypass for \`/healthz\` so the kubelet probe works when \`MCP_AUTH_TOKEN\` is set. Current deployments don't set the token, but the bypass keeps the probe correct under any future auth config.
- **\`k8s/deployment.yaml\` and \`k8s/dev-deployment.yaml\`**:
  - Readiness probe: \`tcpSocket\` → \`httpGet /healthz\`, \`timeoutSeconds: 2\`, \`failureThreshold: 3\` (so a wedged pod is pulled from the Service within ~15s).
  - **New livenessProbe**: \`failureThreshold: 6 × periodSeconds: 30 = 3 min\` of unresponsive \`/healthz\` → pod restart. Readiness pulls slow pods from the Service; liveness recycles chronically wedged ones.

## What this PR explicitly does **not** do

Per discussion on #157: pod resource limits stay at \`cpu: 64, memory: 160Gi\` (we want bursting). No per-query DuckDB \`memory_limit\` either. This PR is purely the load-balancer-level fix.

The deeper \"stop button doesn't stop the server\" gap (client cancellation → \`connection.interrupt()\`) is also out of scope here — its own issue.

## Test plan

- [x] \`pytest tests/\` → 221/221 pass (218 existing + 3 new \`TestHealthz\`)
- [x] \`TestHealthz::test_healthz_bypasses_auth_middleware\` guards against a future edit silently re-gating \`/healthz\` under auth
- [ ] After merge + dev rollout: run a deliberately heavy query that wedges one pod, verify the second pod stays serving and the wedged one is pulled from the Service within ~15s (visible via \`kubectl -n biodiversity get pods\` showing \`READY 0/1\` on the wedged pod; \`kubectl -n biodiversity get endpoints dev-mcp-server-duckdb\` should show only the healthy pod's IP)
- [ ] Verify the liveness probe restarts the wedged pod after ~3 min of being unresponsive (RESTARTS count increments)