### PR TITLE
Fix coarse-zoom MVT 500s on pole-spanning tilesets via ST_MakeValid (#197)

### DIFF
--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -147,6 +147,35 @@ class TestTileEdgeSeams:
             )
 
 
+class TestCoarseTileGeometryRobustness:
+    def test_pole_spanning_set_does_not_500_at_coarse_zoom(self, app_with_tiles, local_bucket):
+        # #197: a global, pole-spanning tileset rendered at coarse zoom used to
+        # 500 — near the web-mercator latitude limit (~±85.05°) a transformed H3
+        # boundary can become invalid, and ST_AsMVTGeom (aggregating the whole
+        # tile) raised TopologyException, killing the *entire* tile on one bad
+        # cell. ST_MakeValid per cell must keep the tile rendering.
+        con = app_with_tiles.state.tile_con
+        sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 4) AS h4, 1.0 AS val FROM (
+                SELECT 80 + random()*9.5 AS lat, -180 + random()*360 AS lng FROM range(2000)
+                UNION ALL SELECT -80 - random()*9.5, -180 + random()*360 FROM range(2000)
+                UNION ALL SELECT random()*40, -180 + random()*360 FROM range(1000)
+            )
+        """
+        result = register_hex_tiles(
+            con=con, sql=sql, finest_res=4, min_res=2, agg="AVG", zoom_offset=2,
+        )
+        h = result["hash"]
+        client = TestClient(app_with_tiles)
+        # Coarse tiles (incl. the z=0 whole-world tile and dateline edges) must
+        # render, not 500.
+        for z, x, y in [(0, 0, 0), (1, 0, 0), (1, 1, 0), (2, 0, 0)]:
+            r = client.get(f"/tiles/hex/{h}/{z}/{x}/{y}.pbf")
+            assert r.status_code in (200, 204), (
+                f"coarse tile {z}/{x}/{y} returned {r.status_code} (TopologyException regression)"
+            )
+
+
 class TestAntimeridian:
     def test_dateline_cell_geometry_does_not_span_globe(self):
         # A hex straddling +/-180 must be unwrapped into a continuous frame, not

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -219,7 +219,16 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
         projected AS (
           SELECT
             ST_AsMVTGeom(
-              ST_Transform({boundary_geom}, 'EPSG:4326', 'EPSG:3857', true),
+              -- ST_MakeValid repairs cells whose web-mercator projection is
+              -- degenerate/self-intersecting — at coarse zoom near the mercator
+              -- latitude limit (~±85.05°), a transformed H3 boundary can become
+              -- invalid, and ST_AsMVTGeom (an aggregate over the whole tile)
+              -- raises TopologyException, 500-ing the *entire* tile on one bad
+              -- cell. Validating per-cell keeps one degenerate hex from taking
+              -- down a global/pole-spanning tileset's coarse tiles (#197).
+              ST_MakeValid(
+                ST_Transform({boundary_geom}, 'EPSG:4326', 'EPSG:3857', true)
+              ),
               {{'min_x': {mx_w}, 'min_y': {my_s}, 'max_x': {mx_e}, 'max_y': {my_n}}}::BOX_2D,
               4096, 256, true
             ) AS geom,


### PR DESCRIPTION
Closes #197.

## Problem
Global, pole-spanning MVT tilesets **500 at coarse zoom** (z=0/1/2). Near the Web Mercator latitude limit (~±85.05°), an H3 boundary transformed to EPSG:3857 can become degenerate/self-intersecting; `ST_AsMVTGeom` rejects it, and since it feeds an `ST_AsMVT` **aggregate over the whole tile**, one bad cell raises `TopologyException` and 500s the *entire* tile. Observed on dev with a 22.7M-cell global GBIF hex.

## Fix
Wrap the projected geometry in `ST_MakeValid(...)` in `_build_tile_sql` — a degenerate cell is repaired rather than aborting the tile.

**Verified:** the z=0 whole-world tile of the 22.7M-cell dataset renders (6.3 MB) instead of 500; a local pole-spanning set's coarse tiles (z=0/1/2 + dateline edges) go 500 → 200.

## Not a #188/#192 regression
Confirmed the **old** center-in-tile lat window `[-85.05, 85.05]` throws the identical error, and our `ST_AsMVTGeom(…,4096,256,true)` args equal the prior defaults. So #192 only changed *which cells* are selected; the un-padded set fails too. Pre-existing gap, never exercised until a global pole-spanning dataset — **prod v0.7.2 is not newly broken by #192.** Same robustness theme as #196 (GeoJSON pole/dateline drop).

## Test
`TestCoarseTileGeometryRobustness` — a pole-spanning tileset's coarse tiles (z=0/1/2 + dateline edges) must return 200/204, not 500. Full suite 109 passing.

## Note
Even fixed, coarse tiles of a 22M-cell global set are ~6 MB — that's the adaptive-density follow-up (#193), separate from this 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)