### PR TITLE
Default TILE_BUILD_THREADS 16→48 (#184)

### DIFF
--- a/server.py
+++ b/server.py
@@ -283,10 +283,14 @@ _POD_ID = os.environ.get("HOSTNAME") or socket.gethostname()
 # connection so writes don't serialise behind each other or behind reads.
 _BUILD_MAX_CONCURRENCY = int(os.environ.get("TILE_BUILD_MAX_CONCURRENCY", "2"))
 _BUILD_INLINE_WAIT_SECONDS = float(os.environ.get("TILE_BUILD_INLINE_WAIT_SECONDS", "5"))
-# Cap DuckDB threads for the CPU-bound pyramid build so it leaves cores for the
-# uvicorn event loop — a build at the full read default (48) can saturate the
-# pod and starve /healthz → liveness SIGKILL (#184). Reads keep the default.
-_BUILD_THREADS = int(os.environ.get("TILE_BUILD_THREADS", "16"))
+# DuckDB threads for the CPU-bound pyramid build. Default 48 leaves ~16 cores
+# free under the 64-core limit, so the uvicorn event loop stays schedulable and
+# /healthz keeps answering during a build. (#185 removed the on-loop polling
+# that was the real event-loop starvation; a pure build at 48 has ample
+# headroom on a properly-sized pod — #184.) Lower this via env only on
+# under-provisioned / contended nodes where the pod can't actually get ~48
+# cores. Reads use TILE_THREADS (also 48) — their queries are tiny.
+_BUILD_THREADS = int(os.environ.get("TILE_BUILD_THREADS", "48"))
 # While a build runs, the owning pod re-writes lock.json this often so a live
 # (possibly slow, thread-capped) build never looks stale; when the pod stops,
 # the lock ages out within _LOCK_STALE_SECONDS. Must stay well under it.

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -19,11 +19,12 @@ def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnecti
     - The shared READ connection (tile-serve GETs + prepare-phase probes) uses
       the default (TILE_THREADS, 48). Harmless there — those queries are tiny
       (LIMIT 0 / LIMIT 1 / single-tile reads).
-    - Pyramid BUILD connections pass a lower cap (server._BUILD_THREADS). A build
-      pegs every thread for minutes; at 48 it can saturate all cores and starve
-      the uvicorn event loop, failing /healthz → liveness SIGKILL (#184). Leaving
-      cores free keeps the loop schedulable. Builds run on their own connection
-      (server._build_executor) so the cap doesn't slow tile reads.
+    - Pyramid BUILD connections pass server._BUILD_THREADS (env TILE_BUILD_THREADS,
+      default 48 — same as reads, leaving ~16 cores free under the 64-core limit).
+      A build pegs every thread for minutes; the headroom keeps the uvicorn event
+      loop schedulable so /healthz answers (#184/#185). Drop it via env only on
+      under-provisioned nodes. Builds run on their own connection
+      (server._build_executor) so this never slows tile reads.
     """
     con = duckdb.connect(":memory:")
     # Extensions may not be pre-installed in dev environments — install defensively.


### PR DESCRIPTION
Follow-up to #186. That PR capped build threads at 16 as a safety margin; on review that's over-conservative and ~2-3× slower for no benefit on properly-sized pods:

- Pod CPU limit is **64** (dev and prod). A build at **48 threads leaves ~16 cores free** → the uvicorn event loop stays schedulable → `/healthz` answers → no liveness kill.
- #185 (validated 20s→0.002s) already removed the on-loop polling that was the *real* starvation. The original kill was at 48 threads **with** that polling piled on.

So: restore **48** as the default; keep `TILE_BUILD_THREADS` as an env knob to lower it only on under-provisioned/contended nodes. The heartbeat + shorter stale window from #186 are unaffected (and are the real keeper).

Will confirm on dev: a real 48-thread build keeps `/healthz` responsive and the pod doesn't restart. 242 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)