### PR TITLE
k8s(prod): promote v0.7.1 by digest (#184 async hex tools + heartbeat)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.0@sha256:6fd667d6c116e58ea7493b08dd626900a21c2fef97a955a20c66a17fbad412a0
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.1@sha256:256f012e1c683c472c9ca952e4d4ae9d0c5c90c01caf46eb4f2f77c7f5d8c916
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod v0.7.0 → **v0.7.1**, landing the dev-validated fixes for the high-seas hex crash loop: async hex tools (#185, /healthz during poll 19.9s→0.002s), lock heartbeat + 120s stale (#186), TILE_BUILD_THREADS=48 (#187). Digest `sha256:256f012e…`. After merge: apply + rollout duckdb-mcp, verify 6/6 converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)