### PR TITLE
Fix equatorial z>=3 tile 500s on global data: DECIMAL overflow in bbox_h0 grid (#204)

### DIFF
--- a/tests/test_tile_endpoint.py
+++ b/tests/test_tile_endpoint.py
@@ -176,6 +176,32 @@ class TestCoarseTileGeometryRobustness:
             )
 
 
+class TestEquatorMeridianTiles:
+    def test_equator_meridian_tile_does_not_500(self, app_with_tiles, local_bucket):
+        # #204: the seam pad shifts an equator/prime-meridian tile edge off 0.0 to
+        # a sub-1 high-precision value (e.g. 0.2033…), which DuckDB types as
+        # DECIMAL(18,17); the bbox_h0 grid subtraction with the opposite (>=10°)
+        # bound then overflowed DECIMAL and 500'd the tile. Bounds are now cast to
+        # DOUBLE. Data straddling (0,0) at z=4 must serve, not 500.
+        con = app_with_tiles.state.tile_con
+        sql = """
+            SELECT h3_latlng_to_cell(lat, lng, 4) AS h4, 1.0 AS val FROM (
+                SELECT (random()-0.5)*40 AS lat, (random()-0.5)*40 AS lng FROM range(3000)
+            )
+        """
+        result = register_hex_tiles(
+            con=con, sql=sql, finest_res=4, min_res=2, agg="AVG", zoom_offset=2,
+        )
+        h = result["hash"]
+        client = TestClient(app_with_tiles)
+        # z=4 tiles straddling the equator (y=8) and prime meridian (x=8).
+        for z, x, y in [(4, 8, 8), (4, 8, 7), (4, 7, 8), (3, 4, 4)]:
+            r = client.get(f"/tiles/hex/{h}/{z}/{x}/{y}.pbf")
+            assert r.status_code in (200, 204), (
+                f"equator/meridian tile {z}/{x}/{y} returned {r.status_code} (#204 DECIMAL overflow)"
+            )
+
+
 class TestAntimeridian:
     def test_dateline_cell_geometry_does_not_span_globe(self):
         # A hex straddling +/-180 must be unwrapped into a continuous frame, not

--- a/tiles/endpoint.py
+++ b/tiles/endpoint.py
@@ -201,10 +201,21 @@ def _build_tile_sql(namespace: str, name: str, z: int, x: int, y: int,
         # while h0 diameter is ~15° (Earth/12 cells), so every overlapping h0
         # cell receives at least one sample point. Sample the padded bbox so an
         # edge hex sitting in a neighboring h0 partition isn't pruned away.
+        #
+        # Bounds are CAST to DOUBLE: a sub-1 high-precision float literal (e.g.
+        # 0.2033…, produced when the seam pad shifts an equator/meridian tile
+        # edge off 0.0) is typed by DuckDB as DECIMAL(18,17) — one integer digit
+        # — and the grid subtraction with the opposite bound (>=10°) overflows it,
+        # 500-ing equatorial mid-zoom tiles on global data (#204). Double
+        # arithmetic sidesteps the decimal typing entirely.
+        def _d(v: float) -> str:
+            return f"CAST({v!r} AS DOUBLE)"
+        lat_expr = f"{_d(south_p)} + (i/7.0) * ({_d(north_p)} - {_d(south_p)})"
+        lng_expr = f"{_d(west_p)} + (j/7.0) * ({_d(east_p)} - {_d(west_p)})"
         bbox_h0_sql = (
             "SELECT DISTINCT CAST(h3_latlng_to_cell(\n"
-            f"  {south_p} + (i/7.0) * ({north_p} - {south_p}),\n"
-            f"  {west_p} + (j/7.0) * ({east_p} - {west_p}),\n"
+            f"  {lat_expr},\n"
+            f"  {lng_expr},\n"
             "  0\n"
             ") AS BIGINT) AS h0\n"
             "FROM range(8) t1(i), range(8) t2(j)"


### PR DESCRIPTION
Closes #204. **Live prod regression** (since v0.7.2).

## Problem
Equatorial / prime-meridian tiles at z≥3 on **global** datasets 500. Confirmed on prod:
```
/tiles/hex/742665ca47002c16/4/8/8.pbf -> 500   (and 4/8/7, 4/7/8, 4/9/8)
```
→ the equatorial band (Amazon, central Africa, SE Asia — the biodiversity hotspots) renders broken on global layers at mid-zoom.

## Cause
The seam pad (#188) shifts a tile edge at *exactly* `0.0` to a sub-1 high-precision value like `0.2033039201402941`. DuckDB types that literal as `DECIMAL(18,17)` (one integer digit); the `bbox_h0` grid-sampling subtraction with the opposite bound (≥10°) overflows it → `ST_AsMVT` aborts → 500. Pre-#188 these edges were clean `0.0`, so it didn't trigger.

## Fix
Cast the four interpolated bounds to `DOUBLE` in the grid-sampling expressions — double arithmetic, no decimal typing. Verified the padded equator-tile grid that 500s today runs clean with the cast.

## Test
`TestEquatorMeridianTiles` — equator/meridian-straddling data at z=4 must serve, not 500. Full suite 110 passing.

Found while benchmarking #189 (build-cost). Fast-tracking as a patch since it's a live prod 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)