### PR TITLE
Server-side GeoJSON auto-select for hex viz (PR 3 of #178)

### DIFF
--- a/server.py
+++ b/server.py
@@ -250,6 +250,7 @@ from tiles.pyramid import (
     prepare_hex_tiles,
     build_hex_tiles,
     cached_result_dict,
+    render_recipe,
     lock_is_stale,
     read_existing_metadata,
     read_failed,
@@ -352,8 +353,12 @@ def register_hex_tiles(
     min_res: int = 2,
     zoom_offset: int = 2,
 ) -> dict:
-    """Materialize a partitioned H3 hex pyramid to public object storage and return
-    a MapLibre-compatible vector tile URL template.
+    """Aggregate an H3 hex visualization to public object storage and return a
+    paste-ready MapLibre render recipe.
+
+    The server picks the rendering automatically — a single GeoJSON file for
+    small/bounded results, a vector tile pyramid for large ones — and hands back
+    a ready `source` and `layer`. You render those verbatim; you never choose.
 
     WHEN TO USE — only when the user explicitly asks for an aggregate
     density / heatmap / hex-grid visualization over a region. Trigger phrases:
@@ -379,26 +384,24 @@ def register_hex_tiles(
           `agg` at every coarser level.
 
     Returns a dict with `status` ∈ {"done", "running", "failed"}:
-    - status="done" (cache hit or fast build): full metadata is included —
-      `tile_url_template` (MapLibre vector tile URL with {z}/{x}/{y}),
-      `value_columns` (MVT feature properties: ["count"] for agg="COUNT",
-      otherwise your value columns), `value_stats` ({<col>: {"by_res":
-      {"<res>": {"min", "max"}}}} for client-side palette domain),
-      `layer_name` (use as `source-layer`), plus `hash`, `bounds`,
-      `finest_res`, `feature_count_finest`.
-    - status="running": pyramid is being built in the background. You get
-      `hash` and `tile_url_template` only. Call
-      `get_hex_tile_status(hash, wait_seconds=30)` to poll — that long-polls
-      server-side, so one call returns either the final result or a single
-      "still running" response. Do NOT retry register_hex_tiles with
-      different parameters; the original build will still finish, and
-      re-submitting queues more work without cancelling the first one.
-    - status="failed": build raised an error inline. `error` field has the
-      exception message. Safe to re-submit with adjusted parameters.
+    - status="done" (cache hit or fast build): includes the render recipe —
+      `source` (pass to map.addSource) and `layer` (pass to map.addLayer),
+      both ready to use as-is with a default color ramp. Also `format`
+      ("geojson" or "vector"), `value_columns` and `value_stats` ({<col>:
+      {"by_res": {"<res>": {"min","max"}}}}) if you want to customize the
+      palette, plus `hash`, `bounds`, `feature_count_finest`.
+    - status="running": being built in the background. You get `hash` and
+      `tile_url_template`. Call `get_hex_tile_status(hash, wait_seconds=30)`
+      to poll — it long-polls server-side, so one call returns either the
+      final recipe or a single "still running" response. Do NOT retry
+      register_hex_tiles with different parameters; the original build still
+      finishes, and re-submitting only queues more work.
+    - status="failed": build raised an error inline. `error` has the message.
+      Safe to re-submit with adjusted parameters.
 
-    MapLibre usage:
-        map.addSource(id, {type: 'vector', tiles: [tile_url_template], minzoom: 0, maxzoom: 14});
-        map.addLayer({..., 'source-layer': layer_name, paint: {...}});
+    MapLibre usage (identical regardless of format — render what you got):
+        map.addSource(id, result.source);
+        map.addLayer({id: ..., source: id, ...result.layer});
 
     SQL patterns — pick the one matching the ask; paste exact paths from
     get_stac_details. `<H>` is the H3 resolution, usually 8.
@@ -487,20 +490,24 @@ mcp.tool()(register_hex_tiles)
 _STATUS_POLL_MAX_WAIT_SECONDS = 60
 
 
-def _done_response(base: dict, source: dict) -> dict:
+def _done_response(base: dict, meta: dict) -> dict:
     """Build a status='done' response from either an S3 metadata dict or
-    a build_hex_tiles return value — both have the same shape."""
+    a build_hex_tiles return value — both have the same shape. Includes the
+    paste-ready render recipe (format + source + layer) so the agent renders
+    the result without choosing between GeoJSON and vector tiles (#178)."""
     return {
         **base,
         "status": "done",
-        "bounds": source["bounds"],
-        "finest_res": source["finest_res"],
-        "min_res": source["min_res"],
-        "zoom_offset": source["zoom_offset"],
-        "value_columns": source["value_columns"],
-        "value_stats": source["value_stats"],
-        "layer_name": source.get("layer_name", MVT_LAYER_NAME),
-        "feature_count_finest": source["feature_count_finest"],
+        "bounds": meta["bounds"],
+        "finest_res": meta["finest_res"],
+        "min_res": meta["min_res"],
+        "zoom_offset": meta["zoom_offset"],
+        "value_columns": meta["value_columns"],
+        "value_stats": meta["value_stats"],
+        "layer_name": meta.get("layer_name", MVT_LAYER_NAME),
+        "feature_count_finest": meta["feature_count_finest"],
+        "geojson_url": meta.get("geojson_url"),
+        **render_recipe(meta, base["tile_url_template"]),
     }
 
 

--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -10,6 +10,14 @@ from tiles.pyramid import register_hex_tiles
 from tiles.db import build_tile_connection
 
 
+@pytest.fixture(autouse=True)
+def _force_vector_path(monkeypatch):
+    # This suite exercises MVT tile serving. Pin the GeoJSON cutoff to 0 so the
+    # auto-selector (#178) always builds the tile pyramid; the GeoJSON path has
+    # dedicated coverage in test_tile_geojson.py.
+    monkeypatch.setattr("tiles.pyramid._GEOJSON_MAX_FEATURES", 0)
+
+
 @pytest.fixture
 def local_bucket(tmp_path, monkeypatch):
     bucket = tmp_path / "tiles-bucket"

--- a/tests/test_tile_geojson.py
+++ b/tests/test_tile_geojson.py
@@ -1,0 +1,144 @@
+"""Coverage for the GeoJSON fast path and the auto-selector (#178).
+
+register_hex_tiles serves small/bounded hex sets as a single GeoJSON
+FeatureCollection (streamed to object storage, fetched client-side) instead of
+building an MVT tile pyramid. Larger sets fall back to the pyramid. The return
+carries a paste-ready MapLibre `source`/`layer` either way.
+"""
+import json
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tiles.endpoint import serve_tile
+from tiles.pyramid import register_hex_tiles, render_recipe
+from tiles.db import build_tile_connection
+
+# A small grid of res-8 cells around Berkeley — well under the default cutoff.
+SMALL_SQL = (
+    "SELECT h3_latlng_to_cell(37.87 + (i * 0.01), -122.27 + (j * 0.01), 8) AS h8 "
+    "FROM range(5) t1(i), range(5) t2(j)"
+)
+
+
+@pytest.fixture
+def con():
+    c = build_tile_connection()
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+@pytest.fixture
+def local_bucket(tmp_path, monkeypatch):
+    bucket = tmp_path / "tiles-bucket"
+    bucket.mkdir()
+    monkeypatch.setenv("TILE_BUCKET_BASE", str(bucket))
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "http://test.local")
+    return bucket
+
+
+class TestAutoSelect:
+    def test_small_set_selects_geojson(self, con, local_bucket):
+        result = register_hex_tiles(con=con, sql=SMALL_SQL, agg="COUNT")
+        assert result["format"] == "geojson"
+        assert result["source"]["type"] == "geojson"
+        # GeoJSON layers carry no source-layer (that's a vector-tile concept).
+        assert "source-layer" not in result["layer"]
+        assert result["source"]["data"] == result["geojson_url"]
+        assert result["feature_count_finest"] == 24
+
+    def test_large_set_falls_back_to_vector(self, con, local_bucket, monkeypatch):
+        # Force the pyramid path by setting the cutoff below the feature count.
+        monkeypatch.setattr("tiles.pyramid._GEOJSON_MAX_FEATURES", 0)
+        result = register_hex_tiles(con=con, sql=SMALL_SQL, agg="COUNT")
+        assert result["format"] == "vector"
+        assert result["source"]["type"] == "vector"
+        assert result["source"]["tiles"] == [result["tile_url_template"]]
+        assert result["layer"]["source-layer"] == result["layer_name"]
+        assert result["geojson_url"] is None
+
+    def test_geojson_skips_parent_pyramid_levels(self, con, local_bucket):
+        result = register_hex_tiles(con=con, sql=SMALL_SQL, agg="COUNT")
+        h = result["hash"]
+        tileset = local_bucket / "hex" / h
+        # Only the finest level is materialized; parent res dirs are not built.
+        res_dirs = sorted(p.name for p in tileset.iterdir() if p.name.startswith("res="))
+        assert res_dirs == ["res=8"]
+        assert (tileset / "data.geojson").exists()
+
+
+class TestGeoJSONOutput:
+    def test_data_geojson_is_valid_feature_collection(self, con, local_bucket):
+        result = register_hex_tiles(con=con, sql=SMALL_SQL, agg="COUNT")
+        path = local_bucket / "hex" / result["hash"] / "data.geojson"
+        gj = json.loads(path.read_text())
+        assert gj["type"] == "FeatureCollection"
+        assert len(gj["features"]) == 24
+        f0 = gj["features"][0]
+        assert f0["type"] == "Feature"
+        assert f0["geometry"]["type"] == "Polygon"
+        # H3 cell boundary is a closed 7-point ring (6 vertices + repeat).
+        assert len(f0["geometry"]["coordinates"][0]) == 7
+        assert "count" in f0["properties"]
+
+    def test_value_column_lands_in_properties(self, con, local_bucket):
+        sql = (
+            "SELECT h3_latlng_to_cell(37.87 + (i * 0.01), -122.27, 8) AS h8, "
+            "       (i + 1) * 1.5 AS score "
+            "FROM range(4) t1(i)"
+        )
+        result = register_hex_tiles(con=con, sql=sql, agg="AVG")
+        assert result["format"] == "geojson"
+        assert result["value_columns"] == ["score"]
+        path = local_bucket / "hex" / result["hash"] / "data.geojson"
+        gj = json.loads(path.read_text())
+        for feat in gj["features"]:
+            assert "score" in feat["properties"]
+        # The default ramp interpolates on the value column.
+        assert result["layer"]["paint"]["fill-color"][2] == ["get", "score"]
+
+
+class TestRenderRecipe:
+    def test_legacy_metadata_without_format_defaults_to_vector(self):
+        meta = {
+            "format": None,  # pre-#178 metadata has no format
+            "value_columns": ["count"],
+            "finest_res": 8,
+            "value_stats": {"count": {"by_res": {"8": {"min": 1, "max": 10}}}},
+            "layer_name": "layer",
+        }
+        recipe = render_recipe(meta, "http://x/tiles/hex/abc/{z}/{x}/{y}.pbf")
+        assert recipe["format"] == "vector"
+        assert recipe["source"]["type"] == "vector"
+
+    def test_degenerate_domain_keeps_distinct_stops(self):
+        # min == max would make MapLibre's interpolate stops collide.
+        meta = {
+            "format": "geojson",
+            "geojson_url": "http://x/data.geojson",
+            "value_columns": ["count"],
+            "finest_res": 8,
+            "value_stats": {"count": {"by_res": {"8": {"min": 5, "max": 5}}}},
+        }
+        ramp = render_recipe(meta, "")["layer"]["paint"]["fill-color"]
+        vmin, vmax = ramp[3], ramp[5]
+        assert vmin != vmax
+
+
+class TestEndpointRejectsGeoJSON:
+    def test_tile_request_for_geojson_tileset_returns_404(self, con, local_bucket):
+        result = register_hex_tiles(con=con, sql=SMALL_SQL, agg="COUNT")
+        assert result["format"] == "geojson"
+
+        app = Starlette(routes=[
+            Route("/tiles/{namespace}/{name}/{z:int}/{x:int}/{y:int}.pbf", serve_tile),
+        ])
+        app.state.tile_con = con
+        client = TestClient(app)
+        # A tile for a GeoJSON tileset is a client error — there are no MVTs.
+        r = client.get(f"/tiles/hex/{result['hash']}/8/41/98.pbf")
+        assert r.status_code == 404

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -2,6 +2,14 @@ import pytest
 from tiles.pyramid import build_pyramid_statements
 
 
+@pytest.fixture(autouse=True)
+def _force_vector_path(monkeypatch):
+    # This suite exercises the MVT tile pyramid. Pin the GeoJSON cutoff to 0 so
+    # the auto-selector (#178) always builds the full pyramid; the GeoJSON path
+    # has dedicated coverage in test_tile_geojson.py.
+    monkeypatch.setattr("tiles.pyramid._GEOJSON_MAX_FEATURES", 0)
+
+
 class TestBuildPyramidStatements:
     def test_returns_list_with_one_statement_per_resolution(self):
         stmts = build_pyramid_statements(

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -235,6 +235,10 @@ async def serve_tile(request: Request) -> Response:
     )
     if meta is None:
         return Response(status_code=404)
+    # GeoJSON tilesets are fetched as a single file from the object-store
+    # gateway, not served as MVT here (#178). No parent pyramid levels exist.
+    if meta.get("format") == "geojson":
+        return Response(status_code=404)
     finest_res = meta["finest_res"]
     min_res = meta["min_res"]
     zoom_offset = meta["zoom_offset"]

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -25,6 +25,12 @@ MVT_LAYER_NAME = "layer"
 # gives ~8x headroom.
 _LOCK_STALE_SECONDS = int(os.environ.get("TILE_LOCK_STALE_SECONDS", "900"))
 
+# Hex sets at or below this many finest-res cells are served as a single
+# GeoJSON FeatureCollection (streamed straight to object storage, fetched
+# client-side by MapLibre from the public gateway) instead of building an MVT
+# tile pyramid. Larger sets fall back to the pyramid. Env-overridable. See #178.
+_GEOJSON_MAX_FEATURES = int(os.environ.get("TILE_GEOJSON_MAX_FEATURES", "100000"))
+
 
 def build_pyramid_statements(
     user_sql: str,
@@ -133,6 +139,72 @@ def _bucket_base() -> str:
 
 def _public_base_url() -> str:
     return os.environ.get("MCP_PUBLIC_BASE_URL", "https://duckdb-mcp.nrp-nautilus.io").rstrip("/")
+
+
+def _s3_public_http_base() -> str:
+    """Public HTTPS gateway for the object store (CORS-enabled, GET-only). A
+    browser fetches GeoJSON directly from here — see stac.py, same gateway."""
+    return os.environ.get("S3_PUBLIC_HTTP_BASE", "https://s3-west.nrp-nautilus.io").rstrip("/")
+
+
+def _to_public_http_url(uri: str) -> str:
+    """Map an s3://bucket/key write URI to the public HTTPS URL MapLibre can
+    fetch client-side. Non-s3 paths (local test dirs) are returned unchanged."""
+    if uri.startswith("s3://"):
+        return f"{_s3_public_http_base()}/{uri[len('s3://'):]}"
+    return uri
+
+
+def build_geojson_statement(finest_uri: str, geojson_uri: str, value_columns: List[str]) -> str:
+    """COPY that writes the finest-res hexes as one valid GeoJSON FeatureCollection.
+
+    Uses DuckDB's native JSON export (FORMAT JSON) plus ST_AsGeoJSON — a spatial
+    scalar, NOT the GDAL-backed ST_Write — so it streams to s3:// over httpfs.
+    A single output row becomes one line that is the whole FeatureCollection
+    object; json_group_array nests each cell's GeoJSON geometry and properties.
+    """
+    props = ", ".join(f"'{c}', \"{c}\"" for c in value_columns)
+    return (
+        "COPY (\n"
+        "  SELECT 'FeatureCollection' AS type,\n"
+        "         coalesce(json_group_array(json_object(\n"
+        "           'type', 'Feature',\n"
+        "           'geometry', CAST(ST_AsGeoJSON(h3_cell_to_boundary_wkt(h)::GEOMETRY) AS JSON),\n"
+        f"           'properties', json_object({props})\n"
+        "         )), '[]'::JSON) AS features\n"
+        f"  FROM read_parquet('{finest_uri}')\n"
+        f") TO '{geojson_uri}' (FORMAT JSON)"
+    )
+
+
+def render_recipe(meta: dict, tile_url_template: str) -> dict:
+    """Return {format, source, layer}: a paste-ready MapLibre source + fill
+    layer with a default linear color ramp over the first value column.
+
+    The agent renders these verbatim and never branches on format. `format` is
+    read from meta ('geojson' or 'vector'; defaults to 'vector' for pre-#178
+    metadata). GeoJSON sources point at the public object-store URL; vector
+    sources at the tile endpoint and carry `source-layer`.
+    """
+    fmt = meta.get("format") or "vector"
+    col = meta["value_columns"][0]
+    by_res = meta.get("value_stats", {}).get(col, {}).get("by_res", {})
+    stats = by_res.get(str(meta["finest_res"])) or (next(iter(by_res.values())) if by_res else None)
+    vmin = stats["min"] if stats and stats.get("min") is not None else 0
+    vmax = stats["max"] if stats and stats.get("max") is not None else vmin
+    if vmax == vmin:
+        vmax = vmin + 1  # degenerate domain — keep the interpolate stops distinct
+    paint = {
+        "fill-color": ["interpolate", ["linear"], ["get", col], vmin, "#fee5d9", vmax, "#a50f15"],
+        "fill-opacity": 0.7,
+    }
+    if fmt == "geojson":
+        source = {"type": "geojson", "data": meta.get("geojson_url")}
+        layer = {"type": "fill", "paint": paint}
+    else:
+        source = {"type": "vector", "tiles": [tile_url_template], "minzoom": 0, "maxzoom": 14}
+        layer = {"type": "fill", "source-layer": meta.get("layer_name", MVT_LAYER_NAME), "paint": paint}
+    return {"format": fmt, "source": source, "layer": layer}
 
 
 def _json_dumps_escaped(obj) -> str:
@@ -246,7 +318,7 @@ def read_existing_metadata(con: duckdb.DuckDBPyConnection, output_uri: str):
 
 
 def cached_result_dict(plan: dict, cached: dict) -> dict:
-    return {
+    result = {
         "tile_url_template": plan["tile_url_template"],
         "hash": plan["hash"],
         "bounds": cached["bounds"],
@@ -257,8 +329,11 @@ def cached_result_dict(plan: dict, cached: dict) -> dict:
         "value_stats": cached["value_stats"],
         "layer_name": cached.get("layer_name", MVT_LAYER_NAME),
         "feature_count_finest": cached["feature_count_finest"],
+        "geojson_url": cached.get("geojson_url"),
         "cache_hit": True,
     }
+    result.update(render_recipe(cached, plan["tile_url_template"]))
+    return result
 
 
 def prepare_hex_tiles(
@@ -373,18 +448,6 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
     )
     if not output_uri.startswith("s3://"):
         os.makedirs(output_uri, exist_ok=True)
-    # Per-phase timing — the COPY loop is the dominant cost (#178). Statement 0
-    # is Phase 1 (raw source -> finest res); statement i builds res finest-i.
-    build_t0 = time.perf_counter()
-    for i, stmt in enumerate(statements):
-        s0 = time.perf_counter()
-        con.sql(stmt)
-        print(
-            f"[tile-build] hash={h} phase={'1' if i == 0 else '2'} "
-            f"res={finest_res - i} copy={time.perf_counter() - s0:.1f}s",
-            file=sys.stderr,
-        )
-    copy_seconds = time.perf_counter() - build_t0
 
     def _jsonable(v):
         # DuckDB returns DECIMAL for literal-typed numerics; coerce to float
@@ -393,20 +456,17 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
             return float(v)
         return v
 
-    stats_t0 = time.perf_counter()
-    value_stats = {}
-    for col in value_columns:
-        by_res = {}
-        for res in range(min_res, finest_res + 1):
-            # Recursive glob — h0 hive sub-partitions live under res=N/.
-            uri = f"{output_uri}res={res}/**/*.parquet"
-            row = con.sql(
-                f'SELECT MIN("{col}") AS mn, MAX("{col}") AS mx '
-                f"FROM read_parquet('{uri}')"
-            ).fetchone()
-            by_res[str(res)] = {"min": _jsonable(row[0]), "max": _jsonable(row[1])}
-        value_stats[col] = {"by_res": by_res}
-    stats_seconds = time.perf_counter() - stats_t0
+    # Per-phase timing — the COPY loop is the dominant build cost (#178).
+    build_t0 = time.perf_counter()
+    copy_seconds = 0.0
+
+    # Phase 1 always: materialize the finest resolution. This is both the
+    # pyramid's base level and the source set for the GeoJSON fast path.
+    s0 = time.perf_counter()
+    con.sql(statements[0])
+    dt = time.perf_counter() - s0
+    copy_seconds += dt
+    print(f"[tile-build] hash={h} phase=1 res={finest_res} copy={dt:.1f}s", file=sys.stderr)
 
     bounds_t0 = time.perf_counter()
     finest_uri = f"{output_uri}res={finest_res}/**/*.parquet"
@@ -420,11 +480,59 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
     w, s, e, n, feature_count = bounds_row[2], bounds_row[0], bounds_row[3], bounds_row[1], bounds_row[4]
     bounds_seconds = time.perf_counter() - bounds_t0
 
+    # Auto-select (#178): small/bounded sets render fastest as a single
+    # client-side GeoJSON; larger sets need the tiled pyramid. The count comes
+    # free from the already-materialized Phase 1 level.
+    serve_format = "geojson" if feature_count <= _GEOJSON_MAX_FEATURES else "vector"
+
+    # Phase 2 (parent resolutions) is only for the tile path — GeoJSON renders
+    # the finest set directly, so coarser pyramid levels are never requested.
+    if serve_format == "vector":
+        for i, stmt in enumerate(statements[1:], start=1):
+            s0 = time.perf_counter()
+            con.sql(stmt)
+            dt = time.perf_counter() - s0
+            copy_seconds += dt
+            print(
+                f"[tile-build] hash={h} phase=2 res={finest_res - i} copy={dt:.1f}s",
+                file=sys.stderr,
+            )
+
+    # Per-resolution value stats. GeoJSON only uses the finest level (the
+    # client colors from it), so we skip the parent levels it never builds.
+    stats_t0 = time.perf_counter()
+    stat_levels = range(min_res, finest_res + 1) if serve_format == "vector" else [finest_res]
+    value_stats = {}
+    for col in value_columns:
+        by_res = {}
+        for res in stat_levels:
+            # Recursive glob — h0 hive sub-partitions live under res=N/.
+            uri = f"{output_uri}res={res}/**/*.parquet"
+            row = con.sql(
+                f'SELECT MIN("{col}") AS mn, MAX("{col}") AS mx '
+                f"FROM read_parquet('{uri}')"
+            ).fetchone()
+            by_res[str(res)] = {"min": _jsonable(row[0]), "max": _jsonable(row[1])}
+        value_stats[col] = {"by_res": by_res}
+    stats_seconds = time.perf_counter() - stats_t0
+
+    # GeoJSON path: stream the FeatureCollection straight to object storage so
+    # MapLibre fetches it directly from the public gateway (no pod serving).
+    geojson_url = None
+    geojson_seconds = 0.0
+    if serve_format == "geojson":
+        gj_t0 = time.perf_counter()
+        geojson_uri = f"{output_uri}data.geojson"
+        con.sql(build_geojson_statement(finest_uri, geojson_uri, value_columns))
+        geojson_url = _to_public_http_url(geojson_uri)
+        geojson_seconds = time.perf_counter() - gj_t0
+
     print(
-        f"[tile-build] hash={h} DONE statements={len(statements)} "
+        f"[tile-build] hash={h} DONE format={serve_format} "
         f"finest_res={finest_res} min_res={min_res} "
         f"copy={copy_seconds:.1f}s stats={stats_seconds:.1f}s bounds={bounds_seconds:.1f}s "
-        f"total={time.perf_counter() - build_t0:.1f}s feature_count_finest={feature_count}",
+        f"geojson={geojson_seconds:.1f}s total={time.perf_counter() - build_t0:.1f}s "
+        f"feature_count_finest={feature_count}",
         file=sys.stderr,
     )
 
@@ -438,6 +546,8 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
         "layer_name": MVT_LAYER_NAME,
         "bounds": [w, s, e, n],
         "feature_count_finest": feature_count,
+        "format": serve_format,
+        "geojson_url": geojson_url,
     }
     metadata_sql = (
         f"COPY (SELECT '{_json_dumps_escaped(metadata)}' AS j) "
@@ -445,7 +555,7 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
     )
     con.sql(metadata_sql)
 
-    return {
+    result = {
         "tile_url_template": plan["tile_url_template"],
         "hash": plan["hash"],
         "bounds": [w, s, e, n],
@@ -456,7 +566,10 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
         "value_stats": value_stats,
         "layer_name": MVT_LAYER_NAME,
         "feature_count_finest": feature_count,
+        "geojson_url": geojson_url,
     }
+    result.update(render_recipe(metadata, plan["tile_url_template"]))
+    return result
 
 
 def register_hex_tiles(


### PR DESCRIPTION
Third and largest PR for #178. Adopts the proven-fast path — DuckDB streams hex polygons straight to object storage as GeoJSON, MapLibre fetches them directly from the public gateway — for the common case, while keeping the MVT pyramid for large/multi-zoom sets. **The server decides; the front-end model never chooses.**

## Design (per the #178 discussion)

**Single tool, server auto-selects.** `register_hex_tiles` stays the only hex-viz tool. After Phase 1 (finest-res aggregation, built either way) the row count decides:
- `count ≤ TILE_GEOJSON_MAX_FEATURES` (default **100,000**, env-overridable) → write a GeoJSON FeatureCollection, **skip Phase 2**. Small results get both the fast render *and* a cheaper build (no parent-level COPYs).
- otherwise → build the pyramid exactly as before.

**Paste-ready return.** Every `status="done"` response now carries a render recipe the agent uses verbatim:
```js
map.addSource(id, result.source);
map.addLayer({id, source: id, ...result.layer});  // identical for both formats
```
- `format`: `"geojson"` | `"vector"`
- `source`: geojson → `{type:'geojson', data:url}`; vector → `{type:'vector', tiles:[...]}`
- `layer`: `{type:'fill', paint:{<default linear ramp over value column>}}`, plus `source-layer` for vector only

The agent branches on nothing. The docstring's old hardcoded `{type:'vector'}` snippet is replaced with "render the returned source/layer" — **shorter** prose, format-agnostic.

## How the GeoJSON is produced

Native `COPY … (FORMAT JSON)` + `ST_AsGeoJSON` — a spatial scalar, **not** the GDAL-backed `ST_Write` — so it streams to `s3://` over httpfs. One output row becomes the whole FeatureCollection.

**Validated end-to-end against real S3** (from a dev pod): write succeeds with the same anonymous secret the pyramid uses; the object is publicly fetchable at the CORS-enabled `s3-west` gateway (HTTP 200); parses as a valid FeatureCollection with correct geometry + properties.

## Changes
- `tiles/pyramid.py`: `_GEOJSON_MAX_FEATURES`, `_to_public_http_url`, `build_geojson_statement`, `render_recipe`; `build_hex_tiles` branches after Phase 1; `metadata.json` gains `format` + `geojson_url`; `cached_result_dict` carries the recipe.
- `tiles/endpoint.py`: 404 for geojson-format tilesets (no MVT exists to serve).
- `server.py`: `_done_response` + `register_hex_tiles` return the recipe; docstring rewrite.
- tests: force-vector autouse fixtures in the MVT suites (`_GEOJSON_MAX_FEATURES=0`); new `tests/test_tile_geojson.py` covers auto-select, GeoJSON validity, recipe shapes (incl. legacy metadata + degenerate domain), and the endpoint 404.

## Backward compatibility
Pre-#178 `metadata.json` has no `format` → `render_recipe` defaults to `vector`, so already-built pyramids keep serving and rendering correctly.

## Ordering / rebase note
Branched off `main`, independent of #179/#180. After #179 (timing logs) merges, this needs a trivial rebase in `build_hex_tiles` (both touch that function); no logic conflict.

## Housekeeping
A 6 KB smoke-test object remains at `s3://public-output/hex/_smoketest_pr178/data.geojson` — anonymous DELETE is forbidden on the bucket, so it needs removing with credentials.

232 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)