### PR TITLE
k8s(prod): promote v0.7.0 by digest (#178 hex tile perf)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.6.8@sha256:2cea60cf303ae826cb925106eeb25a77fa4658573541f5ff3665cc0428399fb4
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.0@sha256:6fd667d6c116e58ea7493b08dd626900a21c2fef97a955a20c66a17fbad412a0
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod from v0.6.8 to **v0.7.0**, landing the #178 hex tile performance work:
- #179 build/serve timing logs
- #180 zoom_offset −1→2 (res = z−2; ~300× fewer hexes/tile at CA-scale zooms)
- #181 server-side GeoJSON auto-select (single tool, paste-ready source/layer)

Pinned by digest per AGENTS.md rollout workflow:
`ghcr.io/boettiger-lab/mcp-data-server:v0.7.0@sha256:6fd667d6c116e58ea7493b08dd626900a21c2fef97a955a20c66a17fbad412a0`

Same commit (696017f) is already running on dev (digest 253a2f83) and smoke-tested: z=8→res=6, GeoJSON auto-select returns a gateway-fetchable FeatureCollection, timing logs present.

After merge: `kubectl apply -f k8s/deployment.yaml` then `kubectl rollout restart deployment/duckdb-mcp -n biodiversity`, and verify all 6 replicas converge on the digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)