### PR TITLE
Run blocking MCP tools off the event loop (Fixes #176)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+import functools
 import hmac
 import os
 import re
@@ -125,6 +126,35 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
         conn.close()
 
 # -------------------------------------------------------------------------
+# 4b. EVENT-LOOP OFFLOAD
+# -------------------------------------------------------------------------
+# FastMCP awaits coroutine tool functions but runs *synchronous* ones inline on
+# the uvicorn event loop (mcp 1.25.0 func_metadata.call_fn_with_arg_validation).
+# Our tools make blocking DuckDB / S3 / long-poll calls, so a single long query
+# would otherwise freeze the whole pod: /healthz stops answering (readiness
+# pulls the pod), tile GETs stall, and other MCP requests queue behind it.
+#
+# `_threaded_tool` wraps a blocking implementation as an async tool that runs the
+# work in a worker thread (anyio.to_thread), keeping the event loop free. A
+# per-tool CapacityLimiter bounds how many of each run at once so N concurrent
+# heavy queries can't oversubscribe CPU/memory. functools.wraps copies
+# __name__/__doc__/__annotations__ and sets __wrapped__, so FastMCP derives the
+# identical tool name + JSON schema from the wrapped function's signature.
+_QUERY_LIMITER = anyio.CapacityLimiter(int(os.environ.get("MCP_QUERY_CONCURRENCY", "8")))
+_REGISTER_LIMITER = anyio.CapacityLimiter(int(os.environ.get("MCP_REGISTER_CONCURRENCY", "4")))
+# Status long-polls are mostly idle waits (cheap to hold), so allow many.
+_STATUS_LIMITER = anyio.CapacityLimiter(int(os.environ.get("MCP_STATUS_CONCURRENCY", "32")))
+
+
+def _threaded_tool(sync_fn, limiter):
+    @functools.wraps(sync_fn)
+    async def _wrapper(**kwargs):
+        return await anyio.to_thread.run_sync(
+            functools.partial(sync_fn, **kwargs), limiter=limiter
+        )
+    return _wrapper
+
+# -------------------------------------------------------------------------
 # 5. MCP RESOURCES (Schema Browsing)
 # -------------------------------------------------------------------------
 @mcp.resource("catalog://list")
@@ -235,7 +265,9 @@ Credentials are scoped to this request only and never persisted.
 {TOOL_INJECTED_CONTEXT}
 """
 
-mcp.tool()(query)
+# Registered async so FastMCP runs the blocking query off the event loop.
+query_tool = _threaded_tool(query, _QUERY_LIMITER)
+mcp.tool()(query_tool)
 
 # -------------------------------------------------------------------------
 # 8b. TILE ENDPOINT — dynamic MVT for H3 hex visualization (see issue #4)
@@ -265,13 +297,26 @@ from tiles.pyramid import (
 # their own connections via the executor below so a long-running COPY can't
 # block tile-serve reads.
 _tile_con = None
+_tile_con_lock = threading.Lock()
 
 
 def _get_tile_con():
+    # Double-checked locking: register_hex_tiles / get_hex_tile_status now run in
+    # worker threads (see _threaded_tool), so first-touch initialization can race.
     global _tile_con
     if _tile_con is None:
-        _tile_con = build_tile_connection()
+        with _tile_con_lock:
+            if _tile_con is None:
+                _tile_con = build_tile_connection()
     return _tile_con
+
+
+def _tile_cursor():
+    # A DuckDB connection is not safe for concurrent queries; .cursor() yields an
+    # independent handle on the same database (loaded extensions + config shared).
+    # The tile-serve path already does this; register/status must too now that
+    # they run off the event loop and can overlap on the shared _tile_con.
+    return _get_tile_con().cursor()
 
 
 # Pod identity for cross-pod attribution in lock.json. In k8s, HOSTNAME
@@ -415,7 +460,7 @@ def register_hex_tiles(
 
     Always pass hive_partitioning = true so the planner can prune h0=* files.
     """
-    read_con = _get_tile_con()
+    read_con = _tile_cursor()
     plan = prepare_hex_tiles(
         con=read_con, sql=sql, agg=agg,
         finest_res=finest_res, min_res=min_res, zoom_offset=zoom_offset,
@@ -471,7 +516,8 @@ def register_hex_tiles(
         }
 
 
-mcp.tool()(register_hex_tiles)
+register_hex_tiles_tool = _threaded_tool(register_hex_tiles, _REGISTER_LIMITER)
+mcp.tool()(register_hex_tiles_tool)
 
 
 _STATUS_POLL_MAX_WAIT_SECONDS = 60
@@ -527,11 +573,15 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0) -> dict:
     paths = tile_paths_for_hash(hash)
     base = {"hash": hash, "tile_url_template": paths["tile_url_template"]}
 
-    cached = read_existing_metadata(_get_tile_con(), paths["output_uri"])
+    # One private cursor for this invocation — this runs in a worker thread now
+    # and must not share query state with concurrent calls on _tile_con.
+    con = _tile_cursor()
+
+    cached = read_existing_metadata(con, paths["output_uri"])
     if cached is not None and "bounds" in cached and "feature_count_finest" in cached:
         return _done_response(base, cached)
 
-    failed = read_failed(_get_tile_con(), paths["output_uri"])
+    failed = read_failed(con, paths["output_uri"])
     if failed is not None:
         return {**base, "status": "failed", "error": failed.get("error", "")}
 
@@ -540,7 +590,7 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0) -> dict:
 
     if job is None:
         # No local job — but another pod may own this build. Consult lock.json.
