### PR TITLE
k8s(prod): promote v0.7.2 by digest (MVT seam fix + adaptive zoom→res: #188)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.1@sha256:256f012e1c683c472c9ca952e4d4ae9d0c5c90c01caf46eb4f2f77c7f5d8c916
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.2@sha256:e22ce38fe0f84a1d43349bd8a972d6a799df7e282a227737ff06d339c3e27879
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
 mcp
-duckdb
+# Pinned: the community `h3` extension is built per exact DuckDB version and
+# lags new releases. Unpinned, CI/image builds pull the latest DuckDB (e.g.
+# 1.5.4) for which `INSTALL h3 FROM community` has no candidate, breaking every
+# tile path. 1.5.3 is the version our extensions (spatial + h3) are validated
+# against and what prod runs. Bump only once community h3 ships for the target.
+duckdb==1.5.3
 pandas
 uvicorn
 tabulate


### PR DESCRIPTION
Promotes **v0.7.2** to production, pinned by digest `sha256:e22ce38f…`. Previous prod: v0.7.1.

Ships the MVT hex tile improvements from #188 / #192. Both are **serve-time** changes that apply to existing tilesets immediately — **no pyramid rebuild or re-registration**.

## What's in v0.7.2

**Tile-edge seams fixed.** Coarse-zoom hex layers showed straight clip lines / half-hexes at tile boundaries. The cause was center-in-tile cell selection (a hex straddling an edge was emitted only by the tile holding its center). Fix widens the cell-selection window by one hex circumradius so every tile a hex touches emits it; `ST_AsMVTGeom`'s buffer (already 256u by default) stitches the duplicates.

**Adaptive zoom→resolution.** Replaced the fixed linear `res = z − zoom_offset` with a feature-count-aware mapping that uses each tileset's registered extent + cell count to pick the finest H3 res keeping a tile near a cell budget (`TILE_TARGET_CELLS_PER_TILE`, default 4000). Bounded data (e.g. CA) now renders res 5–6 hexes at mid-zoom instead of state-sized blobs; global data stays coarser at the same zoom to bound per-tile size. `zoom_offset` retained as a bias knob; pre-existing metadata falls back to the linear mapping.

## Validation
Deployed to dev and validated on the padus app with continental carbon hex: seams eliminated ("huge improvement"), res ladder confirmed (z1→4, z5→5, z8→8, z10→9). Full test suite green (260 tests).

## Rollout (after merge)
```
kubectl apply -f k8s/deployment.yaml
kubectl rollout restart deployment/duckdb-mcp -n biodiversity
```

## Known follow-ups (non-blocking)
- #193 — adaptive res uses average density, so hotspot tiles (e.g. Amazon carbon) run fat/slow at deep zoom; auto-`finest_res` cap on large extents.
- #189 — agent SQL guidance (spatially clip before hexing; avoid `lower()` on hex assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)