### PR TITLE
Hex tile observability: build + serve timing logs (PR 1 of #178)

### DIFF
--- a/server.py
+++ b/server.py
@@ -306,9 +306,16 @@ def _submit_build(plan: dict) -> concurrent.futures.Future:
 
         def _do_build():
             build_con = build_tile_connection()
+            print(f"[tile-build] hash={h} START pod={_POD_ID}", file=sys.stderr)
+            t0 = time.perf_counter()
             try:
                 return build_hex_tiles(build_con, plan)
             except Exception as exc:
+                print(
+                    f"[tile-build] hash={h} FAILED after "
+                    f"{time.perf_counter() - t0:.1f}s: {exc}",
+                    file=sys.stderr,
+                )
                 # Persist failure so other pods (and this pod after _jobs
                 # eviction) can return status=failed instead of "unknown".
                 try:

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -12,6 +12,7 @@ import json
 import math
 import os
 import sys
+import time
 import anyio
 from starlette.requests import Request
 from starlette.responses import Response
@@ -240,11 +241,19 @@ async def serve_tile(request: Request) -> Response:
     target_res = zoom_to_h3_res(z, min_res=min_res, finest_res=finest_res, zoom_offset=zoom_offset)
 
     sql = _build_tile_sql(namespace, name, z, x, y, target_res, finest_res)
+    t0 = time.perf_counter()
     try:
         mvt_bytes = await anyio.to_thread.run_sync(_run_tile_query, con, sql)
     except Exception as e:
         print(f"Tile {z}/{x}/{y} error: {e}", file=sys.stderr)
         return Response(status_code=500)
+    # Per-tile serve timing (#178) — grep [tile-serve] to spot fat/slow tiles
+    # (the symptom of an over-fine zoom->resolution mapping).
+    print(
+        f"[tile-serve] hex/{name} z={z} x={x} y={y} res={target_res} "
+        f"bytes={len(mvt_bytes)} {(time.perf_counter() - t0) * 1000:.0f}ms",
+        file=sys.stderr,
+    )
 
     if not mvt_bytes:
         return Response(status_code=204, headers={"Cache-Control": TILE_CACHE_CONTROL})

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -5,6 +5,7 @@ Tile requests read directly from the pyramid — no coordination needed.
 """
 import json
 import os
+import sys
 import time
 from decimal import Decimal
 from typing import List
@@ -360,6 +361,7 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
     value_columns = plan["value_columns"]
     output_uri = plan["output_uri"]
 
+    h = plan["hash"]
     statements = build_pyramid_statements(
         user_sql=sql,
         finest_res=finest_res,
@@ -371,8 +373,18 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
     )
     if not output_uri.startswith("s3://"):
         os.makedirs(output_uri, exist_ok=True)
-    for stmt in statements:
+    # Per-phase timing — the COPY loop is the dominant cost (#178). Statement 0
+    # is Phase 1 (raw source -> finest res); statement i builds res finest-i.
+    build_t0 = time.perf_counter()
+    for i, stmt in enumerate(statements):
+        s0 = time.perf_counter()
         con.sql(stmt)
+        print(
+            f"[tile-build] hash={h} phase={'1' if i == 0 else '2'} "
+            f"res={finest_res - i} copy={time.perf_counter() - s0:.1f}s",
+            file=sys.stderr,
+        )
+    copy_seconds = time.perf_counter() - build_t0
 
     def _jsonable(v):
         # DuckDB returns DECIMAL for literal-typed numerics; coerce to float
@@ -381,6 +393,7 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
             return float(v)
         return v
 
+    stats_t0 = time.perf_counter()
     value_stats = {}
     for col in value_columns:
         by_res = {}
@@ -393,7 +406,9 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
             ).fetchone()
             by_res[str(res)] = {"min": _jsonable(row[0]), "max": _jsonable(row[1])}
         value_stats[col] = {"by_res": by_res}
+    stats_seconds = time.perf_counter() - stats_t0
 
+    bounds_t0 = time.perf_counter()
     finest_uri = f"{output_uri}res={finest_res}/**/*.parquet"
     bounds_row = con.sql(
         f"SELECT "
@@ -403,6 +418,15 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
         f"FROM read_parquet('{finest_uri}')"
     ).fetchone()
     w, s, e, n, feature_count = bounds_row[2], bounds_row[0], bounds_row[3], bounds_row[1], bounds_row[4]
+    bounds_seconds = time.perf_counter() - bounds_t0
+
+    print(
+        f"[tile-build] hash={h} DONE statements={len(statements)} "
+        f"finest_res={finest_res} min_res={min_res} "
+        f"copy={copy_seconds:.1f}s stats={stats_seconds:.1f}s bounds={bounds_seconds:.1f}s "
+        f"total={time.perf_counter() - build_t0:.1f}s feature_count_finest={feature_count}",
+        file=sys.stderr,
+    )
 
     metadata = {
         "finest_res": finest_res,


### PR DESCRIPTION
First of three PRs for #178. **No behavior change** — adds structured, greppable timing logs so the next two PRs (zoom_offset fix, GeoJSON auto-select) can be measured from pod logs instead of source-reading. Today the only thing in the logs is `/healthz`.

## What it logs

**Build** (`tiles/pyramid.build_hex_tiles`):
```
[tile-build] hash=6b08… phase=1 res=5 copy=0.0s
[tile-build] hash=6b08… phase=2 res=4 copy=0.0s
[tile-build] hash=6b08… phase=2 res=3 copy=0.0s
[tile-build] hash=6b08… DONE statements=4 finest_res=5 min_res=2 copy=0.0s stats=0.0s bounds=0.0s total=0.0s feature_count_finest=5
```
- per-phase COPY timing (phase 1 = finest res; phase 2 = each parent res, descending)
- `DONE` summary splitting the ~15 sequential S3 ops into copy / stats-rescan / bounds / total — this is the multi-minute poll we want to attribute

**Serve** (`tiles/endpoint.serve_tile`):
```
[tile-serve] hex/e2b4… z=5 x=5 y=12 res=2 bytes=214 8ms
```
- `res`, byte size and ms per tile — grep `[tile-serve]` to spot the fat/slow tiles that are the symptom of the over-fine zoom→resolution mapping PR 2 fixes.

**Background lifecycle** (`server._do_build`): `START` (with pod id) and `FAILED` (with elapsed) lines around the executor job.

## Notes
- Follows the repo's existing `print(..., file=sys.stderr)` logging style; no new logging framework.
- All 131 tile + server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)