### PR TITLE
Dial in MVT hex tiles: fix tile-edge seams + adaptive zoom→res (#188)

### DIFF
--- a/server.py
+++ b/server.py
@@ -381,11 +381,13 @@ def _submit_build(plan: dict) -> concurrent.futures.Future:
 # docstring — the MCP framework derives the LLM-facing tool schema from the
 # docstring, so they stay invisible to the agent. Auto-detection (in
 # tiles.pyramid.register_hex_tiles) reads the H column's resolution to set
-# finest_res; min_res=2 is the coarsest level worth materializing. zoom_offset=2
-# maps map-zoom z to H3 res z-2, keeping each tile to ~100-2000 hexes (a healthy
-# MVT feature count) while preserving detail. The previous default (-1, i.e. res
-# z+1) put 40k-130k hexes in every CA-scale tile — fat .pbf payloads and slow
-# ST_AsMVT, for sub-pixel hexes MapLibre couldn't distinguish anyway (#178).
+# finest_res; min_res=2 is the coarsest level worth materializing. zoom_offset is
+# now an adaptive *bias* knob: the tile endpoint picks the H3 res per zoom from
+# the data's extent + cell count to hold each tile near a cell budget (#188), so
+# bounded data (CA) renders finer at mid-zoom than global data does, instead of a
+# single linear offset that fit neither. zoom_offset=2 is neutral (no bias);
+# smaller nudges one res finer per step (legacy direction). The pyramid still
+# builds all res levels, so this is a serve-time choice — no rebuild on retune.
 # Adding `finest_res` etc. to the docstring is almost certainly a mistake — see
 # #125 for the trigger-tightening rationale and the discussion about param surface.
 def register_hex_tiles(

--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -114,6 +114,39 @@ class TestServeTile:
         assert expected in r.content, f"layer name {layer_name!r} not found in MVT bytes"
 
 
+class TestTileEdgeSeams:
+    def test_boundary_hex_emitted_into_neighbor_tiles(self, app_with_tiles, local_bucket):
+        # Seam fix (#188): a hex whose *center* lands in one tile but whose body
+        # overhangs into adjacent tiles must be emitted by every tile it touches.
+        # With the old center-in-tile selection the overhang went undrawn, leaving
+        # a straight clip line (seam) along the tile edge.
+        #
+        # One res-2 cell at (36.5, -119.5): at z=7 its center is in tile (21,50)
+        # but its boundary spans columns 20..22 and rows 49..50. finest=min=2
+        # pins every zoom to res 2 so z=7 serves that single coarse hex.
+        con = app_with_tiles.state.tile_con
+        result = register_hex_tiles(
+            con=con,
+            sql="SELECT h3_latlng_to_cell(36.5, -119.5, 2) AS h2, 1.0 AS val",
+            finest_res=2, min_res=2, agg="AVG", zoom_offset=2,
+        )
+        h = result["hash"]
+        client = TestClient(app_with_tiles)
+
+        def tile_len(z, x, y):
+            r = client.get(f"/tiles/hex/{h}/{z}/{x}/{y}.pbf")
+            assert r.status_code in (200, 204)
+            return len(r.content) if r.status_code == 200 else 0
+
+        empty = tile_len(7, 0, 0)  # far ocean: bare layer envelope, no feature
+        assert tile_len(7, 21, 50) > empty, "center tile should contain the hex"
+        # Each neighbor the hex overhangs into must now also draw it.
+        for nx, ny in [(20, 50), (22, 50), (21, 49)]:
+            assert tile_len(7, nx, ny) > empty, (
+                f"neighbor tile ({nx},{ny}) missing the boundary hex — seam"
+            )
+
+
 class TestAntimeridian:
     def test_dateline_cell_geometry_does_not_span_globe(self):
         # A hex straddling +/-180 must be unwrapped into a continuous frame, not

--- a/tests/test_tile_math.py
+++ b/tests/test_tile_math.py
@@ -33,7 +33,40 @@ class TestTileBounds:
         assert e1 == pytest.approx(w2)
 
 
-from tiles.tile_math import zoom_to_h3_res, content_hash
+from tiles.tile_math import zoom_to_h3_res, content_hash, h3_edge_padding_deg
+
+
+class TestEdgePadding:
+    def test_positive_and_finite(self):
+        pad_lat, pad_lng = h3_edge_padding_deg(5, 36.0)
+        assert pad_lat > 0 and pad_lng > 0
+        assert math.isfinite(pad_lat) and math.isfinite(pad_lng)
+
+    def test_coarser_res_pads_more(self):
+        # res 2 hexes are far larger than res 8, so they need more padding.
+        coarse, _ = h3_edge_padding_deg(2, 0.0)
+        fine, _ = h3_edge_padding_deg(8, 0.0)
+        assert coarse > fine
+
+    def test_lng_padding_grows_toward_poles(self):
+        # A degree of longitude shrinks with latitude, so pad_lng must widen.
+        _, lng_equator = h3_edge_padding_deg(5, 0.0)
+        _, lng_high = h3_edge_padding_deg(5, 60.0)
+        assert lng_high > lng_equator
+        # At the equator pad_lng ≈ pad_lat (cos 0 = 1).
+        lat0, lng0 = h3_edge_padding_deg(5, 0.0)
+        assert lng0 == pytest.approx(lat0, rel=1e-6)
+
+    def test_finite_near_pole(self):
+        # cos(lat) is floored so pad_lng never blows up to infinity at lat 90.
+        pad_lat, pad_lng = h3_edge_padding_deg(5, 90.0)
+        assert math.isfinite(pad_lng)
+        assert pad_lng > pad_lat
+
+    def test_res_out_of_range_is_clamped(self):
+        # Defensive: an out-of-table res must not IndexError.
+        assert h3_edge_padding_deg(99, 0.0) == h3_edge_padding_deg(15, 0.0)
+        assert h3_edge_padding_deg(-5, 0.0) == h3_edge_padding_deg(0, 0.0)
 
 
 class TestZoomToRes:
@@ -53,9 +86,101 @@ class TestZoomToRes:
     def test_default_offset_is_two_maps_z_to_z_minus_2(self):
         # #178: the default must map map-zoom z -> H3 res z-2 (not the old z+1),
         # keeping each tile to ~100-2000 hexes instead of 40k-130k. Pin it so a
-        # regression to the over-fine mapping is caught here.
+        # regression to the over-fine mapping is caught here. (Legacy path: no
+        # bounds/count metadata, so the linear mapping applies.)
         for z in range(4, 11):
             assert zoom_to_h3_res(z, min_res=2, finest_res=12) == z - 2
+
+
+from tiles.tile_math import tiles_covering_bounds
+
+
+# Real-shaped fixtures for the adaptive mapping (#188).
+_CA = dict(bounds=[-124.4, 32.5, -114.1, 42.0], feature_count_finest=539258, finest_res=8)
+_GLOBAL = dict(bounds=[-180.0, -60.0, 180.0, 75.0], feature_count_finest=14_000_000, finest_res=6)
+
+
+class TestTilesCoveringBounds:
+    def test_world_at_z0_is_one_tile(self):
+        assert tiles_covering_bounds(0, [-180, -85, 180, 85]) == 1
+
+    def test_grows_with_zoom(self):
+        prev = 0
+        for z in range(0, 8):
+            n = tiles_covering_bounds(z, _CA["bounds"])
+            assert n >= prev  # more tiles cover the same bbox as zoom increases
+            prev = n
+
+    def test_global_covers_more_than_bounded(self):
+        for z in range(3, 8):
+            assert tiles_covering_bounds(z, _GLOBAL["bounds"]) > tiles_covering_bounds(z, _CA["bounds"])
+
+    def test_never_below_one(self):
+        # A degenerate point bbox still spans (at least) the one tile it sits in.
+        assert tiles_covering_bounds(10, [-122.3, 37.8, -122.3, 37.8]) == 1
+
+
+class TestAdaptiveZoomToRes:
+    def test_bounded_data_renders_finer_than_global_at_mid_zoom(self):
+        # The whole point of the adaptive mapping (#188): at the same zoom,
+        # bounded data (covers few tiles) can afford finer hexes than global
+        # data (which would blow the per-tile budget at that res).
+        for z in range(4, 9):
+            rc = zoom_to_h3_res(z, 2, **_CA)
+            rg = zoom_to_h3_res(z, 2, **_GLOBAL)
+            assert rc >= rg
+        # And strictly finer somewhere in that band, not merely equal throughout.
+        assert any(zoom_to_h3_res(z, 2, **_CA) > zoom_to_h3_res(z, 2, **_GLOBAL)
+                   for z in range(4, 9))
+
+    def test_ca_mid_zoom_is_no_longer_too_coarse(self):
+        # The reported bug: CA at z=5 rendered res 3 (state-sized blobs). The
+        # adaptive mapping should lift mid-zoom CA into the res 5-6 range.
+        assert zoom_to_h3_res(5, 2, **_CA) >= 5
+
+    def test_non_decreasing_in_zoom(self):
+        prev = 0
+        for z in range(0, 14):
+            r = zoom_to_h3_res(z, 2, **_CA)
+            assert r >= prev
+            prev = r
+
+    def test_clamped_to_finest_and_min(self):
+        assert zoom_to_h3_res(22, 2, **_CA) == _CA["finest_res"]  # deep zoom
+        assert zoom_to_h3_res(0, 2, **_CA) >= 2                    # never below min_res
+
+    def test_per_tile_budget_is_respected(self):
+        # The chosen res must keep estimated cells/tile within ~one H3 step of
+        # the 4000 budget (discreteness means it can't hit it exactly; one res
+        # finer is a 7x jump).
+        for z in range(3, 12):
+            r = zoom_to_h3_res(z, 2, **_CA, target_cells_per_tile=4000)
+            if r in (2, _CA["finest_res"]):
+                continue  # clamped — budget not the binding constraint
+            cpt = _CA["feature_count_finest"] * 7 ** (r - _CA["finest_res"]) \
+                / tiles_covering_bounds(z, _CA["bounds"])
+            assert cpt <= 4000 * 7
+
+    def test_smaller_zoom_offset_biases_finer(self):
+        # zoom_offset keeps its legacy direction as an adaptive bias knob:
+        # smaller offset -> finer res.
+        finer = zoom_to_h3_res(6, 2, zoom_offset=0, **_CA)
+        base = zoom_to_h3_res(6, 2, zoom_offset=2, **_CA)
+        coarser = zoom_to_h3_res(6, 2, zoom_offset=4, **_CA)
+        assert finer >= base >= coarser
+        assert finer > coarser
+
+    def test_falls_back_to_linear_without_metadata(self):
+        # Pre-#178 metadata lacks bounds/feature_count -> legacy linear mapping.
+        assert zoom_to_h3_res(8, 2, finest_res=12, zoom_offset=2) == 6
+        assert zoom_to_h3_res(8, 2, finest_res=12, zoom_offset=2,
+                              feature_count_finest=0, bounds=None) == 6
+
+    def test_lower_target_picks_coarser_res(self):
+        # A tighter per-tile budget should never pick a finer res.
+        tight = zoom_to_h3_res(7, 2, **_CA, target_cells_per_tile=500)
+        loose = zoom_to_h3_res(7, 2, **_CA, target_cells_per_tile=8000)
+        assert tight <= loose
 
 
 class TestContentHash:

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -17,7 +17,11 @@ import anyio
 from starlette.requests import Request
 from starlette.responses import Response
 
-from tiles.tile_math import tile_xyz_to_lnglat_bounds, zoom_to_h3_res
+from tiles.tile_math import (
+    h3_edge_padding_deg,
+    tile_xyz_to_lnglat_bounds,
+    zoom_to_h3_res,
+)
 
 
 MVT_CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
@@ -139,8 +143,12 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
          partitioned pyramid to a handful of files instead of scanning the
          entire globe at the target resolution.
       3. Filter pyramid rows where the cell's center lat/lng falls inside the
-         tile bbox. Each cell is rendered by exactly one tile (the one
-         containing its center).
+         tile bbox *widened by one hex circumradius* (h3_edge_padding_deg).
+         A hex straddling a tile edge has its center in one tile but its body
+         in both; the pad makes every tile it touches emit it, so the renderer
+         draws the full hex on both sides of the seam (#188). The same hex thus
+         appears in several neighboring tiles — harmless for rendering, and
+         ST_AsMVTGeom's buffer lets MapLibre stitch the duplicates seamlessly.
       4. Project cell geometries with ST_AsMVTGeom then aggregate with ST_AsMVT.
 
     bbox_h0 candidate-cell derivation:
@@ -162,21 +170,34 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
     # cells whose boundary crosses the antimeridian; unwrap geometry only there.
     touches_dateline = west <= -179.999 or east >= 179.999
     boundary_geom = _boundary_geom_sql(touches_dateline)
+    # ST_AsMVTGeom bounds stay the *exact* tile bbox — the merc projection must
+    # map cell coords to true tile pixels. The seam pad widens only the cell
+    # SELECTION window (below), not the projection bounds.
     mx_w = _lng_to_merc_x(west)
     mx_e = _lng_to_merc_x(east)
     my_s = _lat_to_merc_y(south)
     my_n = _lat_to_merc_y(north)
+
+    # Widen the cell-selection window by ~one hex circumradius so boundary-
+    # crossing hexes are emitted by every tile they touch (#188). pad_lng grows
+    # with latitude; use the pole-most edge so the wider side covers the tile.
+    pad_lat, pad_lng = h3_edge_padding_deg(target_res, max(abs(north), abs(south)))
+    south_p = south - pad_lat
+    north_p = north + pad_lat
+    west_p = west - pad_lng
+    east_p = east + pad_lng
 
     if z <= 2:
         bbox_h0_sql = "SELECT CAST(UNNEST(h3_get_res0_cells()) AS BIGINT) AS h0"
     else:
         # 8x8 grid → sample spacing ~tile_width/7. At z>=3 tile width <= 45°
         # while h0 diameter is ~15° (Earth/12 cells), so every overlapping h0
-        # cell receives at least one sample point.
+        # cell receives at least one sample point. Sample the padded bbox so an
+        # edge hex sitting in a neighboring h0 partition isn't pruned away.
         bbox_h0_sql = (
             "SELECT DISTINCT CAST(h3_latlng_to_cell(\n"
-            f"  {south} + (i/7.0) * ({north} - {south}),\n"
-            f"  {west} + (j/7.0) * ({east} - {west}),\n"
+            f"  {south_p} + (i/7.0) * ({north_p} - {south_p}),\n"
+            f"  {west_p} + (j/7.0) * ({east_p} - {west_p}),\n"
             "  0\n"
             ") AS BIGINT) AS h0\n"
             "FROM range(8) t1(i), range(8) t2(j)"
@@ -192,14 +213,15 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
             hive_partitioning=true
           ) p
           SEMI JOIN bbox_h0 USING (h0)
-          WHERE h3_cell_to_lat(p.h) BETWEEN {south} AND {north}
-            AND h3_cell_to_lng(p.h) BETWEEN {west} AND {east}
+          WHERE h3_cell_to_lat(p.h) BETWEEN {south_p} AND {north_p}
+            AND h3_cell_to_lng(p.h) BETWEEN {west_p} AND {east_p}
         ),
         projected AS (
           SELECT
             ST_AsMVTGeom(
               ST_Transform({boundary_geom}, 'EPSG:4326', 'EPSG:3857', true),
-              {{'min_x': {mx_w}, 'min_y': {my_s}, 'max_x': {mx_e}, 'max_y': {my_n}}}::BOX_2D
+              {{'min_x': {mx_w}, 'min_y': {my_s}, 'max_x': {mx_e}, 'max_y': {my_n}}}::BOX_2D,
+              4096, 256, true
             ) AS geom,
             src.* EXCLUDE (h, h0)
           FROM src
@@ -242,7 +264,22 @@ async def serve_tile(request: Request) -> Response:
     finest_res = meta["finest_res"]
     min_res = meta["min_res"]
     zoom_offset = meta["zoom_offset"]
-    target_res = zoom_to_h3_res(z, min_res=min_res, finest_res=finest_res, zoom_offset=zoom_offset)
+    # Adaptive zoom->res (#188): bounds + feature_count_finest let the mapping
+    # pick the finest res that keeps each tile within the cell budget, so bounded
+    # data (CA) shows finer hexes at mid-zoom than global data does. Both fields
+    # are present in all post-#178 metadata; .get keeps pre-#178 tilesets on the
+    # legacy linear mapping. Budget is ops-tunable via TILE_TARGET_CELLS_PER_TILE.
+    target_res = zoom_to_h3_res(
+        z,
+        min_res=min_res,
+        finest_res=finest_res,
+        zoom_offset=zoom_offset,
+        feature_count_finest=meta.get("feature_count_finest"),
+        bounds=meta.get("bounds"),
+        target_cells_per_tile=int(
+            os.environ.get("TILE_TARGET_CELLS_PER_TILE", "4000")
+        ),
+    )
 
     sql = _build_tile_sql(namespace, name, z, x, y, target_res, finest_res)
     t0 = time.perf_counter()

--- a/tiles/tile_math.py
+++ b/tiles/tile_math.py
@@ -14,15 +14,127 @@ def tile_xyz_to_lnglat_bounds(z: int, x: int, y: int) -> Tuple[float, float, flo
     return (west, lat_s, east, lat_n)
 
 
-def zoom_to_h3_res(z: int, min_res: int, finest_res: int, zoom_offset: int = 2) -> int:
-    """Clamp(z - zoom_offset, min_res, finest_res) — coarser hexes at lower zooms.
+# H3 average hexagon edge length (km) by resolution, res 0-15. For a regular
+# hexagon the circumradius (center-to-vertex) equals the edge length, so this
+# doubles as the max center-to-boundary distance of a cell at each resolution.
+# Source: https://h3geo.org/docs/core-library/restable/
+_H3_EDGE_KM = [
+    1107.712591, 418.6760055, 158.2446558, 59.81085794, 22.6063794,
+    8.544408276, 3.229482772, 1.220629759, 0.461354684, 0.174375668,
+    0.065907807, 0.024910561, 0.009415526, 0.003559893, 0.001348575,
+    0.000509713,
+]
 
-    zoom_offset=2 (the default) maps map-zoom z to H3 res z-2, which keeps each
-    tile to ~100-2000 hexes across zooms — a healthy MVT feature count. Smaller
-    offsets render finer hexes (more features/tile, fatter .pbf); offset=-1 (the
-    old default) produced 40k-130k hexes per tile at CA-scale zooms (#178).
+_EARTH_KM_PER_DEG = 111.195
+
+
+def h3_edge_padding_deg(res: int, lat: float) -> Tuple[float, float]:
+    """Return (pad_lat, pad_lng) in degrees ≈ one hex circumradius at `res`.
+
+    Used to widen a tile's cell-selection window so a hex whose *center* sits
+    just outside the tile bbox — but whose body overlaps it — is still emitted
+    into this tile. That is the seam fix (#188): center-in-tile selection drew
+    each boundary-crossing hex in exactly one tile, leaving the overhang in the
+    neighbor undrawn. Longitude degrees shrink toward the poles, so pad_lng is
+    scaled by 1/cos(lat); cos is floored to keep it finite near the poles.
     """
-    target = z - zoom_offset
+    res = max(0, min(15, res))
+    radius_km = _H3_EDGE_KM[res]
+    pad_lat = radius_km / _EARTH_KM_PER_DEG
+    cos_lat = max(0.01, math.cos(math.radians(lat)))
+    pad_lng = pad_lat / cos_lat
+    return (pad_lat, pad_lng)
+
+
+# The neutral zoom_offset: at this value the adaptive mapping applies no bias.
+# Smaller offsets nudge one H3 res finer per step, larger ones coarser — the
+# same direction the legacy linear mapping used (res = z - zoom_offset).
+_BASE_ZOOM_OFFSET = 2
+
+# Target hexes per *tile*. A screen shows ~4-8 tiles, so a few thousand per tile
+# is ~10-30k hexes per view — dense enough to read as a continuous field, small
+# enough to keep the .pbf and client parse fast. Tunable; see #188.
+_TARGET_CELLS_PER_TILE = 4000
+
+# H3 is aperture-7: each resolution has ~7x the cells of its parent. Rolling a
+# contiguous region up one level multiplies the cell count by ~1/7.
+_H3_APERTURE = 7.0
+
+
+def _merc_y_norm(lat: float) -> float:
+    """Latitude (deg) -> web-mercator Y normalized to [0,1] (0=north, 1=south).
+
+    Clamped to the Web Mercator latitude limit (~85.0511 deg) so the log stays
+    finite at the poles.
+    """
+    lat = max(-85.0511, min(85.0511, lat))
+    siny = math.sin(math.radians(lat))
+    return 0.5 - math.log((1 + siny) / (1 - siny)) / (4 * math.pi)
+
+
+def tiles_covering_bounds(z: int, bounds) -> int:
+    """Count XYZ tiles at zoom z that the data's [w, s, e, n] bbox spans (>=1).
+
+    Used by the adaptive zoom->res mapping to estimate how thinly the data's
+    cells spread across tiles at a given zoom. A wide global extent covers many
+    tiles (so each holds few cells -> finer res is affordable); a small bounded
+    extent covers few tiles (so each holds many cells -> coarser res needed).
+    """
+    w, s, e, n = bounds
+    nt = 2 ** z
+
+    def _clamp_idx(v):
+        # An edge falling exactly on the far boundary (lng 180, merc-y 1.0)
+        # maps to index nt, which is past the last tile (nt-1).
+        return min(nt - 1, max(0, math.floor(v)))
+
+    x0 = _clamp_idx((w + 180.0) / 360.0 * nt)
+    x1 = _clamp_idx((e + 180.0) / 360.0 * nt)
+    y0 = _clamp_idx(_merc_y_norm(n) * nt)  # north edge -> smaller tile-y
+    y1 = _clamp_idx(_merc_y_norm(s) * nt)
+    cols = max(1, x1 - x0 + 1)
+    rows = max(1, y1 - y0 + 1)
+    return cols * rows
+
+
+def zoom_to_h3_res(
+    z: int,
+    min_res: int,
+    finest_res: int,
+    zoom_offset: int = 2,
+    feature_count_finest: int | None = None,
+    bounds=None,
+    target_cells_per_tile: int = _TARGET_CELLS_PER_TILE,
+) -> int:
+    """Map a map-zoom z to the H3 resolution to serve, clamped to [min_res, finest_res].
+
+    Two modes:
+
+    Adaptive (when feature_count_finest and bounds are both given) — pick the
+    finest res whose estimated cells-per-tile stays under target_cells_per_tile.
+    A region of N cells at finest_res has ~N * 7^(r-finest_res) cells at res r;
+    spread across tiles_covering_bounds(z) tiles, that's the per-tile load. This
+    resolves the bounded-vs-global tension a single linear offset can't (#188):
+    CA-sized data covers few tiles so it can afford finer res at mid-zoom, while
+    global data at the same zoom is held coarser to stay within the per-tile
+    budget. zoom_offset still nudges the result one res per step off _BASE
+    (smaller=finer), preserving the knob's legacy direction.
+
+    Legacy (no count/bounds — older metadata) — the linear res = z - zoom_offset.
+    zoom_offset=2 maps z -> z-2; smaller offsets render finer hexes (more
+    features/tile). offset=-1 (the old default) produced 40k-130k hexes per tile
+    at CA-scale zooms (#178).
+    """
+    if feature_count_finest and bounds is not None and feature_count_finest > 0:
+        n_tiles = tiles_covering_bounds(z, bounds)
+        # Solve target >= count_finest * 7^(r-finest) / n_tiles for the largest r:
+        #   r <= finest + log7(target * n_tiles / count_finest)
+        ratio = target_cells_per_tile * n_tiles / feature_count_finest
+        delta = math.log(ratio) / math.log(_H3_APERTURE)
+        bias = _BASE_ZOOM_OFFSET - zoom_offset  # smaller offset -> finer
+        target = int(math.floor(finest_res + delta + 0.5)) + bias
+    else:
+        target = z - zoom_offset
     return max(min_res, min(finest_res, target))
 
 


### PR DESCRIPTION
Closes #188 (both halves: seam fix + zoom_offset retune).

Two **serve-time** fixes for the MVT hex path. Neither requires a pyramid rebuild — the pyramid already materializes every res level, so both are pure read-path changes that apply to existing tilesets immediately.

## 1. Tile-edge seams

The seam (straight clip lines across an otherwise continuous hex grid at tile boundaries).

**Root cause, corrected.** I probed DuckDB 1.5.3 and found `ST_AsMVTGeom` **already defaults to a 256-unit buffer** (output extends to −256/4352 beyond the 0–4096 extent). So the issue's "no buffer" theory was only half right — the buffer was never missing. The real cause was **center-in-tile selection alone**: a hex straddling a tile edge was emitted only by the tile holding its *center*; the neighbor never selected it, so the overhang went undrawn.

**Fix.** Widen the cell-selection window by ~one hex circumradius (`h3_edge_padding_deg`, with `pad_lng` scaled by `1/cos(lat)` and floored near the poles) so every tile a hex touches emits it. The `ST_AsMVTGeom` projection bounds stay the **exact** tile bbox (correct pixel mapping); the buffer stitches the duplicate copies seamlessly. The h0-partition sampling grid is widened to the padded bbox too, so an edge hex sitting in a neighboring h0 partition isn't pruned away. Buffer made explicit (`4096, 256, true`).

Verified end-to-end: one res-2 hex whose center is in tile z7/(21,50) but whose body spans cols 20–22 now renders in **all three overhang neighbors** while a far ocean tile stays an empty envelope. Pre-fix, only the center tile drew it.

## 2. Adaptive zoom→res (the zoom_offset retune)

The issue notes a single global offset can't serve both bounded and global data: CA at z=5 rendered **res 3** (state-sized blobs) while a finer offset would put **40k–130k cells/tile** on global data.

The mapping now uses the registered `bounds` + `feature_count_finest` (both already in post-#178 metadata) to pick the finest res whose estimated cells-per-tile stays under a budget (`TILE_TARGET_CELLS_PER_TILE`, default 4000). A region of N cells at finest_res has ~`N·7^(r−finest)` cells at res r, spread across `tiles_covering_bounds(z)` tiles.

| zoom | CA (bounded) | Global |
|---|---|---|
| z=5 | **res 6** (~2.7k/tile) | res 5 (~3.4k/tile) |
| z=2 | res 5 (detail, cheap) | res 3 (coarse, budget-bound) |

This resolves the tension: bounded data covers few tiles so it affords finer hexes; global data at the same zoom is held coarser to stay within budget. `zoom_offset` is retained as a bias knob (smaller = one res finer per step, legacy direction); pre-#178 metadata falls back to the linear `z − zoom_offset` mapping.

## Tests
New: `TestEdgePadding`, `TestTileEdgeSeams` (neighbor renders the boundary hex), `TestTilesCoveringBounds`, `TestAdaptiveZoomToRes` (bounded-vs-global, budget, clamps, bias, fallback). **Full suite: 260 passing.**

## Follow-ups (separate issues)
- The 4000 target is theory-derived; worth confirming against real renders in the padus app alongside #190.
- #190 (GeoJSON eval) and #189 (registration query opt) are the remaining hex lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)