### PR TITLE
Fix antimeridian-crossing hex tiles rendering as globe-spanning streaks

### DIFF
--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -106,6 +106,68 @@ class TestServeTile:
         assert expected in r.content, f"layer name {layer_name!r} not found in MVT bytes"
 
 
+class TestAntimeridian:
+    def test_dateline_cell_geometry_does_not_span_globe(self):
+        # A hex straddling +/-180 must be unwrapped into a continuous frame, not
+        # emitted as a single ring whose vertices jump +179.9 -> -179.9 (which
+        # MapLibre draws "the long way" as a globe-spanning streak). See #164.
+        from tiles.endpoint import _boundary_geom_sql
+        con = build_tile_connection()
+        try:
+            con.sql(
+                "CREATE TABLE src AS SELECT * FROM (VALUES "
+                "(h3_latlng_to_cell(0.0,  179.95, 5)), "   # east-side crosser
+                "(h3_latlng_to_cell(0.0, -179.97, 7)), "   # west-side crosser
+                "(h3_latlng_to_cell(36.5, -119.5, 5))"     # normal (no crossing)
+                ") t(h)"
+            )
+            geom = _boundary_geom_sql(touches_dateline=True)
+            rows = con.sql(
+                f"SELECT ST_XMax(g) - ST_XMin(g) AS span, ST_IsValid(g) AS valid "
+                f"FROM (SELECT {geom} AS g FROM src)"
+            ).fetchall()
+            assert rows, "no geometry produced"
+            for span, valid in rows:
+                assert valid, "unwrapped boundary geometry must be valid"
+                assert span < 180, f"geometry spans the dateline (lng span={span})"
+        finally:
+            con.close()
+
+    def test_dateline_edge_tile_renders_end_to_end(self, app_with_tiles, local_bucket):
+        # Full pipeline: a tileset with cells right on +/-180 must render its
+        # easternmost tile (the correlated unwrap subquery has to survive inside
+        # ST_AsMVTGeom/ST_AsMVT), not error or come back empty.
+        con = app_with_tiles.state.tile_con
+        user_sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 4) AS h4, 1.0 AS val
+            FROM (
+                SELECT (random()-0.5)*2 AS lat, 179.0 + random()*1.0 AS lng
+                FROM range(400)
+            )
+        """
+        result = register_hex_tiles(
+            con=con, sql=user_sql, finest_res=4, min_res=2, agg="AVG", zoom_offset=4,
+        )
+        client = TestClient(app_with_tiles)
+        # z=2, n=4: easternmost column is x=3 (east edge = +180); equator row y=2.
+        r = client.get(f"/tiles/hex/{result['hash']}/2/3/2.pbf")
+        assert r.status_code == 200, f"edge tile failed: {r.status_code}"
+        assert len(r.content) > 0
+
+    def test_build_tile_sql_unwraps_only_on_dateline_tiles(self):
+        # At z=3 (n=8): x=0 touches -180, x=7 touches +180, x=4 is interior.
+        # The unwrap machinery (ST_MakePolygon rebuild) should appear only for
+        # the edge columns so interior tiles keep the cheap direct projection.
+        from tiles.endpoint import _build_tile_sql
+        kw = dict(namespace="hex", name="abc", z=3, y=4, target_res=5, finest_res=5)
+        interior = _build_tile_sql(x=4, **kw)
+        east = _build_tile_sql(x=7, **kw)
+        west = _build_tile_sql(x=0, **kw)
+        assert "ST_MakePolygon" not in interior
+        assert "ST_MakePolygon" in east
+        assert "ST_MakePolygon" in west
+
+
 class TestH0Pruning:
     def test_build_tile_sql_filters_by_h0(self):
         # Per-tile pruning depends on the SQL restricting reads to the h0

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -90,6 +90,43 @@ def _get_cached_metadata(app_state, con, namespace: str, name: str):
     return cache[key]
 
 
+def _boundary_geom_sql(touches_dateline: bool) -> str:
+    """Return a SQL scalar expression (EPSG:4326 GEOMETRY) for cell `src.h`'s
+    H3 boundary polygon.
+
+    `h3_cell_to_boundary_wkt` emits a cell straddling +/-180 as a single ring
+    whose longitudes jump +179.9 -> -179.9; MapLibre then draws it "the long
+    way," producing globe-spanning streaks (#164). Only the easternmost and
+    westernmost tile columns can contain such cells, so `_build_tile_sql`
+    passes touches_dateline=True only for those tiles.
+
+    When touches_dateline, rebuild the boundary in a continuous frame: dump the
+    ring's vertices and shift each by +/-360 so it stays within 180 deg of the
+    cell's center longitude. The cell then sits wholly on one side of the seam
+    (overflow past +/-180 is clipped to the tile by ST_AsMVTGeom). Non-crossing
+    cells are unchanged (the CASE is a no-op when max-min lng span <= 180).
+    """
+    if not touches_dateline:
+        return "h3_cell_to_boundary_wkt(src.h)::GEOMETRY"
+    return """(
+        WITH _v AS (
+          SELECT ST_X(d.geom) AS x, ST_Y(d.geom) AS y, d.path[1] AS idx
+          FROM UNNEST(ST_Dump(ST_Points(
+                 h3_cell_to_boundary_wkt(src.h)::GEOMETRY))) AS u(d)
+        ),
+        _c AS (
+          SELECT (MAX(x) - MIN(x)) > 180 AS crosses,
+                 h3_cell_to_lng(src.h) AS ref
+          FROM _v
+        )
+        SELECT ST_MakePolygon(ST_MakeLine(list(ST_Point(
+          CASE WHEN _c.crosses AND (_v.x - _c.ref) >  180 THEN _v.x - 360
+               WHEN _c.crosses AND (_v.x - _c.ref) < -180 THEN _v.x + 360
+               ELSE _v.x END, _v.y) ORDER BY _v.idx)))
+        FROM _v, _c
+      )"""
+
+
 def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
                     target_res: int, finest_res: int) -> str:
     """Produce the SQL that returns a single BLOB row (the MVT for this tile).
