### PR TITLE
Fix hex tile zoom→resolution mapping: zoom_offset -1 → 2 (PR 2 of #178)

### DIFF
--- a/server.py
+++ b/server.py
@@ -338,16 +338,19 @@ def _submit_build(plan: dict) -> concurrent.futures.Future:
 # docstring — the MCP framework derives the LLM-facing tool schema from the
 # docstring, so they stay invisible to the agent. Auto-detection (in
 # tiles.pyramid.register_hex_tiles) reads the H column's resolution to set
-# finest_res; min_res=2 and zoom_offset=-1 are the only sensible values for
-# the current tile rendering. Adding `finest_res` etc. to the docstring is
-# almost certainly a mistake — see #125 for the trigger-tightening rationale
-# and the surrounding discussion about parameter surface.
+# finest_res; min_res=2 is the coarsest level worth materializing. zoom_offset=2
+# maps map-zoom z to H3 res z-2, keeping each tile to ~100-2000 hexes (a healthy
+# MVT feature count) while preserving detail. The previous default (-1, i.e. res
+# z+1) put 40k-130k hexes in every CA-scale tile — fat .pbf payloads and slow
+# ST_AsMVT, for sub-pixel hexes MapLibre couldn't distinguish anyway (#178).
+# Adding `finest_res` etc. to the docstring is almost certainly a mistake — see
+# #125 for the trigger-tightening rationale and the discussion about param surface.
 def register_hex_tiles(
     sql: str,
     agg: str = "COUNT",
     finest_res: int | None = None,
     min_res: int = 2,
-    zoom_offset: int = -1,
+    zoom_offset: int = 2,
 ) -> dict:
     """Materialize a partitioned H3 hex pyramid to public object storage and return
     a MapLibre-compatible vector tile URL template.

--- a/tests/test_tile_math.py
+++ b/tests/test_tile_math.py
@@ -50,6 +50,13 @@ class TestZoomToRes:
     def test_custom_offset(self):
         assert zoom_to_h3_res(10, min_res=2, finest_res=9, zoom_offset=2) == 8
 
+    def test_default_offset_is_two_maps_z_to_z_minus_2(self):
+        # #178: the default must map map-zoom z -> H3 res z-2 (not the old z+1),
+        # keeping each tile to ~100-2000 hexes instead of 40k-130k. Pin it so a
+        # regression to the over-fine mapping is caught here.
+        for z in range(4, 11):
+            assert zoom_to_h3_res(z, min_res=2, finest_res=12) == z - 2
+
 
 class TestContentHash:
     def test_stable_for_identical_inputs(self):

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -267,7 +267,7 @@ def prepare_hex_tiles(
     finest_res: int | None = None,
     min_res: int = 2,
     agg: str = "AVG",
-    zoom_offset: int = -1,
+    zoom_offset: int = 2,
 ) -> dict:
     """Inspect user SQL, resolve finest_res, compute the content hash, and
     check the S3 cache. Fast — no COPY runs here.
@@ -465,7 +465,7 @@ def register_hex_tiles(
     finest_res: int | None = None,
     min_res: int = 2,
     agg: str = "AVG",
-    zoom_offset: int = -1,
+    zoom_offset: int = 2,
 ) -> dict:
     """Materialize a partitioned parquet pyramid and return tile-endpoint metadata.
 

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -14,8 +14,14 @@ def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, flo
     return (west, lat_s, east, lat_n)
 
 
-def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = -1) -> int:
-    """Clamp(z - zoom_offset, min_res, finest_res) — coarser hexes at lower zooms."""
+def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 2) -> int:
+    """Clamp(z - zoom_offset, min_res, finest_res) — coarser hexes at lower zooms.
+
+    zoom_offset=2 (the default) maps map-zoom z to H3 res z-2, which keeps each
+    tile to ~100-2000 hexes across zooms — a healthy MVT feature count. Smaller
+    offsets render finer hexes (more features/tile, fatter .pbf); offset=-1 (the
+    old default) produced 40k-130k hexes per tile at CA-scale zooms (#178).
+    """
     target = z - zoom_offset
     return max(min_res, min(finest_res, target))
 


### PR DESCRIPTION
Second of three PRs for #178. The dominant render/serve cost.

## Problem

Default `zoom_offset = -1` made `target_res = clamp(z + 1, min_res, finest)`. The tile SQL renders each cell whose center falls in the tile, so hexes/tile ≈ tile_area ÷ hex_area:

| map zoom | old res (z+1) | hexes/tile | new res (z−2) | hexes/tile |
|---|---|---|---|---|
| 4 | 5 | ~25,000 | 2 | ~70 |
| 5 | 6 | ~43,000 | 3 | ~130 |
| 6 | 7 | ~76,000 | 4 | ~220 |
| 7 | 8 | ~130,000 | 5 | ~390 |

A healthy MVT tile is hundreds–low-thousands of features. At CA-scale zooms every tile was asking DuckDB to compute `h3_cell_to_boundary_wkt → ST_Transform → ST_AsMVTGeom → ST_AsMVT` over 40k–130k geometries, live, per request — for hexes that render sub-pixel and MapLibre can't distinguish anyway.

## Fix

`zoom_offset = 2` → `target_res = z − 2`, keeping each tile to ~100–2000 hexes across zooms (~300× fewer at the affected zooms) while preserving detail.

Context: the original tile-endpoint design (`docs/superpowers/specs/2026-04-15-dynamic-mvt-tile-endpoint-design.md`) used `zoom_offset=4`; `-1` was a later regression. `2` keeps more detail than the original `4` while fixing the load — a good fit since fine hexes render fine here.

## Changes
- Defaults flipped `-1 → 2` in `tile_math.zoom_to_h3_res`, `pyramid.prepare_hex_tiles`, `pyramid.register_hex_tiles`, `server.register_hex_tiles`.
- Corrected the misleading `server.py` comment claiming `zoom_offset=-1` was "the only sensible value."
- New test pins the default mapping (`z → z−2`).

## Migration
None needed. `zoom_offset` is part of the content hash, so existing registrations rebuild under fresh hashes; the endpoint reads each tileset's own `zoom_offset` from `metadata.json`, so already-built pyramids keep serving correctly. Old pyramids built under `-1` are simply orphaned on S3.

## Measuring
With #179 (PR 1) merged, `[tile-serve]` log lines now carry `bytes` and `ms` per tile — before/after on the same map view will show the drop directly.

Full suite (225 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)