### PR TITLE
k8s(prod): promote v0.7.3 by digest (MVT coarse-tile ST_MakeValid: #197)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.2@sha256:e22ce38fe0f84a1d43349bd8a972d6a799df7e282a227737ff06d339c3e27879
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.3@sha256:c3d06161dce3316e51d6e8aa98b6d73be8bbeec452b3cc35b477ce40852d3971
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes **v0.7.3** to production, pinned by digest `sha256:c3d06161…`. Previous prod: v0.7.2.

## What's in v0.7.3
Fixes coarse-zoom **500s on global, pole-spanning MVT tilesets** (#197 / #198). Near the Web Mercator latitude limit (~±85.05°), an H3 boundary transformed to EPSG:3857 can become degenerate; `ST_AsMVTGeom` rejected it and — feeding an `ST_AsMVT` aggregate over the whole tile — raised `TopologyException`, 500ing the entire tile on one bad cell. `ST_MakeValid` repairs the geometry per cell.

**Pre-existing gap, not a #192 regression** (the old center-in-tile window throws identically). Verified on dev: the z=0 whole-world tile of a 22.7M-cell global GBIF set renders (6.8 MB) instead of 500.

## Validation
On dev (v0.7.3 `:main`): previously-500ing coarse tiles for the global dataset now return 200 (`0/0/0`, `1/0/0`, `1/1/0`, `2/3/1`). MVT renders well at all zooms; GeoJSON path confirmed working too.

## Rollout (after merge)
```
kubectl apply -f k8s/deployment.yaml
kubectl rollout restart deployment/duckdb-mcp -n biodiversity
```

## Follow-ups (non-blocking)
#199 (GeoJSON-vs-MVT route control), #193 (coarse-tile size/adaptive density), #196 (GeoJSON pole/dateline robustness), #190 (GeoJSON eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)