@@ -120,6 +157,10 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
     """
     west, south, east, north = tile_xyz_to_lnglat_bounds(z, x, y)
     tileset = _tileset_dir(namespace, name)
+    # Only the edge tile columns (x=0 west=-180, x=2^z-1 east=+180) can hold
+    # cells whose boundary crosses the antimeridian; unwrap geometry only there.
+    touches_dateline = west <= -179.999 or east >= 179.999
+    boundary_geom = _boundary_geom_sql(touches_dateline)
     mx_w = _lng_to_merc_x(west)
     mx_e = _lng_to_merc_x(east)
     my_s = _lat_to_merc_y(south)
@@ -156,7 +197,7 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
         projected AS (
           SELECT
             ST_AsMVTGeom(
-              ST_Transform(h3_cell_to_boundary_wkt(h)::GEOMETRY, 'EPSG:4326', 'EPSG:3857', true),
+              ST_Transform({boundary_geom}, 'EPSG:4326', 'EPSG:3857', true),
               {{'min_x': {mx_w}, 'min_y': {my_s}, 'max_x': {mx_e}, 'max_y': {my_n}}}::BOX_2D
             ) AS geom,
             src.* EXCLUDE (h, h0)


### PR DESCRIPTION
Closes #164.

H3 cells straddling ±180° were emitted by `h3_cell_to_boundary_wkt` as a single ring whose longitudes jump +179.9 → −179.9; MapLibre then draws them "the long way," producing globe-spanning horizontal streaks (reproduced on the **high-seas** app near the dateline — Pacific monuments, GFW effort and EEZ buffer layers).

## Fix
In `_build_tile_sql`'s geometry step, dateline-crossing cells are **unwrapped**: dump the boundary vertices and shift each by ±360 so it stays within 180° of the cell-center longitude, then rebuild a continuous polygon. Overflow past ±180° is clipped to the tile by `ST_AsMVTGeom`, so the cell renders on its center's side of the seam with no streak. Non-crossing cells are unchanged (the shift is a no-op when the lng span ≤ 180°).

## Scope / cost
- **Gated to the two edge tile columns** (`x=0`, `x=2^z−1`) — the only tiles whose bbox can contain a crossing cell. Every interior tile (~99%) runs the identical pre-existing projection.
- No extra S3 I/O. Benchmarked over a 16.6k-cell dateline tile: unwrap path 84.7 ms vs direct 86.1 ms — within noise (DuckDB decorrelates the subquery; `ST_Transform` dominates).

## Tests (TDD)
- `test_dateline_cell_geometry_does_not_span_globe` — the core guard: crossing cells produce a valid polygon with lng span < 180° (fails on old code with span ≈ 359.97°).
- `test_dateline_edge_tile_renders_end_to_end` — full endpoint pipeline renders the easternmost tile of a dateline tileset (correlated unwrap survives inside `ST_AsMVTGeom`/`ST_AsMVT`).
- `test_build_tile_sql_unwraps_only_on_dateline_tiles` — unwrap appears only for edge columns, not interior tiles.

Full suite: 224 passed.

## Note
The empty-tile 500 mentioned in #165 is already gone on `main` — `serve_tile` returns 204 for empty tiles; only genuine query exceptions 500. Not addressed here.
