### PR TITLE
h3-guide: exact h3_cell_area() areas + scope global hex by name/id

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -33,22 +33,35 @@ All spatial operations are hex joins — two datasets overlap wherever their hex
 
 ## Area Conversion
 
-| Resolution | km²/cell | acres/cell |
+H3 cells are not equal-area — true area varies with latitude and reaches ~0.55–0.82 km² at res 8. For a region or feature area, and for per-group breakdowns, sum `h3_cell_area()` over distinct cells (exact at any resolution):
+
+```sql
+-- Region / feature area:
+SELECT SUM(h3_cell_area(h8, 'km^2')) AS area_km2
+FROM (SELECT DISTINCT h8, h0 FROM read_parquet('<hex>') WHERE <scope>);
+
+-- Per-group breakdown (per-state, per-class, etc.):
+SELECT state, SUM(h3_cell_area(h8, 'km^2')) AS area_km2
+FROM (SELECT DISTINCT state, h8, h0 FROM read_parquet('<hex>'))
+GROUP BY state;
+```
+
+When the scope is a name or feature id on a global `h0=*` dataset, restrict `h0` first — see *Scoping by name or feature id* in query-optimization.md.
+
+`h3_cell_area()` takes any resolution column (`h3_cell_area(h6, 'km^2')`) and unit (`'km^2'`, `'m^2'`).
+
+For global aggregates over millions of cells, multiplying an approximate count by the rough per-cell constant is faster (within ~1–2%):
+
+```sql
+SELECT APPROX_COUNT_DISTINCT(h8) * 0.7373 AS area_km2 FROM ...
+```
+
+| Resolution | km²/cell (rough) | acres/cell (rough) |
 |---|---|---|
 | h5 | 252.9 | 62,502 |
 | h6 | 36.13 | 8,929 |
 | h8 | 0.7373 | 182.2 |
 | h10 | 0.01505 | 3.718 |
-
-```sql
--- Global aggregate (millions of cells, ~1% error acceptable):
-SELECT APPROX_COUNT_DISTINCT(h8) * 0.7373 AS area_km2 FROM ...
-
--- Per-group breakdown (per-state, per-class, etc.) — use exact COUNT DISTINCT:
-SELECT state, COUNT(DISTINCT h8) * 0.7373 AS area_km2
-FROM ...
-GROUP BY state
-```
 
 ## Coordinates from H3 Cells
 

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -33,7 +33,12 @@ All spatial operations are hex joins — two datasets overlap wherever their hex
 
 ## Area Conversion
 
-H3 cells are not equal-area — true area varies with latitude and reaches ~0.55–0.82 km² at res 8. For a region or feature area, and for per-group breakdowns, sum `h3_cell_area()` over distinct cells (exact at any resolution):
+H3 cells are not equal-area — true area varies with latitude and icosahedral distortion (res-8 cells span ~0.55–0.82 km²). Pick the method by scope:
+
+- **Scoped to a region, feature, or group** (a `WHERE`/mask bounds it to roughly ≤ a few million cells) — the common case, and the accuracy-critical one: sum exact `h3_cell_area()` over distinct cells.
+- **Unscoped global coverage** (millions of cells, no region filter): multiply an approximate count by the rough per-cell constant.
+
+For a region or feature area, and for per-group breakdowns, sum `h3_cell_area()` over distinct cells (exact at any resolution):
 
 ```sql
 -- Region / feature area:
@@ -50,11 +55,13 @@ When the scope is a name or feature id on a global `h0=*` dataset, restrict `h0`
 
 `h3_cell_area()` takes any resolution column (`h3_cell_area(h6, 'km^2')`) and unit (`'km^2'`, `'m^2'`).
 
-For global aggregates over millions of cells, multiplying an approximate count by the rough per-cell constant is faster (within ~1–2%):
+For unscoped global aggregates over millions of cells, multiplying an approximate count by the rough per-cell constant is faster (within ~1–2%). Exact area would force materializing every distinct cell, defeating the approximate path:
 
 ```sql
 SELECT APPROX_COUNT_DISTINCT(h8) * 0.7373 AS area_km2 FROM ...
 ```
+
+The constants below are latitude/distortion-averaged, not true per-cell values (res-8 cells range ~0.55–0.82 km²):
 
 | Resolution | km²/cell (rough) | acres/cell (rough) |
 |---|---|---|

--- a/query-optimization.md
+++ b/query-optimization.md
@@ -54,6 +54,28 @@ SELECT h8, h0, MODE(lc_class) AS dominant
 FROM lc_on_scope GROUP BY h8, h0;
 ```
 
