### PR TITLE
Steer map display to COG/PMTiles; reserve register_hex_tiles for derived per-area values

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -296,14 +296,22 @@ Then tell the user the *public https* address (note the use of the public, not p
 
 ## Rendering hex results as a map layer
 
-For hex result sets too large to display as a table (roughly >100k cells), or
-whenever the user wants to visualize hexes directly on the map, use the
-`register_hex_tiles` MCP tool instead of returning markdown.
+Before building a hex tileset, check whether the value is already renderable —
+hex is the right display path for **one** case only:
 
-**When to use:**
-- User asks to *show*, *render*, *visualize*, or *color* hexes on the map
-- Result set would exceed the 50-row `query` cap with meaningful content
-- The answer is "per-hex values across a region" rather than "top N rows"
+| To display… | Use | Not hex because |
+|---|---|---|
+| A raster-native field (effort, elevation, SST) | **COG via titiler** | hex is a lossy re-bin of it |
+| An existing column in a layer's PMTiles | **data-driven paint (set_style)** | the attribute is already there |
+| A **derived per-area value in no layer** (zonal-stats / vector×raster join / computed class) | **`register_hex_tiles`** ✓ | the legitimate case |
+
+So use `register_hex_tiles` only when **all** hold:
+- The value is *derived/computed* and lives in no existing layer
+- The user wants it shown as per-hex values across a region (not a top-N table)
+- The result set is large (would exceed the 50-row `query` cap)
+
+(Hex *computation* — joins, area, zonal stats — is separate and stays ideal in
+hex parquet; this section is only about the visual tile server.)
 
 **How to use:**
 1. Write your analysis SQL that returns `(h3_index, value1, value2, ...)` — first

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -303,10 +303,10 @@ hex is the right display path for **one** case only:
 |---|---|---|
 | A raster-native field (effort, elevation, SST) | **COG via titiler** | hex is a lossy re-bin of it |
 | An existing column in a layer's PMTiles | **data-driven paint (set_style)** | the attribute is already there |
-| A **derived per-area value in no layer** (zonal-stats / vector×raster join / computed class) | **`register_hex_tiles`** ✓ | the legitimate case |
+| A value your SQL **computes** that no layer/COG serves | **`register_hex_tiles`** ✓ | nothing else can render it |
 
 So use `register_hex_tiles` only when **all** hold:
-- The value is *derived/computed* and lives in no existing layer
+- The value is produced by your SQL and is not already a servable field (a layer's PMTiles column, or a COG raster)
 - The user wants it shown as per-hex values across a region (not a top-N table)
 - The result set is large (would exceed the 50-row `query` cap)
 

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -296,22 +296,19 @@ Then tell the user the *public https* address (note the use of the public, not p
 
 ## Rendering hex results as a map layer
 
-Before building a hex tileset, check whether the value is already renderable —
-hex is the right display path for **one** case only:
+Use `register_hex_tiles` only to display a value your SQL computes that no
+layer or COG already serves. Otherwise render the existing source:
 
-| To display… | Use | Not hex because |
-|---|---|---|
-| A raster-native field (effort, elevation, SST) | **COG via titiler** | hex is a lossy re-bin of it |
-| An existing column in a layer's PMTiles | **data-driven paint (set_style)** | the attribute is already there |
-| A value your SQL **computes** that no layer/COG serves | **`register_hex_tiles`** ✓ | nothing else can render it |
+| To display… | Use |
+|---|---|
+| A raster field (effort, elevation, SST) | the **COG via titiler** |
+| A column already in a layer's PMTiles (e.g. county population) | **data-driven paint (set_style)** on that layer |
+| A value your SQL computes that no layer/COG serves | **`register_hex_tiles`** |
 
-So use `register_hex_tiles` only when **all** hold:
-- The value is produced by your SQL and is not already a servable field (a layer's PMTiles column, or a COG raster)
-- The user wants it shown as per-hex values across a region (not a top-N table)
+Use `register_hex_tiles` only when all hold:
+- The value is produced by your SQL, not already a servable field (a layer's PMTiles column, or a COG raster)
+- It is shown as per-hex values across a region, not a top-N table
 - The result set is large (would exceed the 50-row `query` cap)
-
-(Hex *computation* — joins, area, zonal stats — is separate and stays ideal in
-hex parquet; this section is only about the visual tile server.)
 
 **How to use:**
 1. Write your analysis SQL that returns `(h3_index, value1, value2, ...)` — first

--- a/server.py
+++ b/server.py
@@ -351,6 +351,11 @@ def register_hex_tiles(
     "aggregate X by hex", "visualize density of X", "map the count of X per
     area". If the user did not ask for one of these, do NOT use this tool.
 
+    The ONE legitimate display case is a DERIVED per-area value that lives in
+    no layer — a zonal-stats / vector×raster join result or a computed
+    classification. If the value is already renderable, render that instead
+    (see WHEN NOT TO USE).
+
     WHEN NOT TO USE — most map/data questions are NOT hex-tile questions.
     Do NOT use this tool for:
       - Counting / summing / averaging questions that return a number or
@@ -361,10 +366,12 @@ def register_hex_tiles(
       - Navigating, framing, or zooming the map ("show me Yosemite",
         "zoom to LA" → use the map client's fly-to / curated layer
         controls, not this tool).
-      - Styling or filtering an existing curated layer ("color counties
-        by population", "filter parks to GAP 1" → use the map client's
-        set_style / set_filter on the existing layer; do NOT create a
-        new hex tileset for this).
+      - Coloring/filtering a layer by a column ALREADY in its data
+        ("color counties by population", "filter parks to GAP 1") → use
+        the map client's set_style / set_filter on that layer; do NOT
+        re-bin to hex.
+      - A raster-native field ("show fishing effort / elevation / SST") →
+        render the COG via titiler; hex is a lossy re-bin of it.
       - "Showing" or "displaying" a dataset whose layer is already in the
         catalog — use the curated layer rather than rebuilding it as hexes.
 

--- a/server.py
+++ b/server.py
@@ -351,10 +351,10 @@ def register_hex_tiles(
     "aggregate X by hex", "visualize density of X", "map the count of X per
     area". If the user did not ask for one of these, do NOT use this tool.
 
-    The ONE legitimate display case is a DERIVED per-area value that lives in
-    no layer — a zonal-stats / vector×raster join result or a computed
-    classification. If the value is already renderable, render that instead
-    (see WHEN NOT TO USE).
+    The ONE legitimate display case is a value your SQL COMPUTES that is not
+    already a servable field anywhere — i.e. not a column in a layer's PMTiles
+    and not a raster field served by a COG. If the value already lives
+    somewhere renderable, render that instead (see WHEN NOT TO USE).
 
     WHEN NOT TO USE — most map/data questions are NOT hex-tile questions.
     Do NOT use this tool for:

--- a/server.py
+++ b/server.py
@@ -349,34 +349,12 @@ def register_hex_tiles(
     density / heatmap / hex-grid visualization over a region. Trigger phrases:
     "hex map", "density map", "heatmap", "show density of X", "hex grid",
     "aggregate X by hex", "visualize density of X", "map the count of X per
-    area". If the user did not ask for one of these, do NOT use this tool.
+    area".
 
-    The ONE legitimate display case is a value your SQL COMPUTES that is not
-    already a servable field anywhere — i.e. not a column in a layer's PMTiles
-    and not a raster field served by a COG. If the value already lives
-    somewhere renderable, render that instead (see WHEN NOT TO USE).
-
-    WHEN NOT TO USE — most map/data questions are NOT hex-tile questions.
-    Do NOT use this tool for:
-      - Counting / summing / averaging questions that return a number or
-        short table ("how many protected areas in CA?" → use the `query`
-        tool and answer with the number).
-      - Listing or looking up individual features ("what species are in
-        Yosemite?", "list the largest fires last year" → use `query`).
-      - Navigating, framing, or zooming the map ("show me Yosemite",
-        "zoom to LA" → use the map client's fly-to / curated layer
-        controls, not this tool).
-      - Coloring/filtering a layer by a column ALREADY in its data
-        ("color counties by population", "filter parks to GAP 1") → use
-        the map client's set_style / set_filter on that layer; do NOT
-        re-bin to hex.
-      - A raster-native field ("show fishing effort / elevation / SST") →
-        render the COG via titiler; hex is a lossy re-bin of it.
-      - "Showing" or "displaying" a dataset whose layer is already in the
-        catalog — use the curated layer rather than rebuilding it as hexes.
-
-    If the user's intent is ambiguous, do NOT silently create a hex tileset.
-    Ask whether they want a density / heatmap visualization first.
+    Call this ONLY to display a value your SQL COMPUTES that is not already a
+    servable field anywhere — not a column in a layer's PMTiles, and not a
+    raster field served by a COG. If the value already lives somewhere
+    renderable, render that instead. If intent is ambiguous, ask first.
 
     Parameters:
     - `sql`: a SELECT whose first column is an H3 index. The tool reads that


### PR DESCRIPTION
Closes #165.

Models over-reached for `register_hex_tiles` to **display** fields that already have a better rendering path (raster-native fields → COG via titiler; existing PMTiles columns → data-driven paint), inheriting the hex tile server's antimeridian-wrap (#164) and empty-tile costs.

The fix steers display to the right format — and applies *less-is-more*, since the issue is itself evidence the prior negative guidance wasn't working.

## Changes (docs only, no behavior change)

**`server.py` — `register_hex_tiles` docstring**
- Replaced the five-bullet `WHEN NOT TO USE` enumeration with a single positive gate: *call this only to display a value your SQL computes that no layer or COG already serves.*
- Rationale: the negative list did not prevent the overuse #165 is about, and each "do NOT use for [common task]" bullet re-primes the tool for exactly those asks (cf. the negation-priming result in #133/#134). The positive gate subsumes every dropped negative — counting/listing aren't "display a value across a region"; styling an existing layer / showing a catalog dataset are "already a servable field." Net −22/+5 lines.

**`h3-guide.md` — "Rendering hex results as a map layer"**
- Replaced the old "color/visualize hexes" triggers (which steered the wrong way) with a compact positive routing table (raster → COG; existing PMTiles column → set_style; SQL-computed value no layer serves → `register_hex_tiles`) plus an all-three-must-hold checklist.
- Dropped the "why not hex" explanation column and the meta-aside per AGENTS.md (small-model prompt files: just the rules, prefer positive framing).

## Notes
- Hex **computation** (joins, area, zonal stats) stays ideal in hex parquet — this is only about the visual tile server. Avoided "zonal-stats / vector×raster" framing because every operation here is mechanically a join on H3 hashes; the display test is value *provenance* (already a servable field?), not operation type.
- Did **not** bake the #164/empty-tile-500 defect note into the docstring: #164 is still open and that text goes stale once it lands.
- Whether the leaner gate reduces overuse is a hypothesis to confirm in the geo-agent-training log review; smaller surface makes a later A/B cleaner.
