### PR TITLE
Hex build robustness: cap build threads + lock heartbeat (#184)

### DIFF
--- a/server.py
+++ b/server.py
@@ -283,6 +283,14 @@ _POD_ID = os.environ.get("HOSTNAME") or socket.gethostname()
 # connection so writes don't serialise behind each other or behind reads.
 _BUILD_MAX_CONCURRENCY = int(os.environ.get("TILE_BUILD_MAX_CONCURRENCY", "2"))
 _BUILD_INLINE_WAIT_SECONDS = float(os.environ.get("TILE_BUILD_INLINE_WAIT_SECONDS", "5"))
+# Cap DuckDB threads for the CPU-bound pyramid build so it leaves cores for the
+# uvicorn event loop — a build at the full read default (48) can saturate the
+# pod and starve /healthz → liveness SIGKILL (#184). Reads keep the default.
+_BUILD_THREADS = int(os.environ.get("TILE_BUILD_THREADS", "16"))
+# While a build runs, the owning pod re-writes lock.json this often so a live
+# (possibly slow, thread-capped) build never looks stale; when the pod stops,
+# the lock ages out within _LOCK_STALE_SECONDS. Must stay well under it.
+_LOCK_HEARTBEAT_SECONDS = float(os.environ.get("TILE_LOCK_HEARTBEAT_SECONDS", "30"))
 _build_executor = concurrent.futures.ThreadPoolExecutor(
     max_workers=_BUILD_MAX_CONCURRENCY,
     thread_name_prefix="tile-build",
@@ -293,6 +301,33 @@ _jobs_lock = threading.Lock()
 # string; "done" status reads metadata.json directly so the job dict
 # isn't authoritative for success.
 _jobs: dict = {}
+
+
+def _start_lock_heartbeat(output_uri: str):
+    """Spawn a daemon thread that refreshes lock.json's heartbeat every
+    _LOCK_HEARTBEAT_SECONDS until stopped, so a long (thread-capped) build never
+    looks stale to status polls. Uses its own tiny connection — the build's
+    connection is busy running the multi-minute COPY. Preserves the original
+    started_at (read from the lock register wrote) so reported elapsed grows.
+    Returns a stop() callable; call it when the build ends (the pod dying just
+    stops the heartbeat, letting the lock age out within _LOCK_STALE_SECONDS)."""
+    stop = threading.Event()
+    hb_con = build_tile_connection(threads=1)
+    existing = read_lock(hb_con, output_uri)
+    started_at = (existing or {}).get("started_at")
+
+    def _beat():
+        try:
+            while not stop.wait(_LOCK_HEARTBEAT_SECONDS):
+                try:
+                    write_lock(hb_con, output_uri, pod_id=_POD_ID, started_at=started_at)
+                except Exception:
+                    pass  # transient S3 blip; next beat retries
+        finally:
+            hb_con.close()
+
+    threading.Thread(target=_beat, name="tile-lock-heartbeat", daemon=True).start()
+    return stop.set
 
 
 def _submit_build(plan: dict) -> concurrent.futures.Future:
@@ -306,9 +341,11 @@ def _submit_build(plan: dict) -> concurrent.futures.Future:
             return existing["future"]
 
         def _do_build():
-            build_con = build_tile_connection()
-            print(f"[tile-build] hash={h} START pod={_POD_ID}", file=sys.stderr)
+            build_con = build_tile_connection(threads=_BUILD_THREADS)
+            print(f"[tile-build] hash={h} START pod={_POD_ID} threads={_BUILD_THREADS}",
+                  file=sys.stderr)
             t0 = time.perf_counter()
+            stop_heartbeat = _start_lock_heartbeat(plan["output_uri"])
             try:
                 return build_hex_tiles(build_con, plan)
             except Exception as exc:
@@ -326,6 +363,7 @@ def _submit_build(plan: dict) -> concurrent.futures.Future:
                     pass
                 raise
             finally:
+                stop_heartbeat()
                 build_con.close()
 
         future = _build_executor.submit(_do_build)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -311,6 +311,29 @@ class TestTileRouteMounted:
         assert async_result == sync_result
         assert async_result["status"] == "unknown"
 
+    def test_lock_heartbeat_refreshes_and_preserves_started_at(self, tmp_path, monkeypatch):
+        """A running build's heartbeat keeps the lock fresh (bumps heartbeat_at)
+        while preserving started_at, so a slow build never looks stale and
+        reported elapsed keeps growing (#184)."""
+        import server, time
+        from tiles.db import build_tile_connection
+        from tiles.pyramid import write_lock, read_lock
+        monkeypatch.setattr(server, "_LOCK_HEARTBEAT_SECONDS", 0.05)
+        uri = str(tmp_path) + "/"
+        con = build_tile_connection(threads=1)
+        try:
+            write_lock(con, uri, pod_id="register", started_at=1234.0)  # register's lock
+            stop = server._start_lock_heartbeat(uri)
+            time.sleep(0.3)
+            stop()
+            time.sleep(0.1)
+            lock = read_lock(con, uri)
+            assert lock["started_at"] == 1234.0          # preserved across beats
+            assert lock["heartbeat_at"] > 1234.0          # refreshed toward now
+            assert lock["pod_id"] == server._POD_ID
+        finally:
+            con.close()
+
 
 class TestHealthz:
     """The /healthz endpoint is the kubelet probe target (see issue #157).

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -742,6 +742,47 @@ class TestLockMarkers:
     def test_lock_is_stale_handles_none(self):
         assert lock_is_stale(None) is True
 
+    def test_write_lock_records_heartbeat_and_preserves_started_at(self, tmp_path):
+        con = self._con()
+        uri = str(tmp_path) + "/"
+        write_lock(con, uri, pod_id="pod-A", started_at=1000.0)
+        lock = read_lock(con, uri)
+        assert lock["started_at"] == 1000.0  # preserved across heartbeats
+        assert isinstance(lock["heartbeat_at"], (int, float))
+        assert lock["heartbeat_at"] >= lock["started_at"]
+
+    def test_lock_is_stale_uses_heartbeat_not_started_at(self):
+        # Old started_at but a fresh heartbeat (live, slow build) → NOT stale.
+        live = {"started_at": time.time() - 10_000, "pod_id": "p", "heartbeat_at": time.time()}
+        assert lock_is_stale(live) is False
+        # Fresh started_at but a stale heartbeat (pod died) → stale.
+        dead = {"started_at": time.time(), "pod_id": "p", "heartbeat_at": time.time() - 10_000}
+        assert lock_is_stale(dead) is True
+
+    def test_lock_is_stale_back_compat_started_at_only(self):
+        # Pre-heartbeat lock (written by an older pod) falls back to started_at.
+        assert lock_is_stale({"started_at": time.time(), "pod_id": "p"}) is False
+        assert lock_is_stale({"started_at": time.time() - 10_000, "pod_id": "p"}) is True
+
+
+class TestBuildConnectionThreads:
+    def test_threads_param_is_applied(self):
+        from tiles.db import build_tile_connection
+        con = build_tile_connection(threads=7)
+        try:
+            assert int(con.sql("SELECT current_setting('threads')").fetchone()[0]) == 7
+        finally:
+            con.close()
+
+    def test_default_threads_from_env(self, monkeypatch):
+        from tiles.db import build_tile_connection
+        monkeypatch.setenv("TILE_THREADS", "5")
+        con = build_tile_connection()
+        try:
+            assert int(con.sql("SELECT current_setting('threads')").fetchone()[0]) == 5
+        finally:
+            con.close()
+
 
 from tiles.pyramid import write_failed, read_failed
 

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -4,14 +4,26 @@ Separate from the per-request isolated connections used by the `query` tool:
 tile requests never take user credentials, so the connection can be long-lived
 and shared across requests via con.cursor() for per-request isolation.
 """
+import os
+
 import duckdb
 
 
-def build_tile_connection() -> duckdb.DuckDBPyConnection:
+def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnection:
     """Create a :memory: connection with extensions loaded and S3 configured.
 
     Extensions are assumed to be pre-installed in the image (see mcp-data-server#54);
     LOAD is per-session and always required.
+
+    `threads` sets DuckDB's per-query parallelism for this connection:
+    - The shared READ connection (tile-serve GETs + prepare-phase probes) uses
+      the default (TILE_THREADS, 48). Harmless there — those queries are tiny
+      (LIMIT 0 / LIMIT 1 / single-tile reads).
+    - Pyramid BUILD connections pass a lower cap (server._BUILD_THREADS). A build
+      pegs every thread for minutes; at 48 it can saturate all cores and starve
+      the uvicorn event loop, failing /healthz → liveness SIGKILL (#184). Leaving
+      cores free keeps the loop schedulable. Builds run on their own connection
+      (server._build_executor) so the cap doesn't slow tile reads.
     """
     con = duckdb.connect(":memory:")
     # Extensions may not be pre-installed in dev environments — install defensively.
@@ -19,18 +31,9 @@ def build_tile_connection() -> duckdb.DuckDBPyConnection:
     con.sql("INSTALL spatial; LOAD spatial")
     con.sql("INSTALL h3 FROM community; LOAD h3")
 
-    # Per-query parallelism. THREADS=48 gives register_hex_tiles enough
-    # parallel S3 readers / hash-aggregation workers to push Phase 1 of the
-    # pyramid build past its previous ~30 MB/s effective S3 read ceiling
-    # (the bottleneck observed on the global irrecoverable-carbon build,
-    # which took ~6 min at THREADS=16). The same setting applies to the
-    # shared read connection (tile-serve GETs + prepare-phase probes); on
-    # that connection the higher thread count is harmless because the
-    # queries are tiny (LIMIT 0 / LIMIT 1, single-tile reads). Pyramid
-    # builds run on their own connections from this factory (see
-    # server._build_executor), so a long-running COPY doesn't block tile
-    # reads.
-    con.sql("SET THREADS=48")
+    if threads is None:
+        threads = int(os.environ.get("TILE_THREADS", "48"))
+    con.sql(f"SET THREADS={int(threads)}")
     con.sql("SET preserve_insertion_order=false")
     con.sql("SET enable_object_cache=true")
     con.sql("SET temp_directory='/tmp'")

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -19,11 +19,14 @@ from tiles.tile_math import content_hash
 # `source-layer` option.
 MVT_LAYER_NAME = "layer"
 
-# Builds are tracked across pods via lock.json. A lock older than this
-# is treated as abandoned (the owning pod likely crashed mid-build).
-# Configurable for ops; observed builds complete in 100-120s so 900s
-# gives ~8x headroom.
-_LOCK_STALE_SECONDS = int(os.environ.get("TILE_LOCK_STALE_SECONDS", "900"))
+# Builds are tracked across pods via lock.json. The owning pod refreshes the
+# lock's heartbeat_at every server._LOCK_HEARTBEAT_SECONDS while the build runs;
+# a lock whose heartbeat is older than this is treated as abandoned (the owning
+# pod crashed / was killed / rolled out mid-build). Kept a few heartbeat
+# intervals so brief S3 hiccups don't false-expire a live build, but far below
+# the old fixed 900s so a dead build's "running" ghost resolves in ~2 min, not
+# 15 (#184). Configurable for ops.
+_LOCK_STALE_SECONDS = int(os.environ.get("TILE_LOCK_STALE_SECONDS", "120"))
 
 # Hex sets at or below this many finest-res cells are served as a single
 # GeoJSON FeatureCollection (streamed straight to object storage, fetched
@@ -266,10 +269,22 @@ def _write_json_marker(con: duckdb.DuckDBPyConnection, uri: str, payload: dict) 
     con.sql(sql)
 
 
-def write_lock(con: duckdb.DuckDBPyConnection, output_uri: str, pod_id: str) -> None:
+def write_lock(con: duckdb.DuckDBPyConnection, output_uri: str, pod_id: str,
+               started_at: float | None = None) -> None:
     """Write {output_uri}lock.json announcing this pod owns the in-progress
-    build for this hash. Overwrites any prior lock at the same path."""
-    payload = {"started_at": time.time(), "pod_id": pod_id}
+    build for this hash. Overwrites any prior lock at the same path.
+
+    `started_at` marks when the build began and is preserved across heartbeats
+    (so reported elapsed keeps growing); `heartbeat_at` is bumped to now on every
+    write and is what staleness is judged on. The owning pod re-writes the lock
+    periodically (server heartbeat) so a live build stays fresh; once the pod
+    stops (done/crash), heartbeat_at ages out and lock_is_stale flips true."""
+    now = time.time()
+    payload = {
+        "started_at": now if started_at is None else started_at,
+        "pod_id": pod_id,
+        "heartbeat_at": now,
+    }
     _write_json_marker(con, f"{output_uri}lock.json", payload)
 
 
@@ -279,16 +294,17 @@ def read_lock(con: duckdb.DuckDBPyConnection, output_uri: str):
 
 
 def lock_is_stale(lock: dict | None, now: float | None = None) -> bool:
-    """A missing lock is 'stale' (treated the same as absent). A lock older
-    than _LOCK_STALE_SECONDS is considered abandoned."""
+    """A missing lock is 'stale' (treated the same as absent). A lock whose last
+    heartbeat is older than _LOCK_STALE_SECONDS is considered abandoned. Falls
+    back to started_at for pre-heartbeat locks written by older pods."""
     if lock is None:
         return True
-    started = lock.get("started_at")
-    if not isinstance(started, (int, float)):
+    beat = lock.get("heartbeat_at", lock.get("started_at"))
+    if not isinstance(beat, (int, float)):
         return True
     if now is None:
         now = time.time()
-    return (now - started) > _LOCK_STALE_SECONDS
+    return (now - beat) > _LOCK_STALE_SECONDS
 
 
 def write_failed(con: duckdb.DuckDBPyConnection, output_uri: str, error: str) -> None:


### PR DESCRIPTION
Follows #185 (async hex tools). Hardens the build path so a long pyramid build can't kill its pod or strand the client — independent of the source-query optimization (later track).

## 1. Cap build threads (`TILE_BUILD_THREADS`, default 16)
#185 fixed the dominant starvation (sync polling on the event loop). The residual: the build itself runs CPU-bound DuckDB in the executor, and at the read default (`THREADS=48`) it can peg every core for minutes and still starve the loop → `/healthz` fails → liveness SIGKILL. Capping build threads leaves cores for the loop. Reads keep `TILE_THREADS=48` (tiny queries). `build_tile_connection()` gains a `threads` param.

## 2. Lock heartbeat (fixes the orphaned-lock "ghost running")
A dead build used to leave `lock.json` reading as `running` for the full 900s stale window → high-seas polled a dead build for ~15 min, then "unknown" → re-register loop.

Now the owning pod re-writes `lock.json`'s new `heartbeat_at` every `TILE_LOCK_HEARTBEAT_SECONDS` (30s) from a daemon thread on its own tiny connection (the build connection is busy with the multi-minute COPY), preserving the original `started_at`. `lock_is_stale` judges on `heartbeat_at` (falls back to `started_at` for pre-heartbeat locks), and `TILE_LOCK_STALE_SECONDS` drops **900 → 120**. So:
- a live but slow (thread-capped) build never looks stale (heartbeat keeps it fresh), and
- a dead build stops heartbeating → its ghost resolves in **~2 min, not 15**.

## Tests
heartbeat preserves `started_at` + refreshes `heartbeat_at`; `lock_is_stale` uses `heartbeat_at` with `started_at` back-compat; `build_tile_connection` honors threads param/env. **242 pass.**

## Validation plan (dev)
Re-run a heavy build (IUCN-style global scan) on dev and confirm: pod survives (no liveness kill), `[tile-build]` shows `threads=16`, lock `heartbeat_at` advances during the build, and a killed build's status flips to `unknown` within ~2 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)