### PR TITLE
docs: fix broken VitePress build (exclude superpowers/, fix AGENTS link)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,17 +15,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Compute image tags
         id: tags
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -37,10 +37,10 @@ jobs:
         run: npm run docs:build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/.vitepress/dist
 
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v5
+
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
     

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -3,6 +3,10 @@ export default {
   description: 'An open MCP server that connects AI agents to cloud-native data — grounding them in STAC metadata and validated query engines (DuckDB on S3).',
   base: '/mcp-data-server/',
 
+  // Internal planning/spec artifacts, not part of the published site. Their
+  // Go-template `{{ ... }}` syntax also breaks VitePress's Vue parser.
+  srcExclude: ['superpowers/**'],
+
   themeConfig: {
     nav: [
       { text: 'Guide', link: '/guide/quickstart' },

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -38,7 +38,7 @@ Code is baked into the image, so redeploying means rolling to a new image — no
   kubectl rollout restart deployment/duckdb-mcp -n biodiversity
   ```
 
-See [`AGENTS.md` → Rollout workflow](../../AGENTS.md) for the full release procedure (tagging, reading the digest, verifying convergence).
+See [`AGENTS.md` → Rollout workflow](https://github.com/boettiger-lab/mcp-data-server/blob/main/AGENTS.md) for the full release procedure (tagging, reading the digest, verifying convergence).
 
 ## Environment variables
 


### PR DESCRIPTION
The GitHub Pages deploy was failing at the 'Build VitePress docs' step:

1. VitePress builds every .md under docs/ by default, including the
   internal superpowers/ planning + spec artifacts. Those contain Go
   template syntax ({{ .Manifest.Digest }}) that VitePress's Vue parser
   chokes on. Exclude superpowers/** via srcExclude — they are not part
   of the published site anyway.

2. docs/guide/deployment.md linked to ../../AGENTS.md, which lives at the
   repo root outside the docs tree and resolves to a dead link in the
   built site. Point it at the GitHub-hosted file instead.

Verified locally with 'vitepress build docs'.