-        lock = read_lock(_get_tile_con(), paths["output_uri"])
+        lock = read_lock(con, paths["output_uri"])
         if lock is None or lock_is_stale(lock):
             return {**base, "status": "unknown"}
 
@@ -549,10 +599,10 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0) -> dict:
         # this is server-internal, the LLM sees one tool call.
         deadline = time.time() + wait_seconds
         while True:
-            cached = read_existing_metadata(_get_tile_con(), paths["output_uri"])
+            cached = read_existing_metadata(con, paths["output_uri"])
             if cached is not None and "bounds" in cached and "feature_count_finest" in cached:
                 return _done_response(base, cached)
-            failed_now = read_failed(_get_tile_con(), paths["output_uri"])
+            failed_now = read_failed(con, paths["output_uri"])
             if failed_now is not None:
                 return {**base, "status": "failed", "error": failed_now.get("error", "")}
             if time.time() >= deadline:
@@ -587,7 +637,8 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0) -> dict:
             "elapsed_seconds": round(time.time() - job["started_at"], 1)}
 
 
-mcp.tool()(get_hex_tile_status)
+get_hex_tile_status_tool = _threaded_tool(get_hex_tile_status, _STATUS_LIMITER)
+mcp.tool()(get_hex_tile_status_tool)
 
 
 def mount_tiles(app):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -803,5 +803,128 @@ class TestBuildFailureMarker:
         assert "synthetic build failure" in failed["error"]
 
 
