### PR TITLE
k8s(prod): promote v0.7.5 by digest (equatorial tile 500 fix: #204)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.4@sha256:8bebbe4f2619cd4505c8672075afcaa349051ed8722ac2d0a16b0c8f7fc97c5e
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.5@sha256:8276b0b0e0204153b67ff29b3ae11d2f0b3cb680551b5a83ce0d4f6f552e86cd
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes **v0.7.5** to production (digest `sha256:8276b0b0…`). Previous prod: v0.7.4.

Fixes a **live prod regression** (#204 / since v0.7.2): equatorial / prime-meridian z≥3 tiles on global datasets 500 (DECIMAL overflow in the `bbox_h0` grid, from the #188 seam pad shifting a `0.0` tile edge to a sub-1 high-precision literal). The equatorial band — Amazon, central Africa, SE Asia — was rendering broken on global layers at mid-zoom.

Verified on dev (v0.7.5 `:main`): the global-GBIF tiles `4/8/8`, `4/8/7`, `4/7/8`, `4/9/8` that **500 on prod** now return **200**.

## Rollout (after merge)
```
kubectl apply -f k8s/deployment.yaml
kubectl rollout restart deployment/duckdb-mcp -n biodiversity
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)