### PR TITLE
k8s(prod): promote v0.7.4 by digest (MVT antimeridian streak fix: #201)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.3@sha256:c3d06161dce3316e51d6e8aa98b6d73be8bbeec452b3cc35b477ce40852d3971
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.4@sha256:8bebbe4f2619cd4505c8672075afcaa349051ed8722ac2d0a16b0c8f7fc97c5e
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes **v0.7.4** to production, pinned by digest `sha256:8bebbe4f…`. Previous prod: v0.7.3.

Ships the antimeridian-streak fix (#201 / #202): `_boundary_geom_sql` projects dateline cells to web-mercator by hand so the #164 unwrap survives instead of being re-wrapped by `ST_Transform` into a globe-spanning band. Verified on dev — dateline-tile globe-spanning cells **66 → 0**.

Shipping the validated fix to prod so dev is free for #189 (registration query-opt) experimentation.

## Rollout (after merge)
```
kubectl apply -f k8s/deployment.yaml
kubectl rollout restart deployment/duckdb-mcp -n biodiversity
```

Note: tiles are `immutable`-cached on the data hash, not code — clients may need a hard-refresh to drop previously-cached streaky tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)