+class TestEventLoopOffload:
+    """The MCP tools (query, register_hex_tiles, get_hex_tile_status) run their
+    blocking DuckDB / long-poll work in worker threads so a single long request
+    never blocks the uvicorn event loop — and thus /healthz, tile GETs, and other
+    concurrent MCP requests on the same pod. See issue (async tool offload)."""
+
+    def test_threaded_tool_preserves_name_doc_and_schema(self):
+        import inspect
+        import server
+
+        def impl(sql_query: str, s3_key: str = None) -> str:
+            """IMPL DOCSTRING."""
+            return "x"
+
+        w = server._threaded_tool(impl, server._QUERY_LIMITER)
+        # FastMCP derives the tool name + JSON schema from the wrapped function's
+        # signature/doc, so these must survive wrapping unchanged.
+        assert inspect.iscoroutinefunction(w)
+        assert w.__name__ == "impl"
+        assert w.__doc__ == "IMPL DOCSTRING."
+        assert str(inspect.signature(w)) == "(sql_query: str, s3_key: str = None) -> str"
+
+    def test_threaded_tool_keeps_event_loop_responsive(self):
+        """While the wrapped (blocking) implementation runs, the event loop must
+        keep ticking. If the work ran on the loop, the concurrent sleeps below
+        could not make progress until it finished."""
+        import threading
+        import anyio
+        import server
+
+        gate = threading.Event()
+
+        def blocking():
+            gate.wait(2.0)
+            return "done"
+
+        tool = server._threaded_tool(blocking, server._QUERY_LIMITER)
+
+        async def main():
+            ticks = 0
+            result = {}
+            async with anyio.create_task_group() as tg:
+
+                async def runner():
+                    result["r"] = await tool()
+
+                tg.start_soon(runner)
+                for _ in range(5):
+                    await anyio.sleep(0.02)
+                    ticks += 1
+                gate.set()  # release the worker thread so runner (and the tg) finish
+            assert ticks == 5
+            return result["r"]
+
+        assert anyio.run(main) == "done"
+
+    def test_registered_tools_are_async_with_stable_schema(self):
+        import inspect
+        import anyio
+        import server
+
+        # The wrappers actually registered with FastMCP are coroutine functions.
+        for wrapper in (
+            server.query_tool,
+            server.register_hex_tiles_tool,
+            server.get_hex_tile_status_tool,
+        ):
+            assert inspect.iscoroutinefunction(wrapper)
+
+        # Wrapping must not change the LLM-facing tool schema.
+        tools = {t.name: t for t in anyio.run(server.mcp.list_tools)}
+        assert sorted(tools["query"].inputSchema["properties"]) == [
+            "s3_endpoint", "s3_key", "s3_scope", "s3_secret", "sql_query",
+        ]
+        assert sorted(tools["register_hex_tiles"].inputSchema["properties"]) == [
+            "agg", "finest_res", "min_res", "sql", "zoom_offset",
+        ]
+        assert sorted(tools["get_hex_tile_status"].inputSchema["properties"]) == [
+            "hash", "wait_seconds",
+        ]
+
+    def test_register_uses_isolated_cursor_not_shared_connection(
+        self, isolated_jobs, monkeypatch
+    ):
+        """register_hex_tiles must run its prepare-phase probes on a fresh cursor,
+        not the shared _tile_con — otherwise concurrent offloaded calls race on a
+        single DuckDB connection."""
+        import server
+
+        captured = {}
+        real_prepare = server.prepare_hex_tiles
+
+        def spy_prepare(con, **kw):
+            captured["con"] = con
+            return real_prepare(con=con, **kw)
+
+        monkeypatch.setattr(server, "prepare_hex_tiles", spy_prepare)
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        assert captured["con"] is not server._get_tile_con()
+
+    def test_status_uses_isolated_cursor_not_shared_connection(
+        self, isolated_jobs, monkeypatch
+    ):
+        """get_hex_tile_status reads markers on a fresh cursor, not the shared
+        _tile_con, for the same concurrency reason."""
+        import server
+
+        captured = {}
+        real_read = server.read_existing_metadata
+
+        def spy_read(con, output_uri):
+            captured["con"] = con
+            return real_read(con, output_uri)
+
+        monkeypatch.setattr(server, "read_existing_metadata", spy_read)
+        server.get_hex_tile_status(hash="0" * 16, wait_seconds=0)
+        assert captured["con"] is not server._get_tile_con()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #176.

## What

FastMCP runs **synchronous** tool functions inline on the uvicorn event loop (mcp 1.25.0). All three of our tools are sync and block: `query` (DuckDB scan, ≤300s), `register_hex_tiles` (prepare probes + 5s inline wait), `get_hex_tile_status` (up to 60s long-poll). So one long call froze the pod — `/healthz` unanswered (readiness pulls the pod), tiles stalled, other MCP requests queued. Effective per-pod concurrency was 1.

This registers the three tools as `async` wrappers that run the blocking body in a worker thread (`anyio.to_thread.run_sync`), bounded by per-tool `CapacityLimiter`s. The event loop stays free, so `/healthz` and tiles stay responsive while a query runs, and each pod becomes a bounded N-slot worker.

## How

- `_threaded_tool(sync_fn, limiter)` — async wrapper using `functools.wraps` so FastMCP derives the **identical** tool name + JSON schema from the wrapped signature (verified by test). Limits are env-tunable: `MCP_QUERY_CONCURRENCY` (8), `MCP_REGISTER_CONCURRENCY` (4), `MCP_STATUS_CONCURRENCY` (32).
- Concurrency safety: offloaded `register_hex_tiles` / `get_hex_tile_status` can now overlap on the shared `_tile_con`. They read/write markers through `.cursor()` (independent handle, same DB + extensions — the tile-serve path already does this), and `_get_tile_con()`'s lazy init is double-checked-lock guarded.
- The sync implementation functions are unchanged in behavior and remain directly unit-testable.

## Tests

- New `TestEventLoopOffload`: wrapper preserves name/doc/signature and is a coroutine; event loop stays responsive while the wrapped impl blocks; registered tools are async with unchanged schemas; register/status use an isolated cursor, not the shared connection.
- Full suite green (229 passed locally).

## Rollout

Test on **dev** (`dev-duckdb-mcp`, tracks `:main`) before promoting to prod. Suggested dev check: fire a deliberate multi-minute query and confirm `/healthz` keeps returning 200 and tiles keep serving during it.

## Follow-ups (not in this PR)

- `get_hex_tile_status` long-polls still hold a worker thread for the wait (bounded by `MCP_STATUS_CONCURRENCY`); an `anyio.sleep`-based rewrite would free them.
- Revisit the `/healthz` "starvation = busy" rationale (#157): starvation is no longer the busy signal once tools run off-loop.