### PR TITLE
Fix antimeridian streaks on global MVT: project dateline cells by hand (#201)

### DIFF
--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -181,7 +181,15 @@ class TestAntimeridian:
         # A hex straddling +/-180 must be unwrapped into a continuous frame, not
         # emitted as a single ring whose vertices jump +179.9 -> -179.9 (which
         # MapLibre draws "the long way" as a globe-spanning streak). See #164.
+        #
+        # #201: _boundary_geom_sql now returns the geometry already in EPSG:3857.
+        # The earlier version measured the *4326* span (which the unwrap fixed)
+        # but ST_Transform then re-normalized the out-of-range longitudes and
+        # recreated a globe-spanning polygon in mercator. So assert the span in
+        # *mercator* (post-projection) is well under the world width — this is
+        # the assertion that actually catches the streak regression.
         from tiles.endpoint import _boundary_geom_sql
+        WORLD_M = 20037508.34 * 2  # full web-mercator world width (meters)
         con = build_tile_connection()
         try:
             con.sql(
@@ -199,7 +207,11 @@ class TestAntimeridian:
             assert rows, "no geometry produced"
             for span, valid in rows:
                 assert valid, "unwrapped boundary geometry must be valid"
-                assert span < 180, f"geometry spans the dateline (lng span={span})"
+                # A single H3 cell is tiny (<<1% of the world); the streak bug
+                # made it ~the full world width in mercator.
+                assert span < WORLD_M * 0.5, (
+                    f"cell geometry spans the globe in mercator (x-span={span:.0f})"
+                )
         finally:
             con.close()
 

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -96,24 +96,29 @@ def _get_cached_metadata(app_state, con, namespace: str, name: str):
 
 
 def _boundary_geom_sql(touches_dateline: bool) -> str:
-    """Return a SQL scalar expression (EPSG:4326 GEOMETRY) for cell `src.h`'s
-    H3 boundary polygon.
+    """Return a SQL scalar expression for cell `src.h`'s H3 boundary polygon,
+    already projected to EPSG:3857 (web mercator).
 
-    `h3_cell_to_boundary_wkt` emits a cell straddling +/-180 as a single ring
-    whose longitudes jump +179.9 -> -179.9; MapLibre then draws it "the long
-    way," producing globe-spanning streaks (#164). Only the easternmost and
-    westernmost tile columns can contain such cells, so `_build_tile_sql`
-    passes touches_dateline=True only for those tiles.
+    Non-dateline tiles: ST_Transform of the raw EPSG:4326 boundary.
 
-    When touches_dateline, rebuild the boundary in a continuous frame: dump the
-    ring's vertices and shift each by +/-360 so it stays within 180 deg of the
-    cell's center longitude. The cell then sits wholly on one side of the seam
-    (overflow past +/-180 is clipped to the tile by ST_AsMVTGeom). Non-crossing
-    cells are unchanged (the CASE is a no-op when max-min lng span <= 180).
+    Dateline tiles: `h3_cell_to_boundary_wkt` emits a cell straddling +/-180 as
+    a single ring whose longitudes jump +179.9 -> -179.9 (#164). We rebuild it
+    in a continuous frame (shift each vertex +/-360 to stay within 180 deg of
+    the cell's center longitude) AND project to mercator *by hand* rather than
+    via ST_Transform. ST_Transform re-normalizes longitude into [-180,180],
+    which would undo the unwrap (e.g. -180.16 -> +179.84) and recreate a
+    globe-spanning polygon -> the horizontal streaks of #201. Mercator x is
+    linear in lng, so projecting the shifted (possibly out-of-range) longitudes
+    directly keeps the cell continuous just past the world edge, where
+    ST_AsMVTGeom clips it cleanly. Only the edge tile columns pass
+    touches_dateline=True. x/y formulas match _lng_to_merc_x / _lat_to_merc_y
+    (and EPSG:3857) so dateline cells line up with the ST_Transform'd rest.
     """
     if not touches_dateline:
-        return "h3_cell_to_boundary_wkt(src.h)::GEOMETRY"
-    return """(
+        return ("ST_Transform(h3_cell_to_boundary_wkt(src.h)::GEOMETRY, "
+                "'EPSG:4326', 'EPSG:3857', true)")
+    scale = 20037508.34 / 180.0
+    return f"""(
         WITH _v AS (
           SELECT ST_X(d.geom) AS x, ST_Y(d.geom) AS y, d.path[1] AS idx
           FROM UNNEST(ST_Dump(ST_Points(
@@ -125,9 +130,11 @@ def _boundary_geom_sql(touches_dateline: bool) -> str:
           FROM _v
         )
         SELECT ST_MakePolygon(ST_MakeLine(list(ST_Point(
-          CASE WHEN _c.crosses AND (_v.x - _c.ref) >  180 THEN _v.x - 360
-               WHEN _c.crosses AND (_v.x - _c.ref) < -180 THEN _v.x + 360
-               ELSE _v.x END, _v.y) ORDER BY _v.idx)))
+          (CASE WHEN _c.crosses AND (_v.x - _c.ref) >  180 THEN _v.x - 360
+                WHEN _c.crosses AND (_v.x - _c.ref) < -180 THEN _v.x + 360
+                ELSE _v.x END) * {scale},
+          ln(tan((90.0 + _v.y) * pi() / 360.0)) / (pi() / 180.0) * {scale}
+          ) ORDER BY _v.idx)))
         FROM _v, _c
       )"""
 
@@ -219,16 +226,17 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
         projected AS (
           SELECT
             ST_AsMVTGeom(
-              -- ST_MakeValid repairs cells whose web-mercator projection is
+              -- boundary_geom is already EPSG:3857 (_boundary_geom_sql projects
+              -- it; the dateline branch by hand to avoid ST_Transform re-wrapping
+              -- the unwrap into globe-spanning streaks, #201).
+              -- ST_MakeValid repairs cells whose mercator projection is still
               -- degenerate/self-intersecting — at coarse zoom near the mercator
-              -- latitude limit (~±85.05°), a transformed H3 boundary can become
+              -- latitude limit (~±85.05°) a projected H3 boundary can become
               -- invalid, and ST_AsMVTGeom (an aggregate over the whole tile)
               -- raises TopologyException, 500-ing the *entire* tile on one bad
               -- cell. Validating per-cell keeps one degenerate hex from taking
               -- down a global/pole-spanning tileset's coarse tiles (#197).
-              ST_MakeValid(
-                ST_Transform({boundary_geom}, 'EPSG:4326', 'EPSG:3857', true)
-              ),
+              ST_MakeValid({boundary_geom}),
               {{'min_x': {mx_w}, 'min_y': {my_s}, 'max_x': {mx_e}, 'max_y': {my_n}}}::BOX_2D,
               4096, 256, true
             ) AS geom,


### PR DESCRIPTION
Closes #201.

## Problem
Global MVT hex data showed **horizontal streaks** at multiple latitude bands near the antimeridian (vanish when panning away). Root cause confirmed server-side: the #164 dateline unwrap rebuilds an antimeridian cell as a continuous ring in 4326 (span 0.6°) — but with longitudes just past ±180 (e.g. `-180.16°`). `ST_Transform(4326→3857)` **re-normalizes** those back into range (`-180.16°`→`+179.84°`), recreating a globe-spanning polygon in mercator (x-span ≈ world width).

Before v0.7.3 that threw `TopologyException` (part of #197's 500s); v0.7.3's `ST_MakeValid` made it a *valid* band → the streaks.

## Fix
`_boundary_geom_sql` now returns the geometry **already in EPSG:3857**:
- non-dateline: `ST_Transform` of the raw boundary (unchanged behavior);
- dateline: a **by-hand spherical-mercator projection** (`x = lng·20037508.34/180`, `y = mercator_y(lat)`) of the shifted vertices. Mercator x is linear in lng, so out-of-range longitudes project just past the world edge (continuous), where `ST_AsMVTGeom` clips cleanly — no re-wrap.

`_build_tile_sql` drops its now-redundant outer `ST_Transform`; `ST_MakeValid` stays as the pole/degenerate backstop (#197).

## Verification
On the global GBIF dataset, the dateline tile's globe-spanning cells go **66 → 0**; the tile renders (3.1 MB). Full suite **109 passing**.

## Test gap closed
The dateline test asserted only the **4326** span (which the unwrap fixed) — it never checked post-transform, so the re-wrap slipped through. It now asserts the **mercator** x-span is well under the world width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)