### PR TITLE
k8s: bump prod to v0.6.7 (/healthz probes) + document pin-then-apply release step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@ kubectl apply -f k8s/deployment.yaml
 kubectl rollout restart deployment/duckdb-mcp -n biodiversity
 ```
 
+Prod clones a pinned tag, so a release is two steps: **first** bump the `--branch vX.Y.Z`
+pin in `k8s/deployment.yaml` to the new tag (separate commit, as in #151), **then** apply.
+Never `kubectl apply -f k8s/deployment.yaml` to prod while the pin still points at the
+previous tag — `deployment.yaml` changes (e.g. new `/healthz` probes) can reference code
+the pinned tag doesn't yet have, and the rollout will stall on failing probes.
+
 `kubectl apply` must precede `rollout restart` — a git push alone does not update the cluster.
 
 ---

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            git clone --branch v0.6.6 https://github.com/boettiger-lab/mcp-data-server.git /app && \
+            git clone --branch v0.6.7 https://github.com/boettiger-lab/mcp-data-server.git /app && \
             cd /app && \
             python server.py
         env:


### PR DESCRIPTION
## What

- Bump prod tag pin `v0.6.6 → v0.6.7` in `k8s/deployment.yaml`.
- Make the implicit release step explicit in `AGENTS.md`: bump the `--branch` pin **before** `kubectl apply`.

## Why

`v0.6.7` (tag at 66a165d) adds the `/healthz` endpoint + httpGet readiness/liveness probes (#158). That PR added the probes to `deployment.yaml` but left the pin at `v0.6.6`, which has no `/healthz` route. The probes have been running on **dev** (clones `main`, unpinned) for a day and are healthy; this PR ships the same code to prod the normal way — by moving the pin to a tag that contains `/healthz`.

Mirrors the established convention: tag marks the code (#150 → v0.6.6), pin bump is a separate following commit (#151 → bump to v0.6.6).

## Deploy (after merge)

```
kubectl apply -f k8s/deployment.yaml
kubectl rollout restart deployment/duckdb-mcp -n biodiversity
```