+### Scoping by name or feature id (no region mask)
+
+To filter a global `…/hex/h0=*/…` dataset by a name or `_cng_fid` and there is no region-mask hex to join, first restrict `h0` to the region, then apply the attribute filter:
+
+- **Known coordinates** (island centroids, a city, bbox corners): build the `h0` set with `h3_latlng_to_cell(lat, lng, 0)` per point and `UNNEST(h3_grid_disk(h0, 1))` to include neighbouring res-0 cells. For large or multi-part features, supply every known point or the bbox corners — one centroid can miss partitions the feature reaches.
+- **Known name only**: look the feature up in the dataset's GeoParquet asset (one row per feature) to read its centroid/bbox, convert to `h0`, then query the hex.
+
+```sql
+WITH h0s AS (
+  SELECT DISTINCT d
+  FROM (VALUES (19.282,166.647),(16.728,-169.534),(6.383,-162.417),
+               (0.807,-176.617),(-0.374,-159.997)) AS i(lat,lng),
+       UNNEST(h3_grid_disk(h3_latlng_to_cell(lat,lng,0),1)) AS t(d)
+)
+SELECT SUM(h3_cell_area(h8, 'km^2')) AS area_km2
+FROM (
+  SELECT DISTINCT h8, h0
+  FROM read_parquet('s3://<bucket>/<dataset>/hex/h0=*/data_00.parquet')
+  WHERE h0 IN (SELECT d FROM h0s) AND _cng_fid IN (201, 246, 243, 142, 90)
+);
+```
+
 ## 3. Trust your schema — don't grep with DESCRIBE+LIKE
 
 For datasets already loaded in your app, the column list returned by `get_schema`


### PR DESCRIPTION
Two Layer-2 guidance fixes, both surfaced by the same high-seas app session and verified against official Marine Regions areas. They touch the same area/scope guidance, so they ship together.

## #162 — exact per-cell area instead of the flat constant
H3 cells are **not** equal-area. Confirmed on the live server: res-8 cell area ranges **0.549–0.819 km²**, so the flat `0.7373` constant can be off by ~25% per cell — worst at high latitude / near icosahedron vertices / across the antimeridian (the Howland & Baker EEZ block was overstated +23%).

- `h3-guide.md` Area Conversion now defaults to `SUM(h3_cell_area(h8, 'km^2'))` over distinct cells for region/feature/per-group areas.
- The flat constant table + `APPROX_COUNT_DISTINCT × 0.7373` is kept, labelled *rough*, as the fast path for million-cell global aggregates (where materializing exact distinct cells is the expensive part).

## #161 — scope a global `h0=*` dataset before filtering by name/id
Filtering `…/hex/h0=*/…` by `NAME_ENG`/`_cng_fid` with no region mask opens every partition worldwide (the session measured 100–330 s per query, hitting the 300 s timeout, and never returned an answer). The attribute can't prune `h0`.

- New *Scoping by name or feature id* subsection in `query-optimization.md §2`: derive the `h0` set from known coordinates (`h3_latlng_to_cell` + `h3_grid_disk`) or a GeoParquet centroid/bbox lookup, then `WHERE h0 IN (...)`. Verified: the PIHMNM coordinate set yields **15 partitions** vs. a full global scan.
- Cross-referenced from `h3-guide.md`.

## Notes
- Edits follow `AGENTS.md` rules for these runtime-prompt files: short, positive framing, correct-shape SQL only, no ❌ blocks / internals.
- The shared example uses both fixes together (`h0 IN (...)` scope + `h3_cell_area()` area).

Fixes #161
Fixes #162