### PR TITLE
Pyramid build: partition only finest level by h0, coarse levels single-file (#189)

### DIFF
--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -247,13 +247,13 @@ class TestInspectUserSQL:
 
 
 class TestRegisterHexTiles:
-    def test_writes_h0_subpartitions(self, local_bucket, h3_conn):
-        # h0 partitioning enables file-level pruning when tile requests filter
-        # by candidate h0 cells. Verify both that the on-disk layout includes
-        # h0=... subdirectories and that h0 is recoverable when reading back
-        # with hive_partitioning=true (matches what the tile endpoint does).
-        # Use lat/lng spans that span multiple h0 cells so the partition split
-        # is observable.
+    def test_finest_h0_partitioned_coarse_levels_single_file(self, local_bucket, h3_conn):
+        # #189: only the FINEST level is partitioned by h0 (file-level pruning
+        # earns its keep there — high-zoom tiles hit a huge level). Coarser
+        # levels are PARTITION_BY (res) only, with h0 kept as a DATA column, to
+        # skip the per-h0-file write overhead on small levels. h0 must stay
+        # recoverable on EVERY level for the serve-side SEMI JOIN USING (h0).
+        # Use lat/lng spanning multiple h0 cells so the split is observable.
         user_sql = """
             SELECT h3_latlng_to_cell(lat, lng, 4) AS h4, val
             FROM (VALUES (37.8, -122.3, 1.0),
@@ -264,22 +264,33 @@ class TestRegisterHexTiles:
             con=h3_conn, sql=user_sql, finest_res=4, min_res=2,
             agg="AVG", zoom_offset=-1,
         )
-        # At least 2 h0 partitions under each res= directory.
-        for res in (2, 3, 4):
-            res_dir = local_bucket / "hex" / result["hash"] / f"res={res}"
-            h0_subdirs = [p for p in res_dir.iterdir() if p.is_dir() and p.name.startswith("h0=")]
-            assert len(h0_subdirs) >= 2, f"res={res} expected ≥2 h0 partitions, got {[p.name for p in h0_subdirs]}"
-        # h0 column comes back via hive_partitioning and equals h3_cell_to_parent(h, 0).
-        uri = str(local_bucket / "hex" / result["hash"] / "res=4" / "**" / "*.parquet")
-        cols = h3_conn.sql(
-            f"SELECT * FROM read_parquet('{uri}', hive_partitioning=true) LIMIT 1"
-        ).columns
-        assert "h0" in cols
-        mismatches = h3_conn.sql(
-            f"SELECT COUNT(*) FROM read_parquet('{uri}', hive_partitioning=true) "
-            "WHERE h0::BIGINT != h3_cell_to_parent(h, 0)::BIGINT"
-        ).fetchone()[0]
-        assert mismatches == 0
+        base = local_bucket / "hex" / result["hash"]
+        # Finest level (res=4): h0= subdirectories present.
+        finest_h0 = [p for p in (base / "res=4").iterdir()
+                     if p.is_dir() and p.name.startswith("h0=")]
+        assert len(finest_h0) >= 2, (
+            f"finest res=4 expected ≥2 h0 partitions, got {[p.name for p in (base / 'res=4').iterdir()]}"
+        )
+        # Coarse levels (res=2,3): NOT h0-partitioned (single file per res).
+        for res in (2, 3):
+            h0_subdirs = [p for p in (base / f"res={res}").iterdir()
+                          if p.is_dir() and p.name.startswith("h0=")]
+            assert not h0_subdirs, (
+                f"coarse res={res} should not be h0-partitioned, got {[p.name for p in h0_subdirs]}"
+            )
+        # h0 recoverable + correct on BOTH a partitioned (finest, from path) and
+        # a single-file (coarse, from data column) level.
+        for res in (4, 2):
+            uri = str(base / f"res={res}" / "**" / "*.parquet")
+            cols = h3_conn.sql(
+                f"SELECT * FROM read_parquet('{uri}', hive_partitioning=true) LIMIT 1"
+            ).columns
+            assert "h0" in cols, f"res={res} missing h0 column"
+            mismatches = h3_conn.sql(
+                f"SELECT COUNT(*) FROM read_parquet('{uri}', hive_partitioning=true) "
+                "WHERE h0::BIGINT != h3_cell_to_parent(h, 0)::BIGINT"
+            ).fetchone()[0]
+            assert mismatches == 0, f"res={res} h0 mismatch"
 
     def test_writes_pyramid_partitions(self, local_bucket, h3_conn):
         # Source: 5 cells at r5 around a point.

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -54,6 +54,17 @@ def build_pyramid_statements(
         small) and writes res. Working set per Phase 2 step is bounded by the
         cardinality of the previous res, which shrinks ~7x per step.
 
+    Partitioning strategy (#189): only the FINEST level is partitioned by
+    (res, h0). The h0 partitioning earns its keep at *serve* time only on the
+    finest level — high-zoom tiles hit a huge level and need file-level h0
+    pruning. Coarser levels are written PARTITION_BY (res) only, with h0 kept as
+    a data column (so the serve-side `SEMI JOIN ... USING (h0)` still works).
+    Reason: writing a level as ~122 tiny h0 files costs ~0.8s/file of Ceph
+    object overhead regardless of cell count, so coarse levels (which hold few
+    cells) paid 60-100s each to write near-empty partitions; a single file
+    writes in <1s. Benchmarked in-cluster: ~2.6-3x faster builds, and coarse
+    tiles even serve ~1.6x faster single-file (one file beats globbing 122).
+
     AVG mode stores an internal `__pyramid_weight` column alongside the aggregate
     so parent rollups produce correctly weighted averages instead of an
     unweighted mean-of-means.
@@ -118,6 +129,9 @@ def build_pyramid_statements(
     statements = [phase_1]
 
     # Phase 2: each parent res reads from the previously written res+1.
+    # Coarser levels are PARTITION_BY (res) only — h0 stays a data column (still
+    # SELECTed below), so serve-side h0 filtering works but we don't pay the
+    # per-h0-file write overhead on these small levels (#189).
     for res in range(finest_res - 1, min_res - 1, -1):
         src_uri = f"{output_uri}res={res + 1}/**/*.parquet"
         stmt = (
@@ -129,7 +143,7 @@ def build_pyramid_statements(
             f"  FROM read_parquet('{src_uri}', hive_partitioning=true)\n"
             f"  GROUP BY 1, 2\n"
             f") TO '{output_uri}' "
-            f"(FORMAT PARQUET, PARTITION_BY (res, h0), OVERWRITE_OR_IGNORE)"
+            f"(FORMAT PARQUET, PARTITION_BY (res), OVERWRITE_OR_IGNORE)"
         )
         statements.append(stmt)
 


### PR DESCRIPTION
Part of #189 (build-cost lever B).

## Change
Pyramid levels were all written `PARTITION_BY (res, h0)` (up to 122 h0 files each). Now only the **finest** level keeps `(res, h0)`; coarser levels are `PARTITION_BY (res)` only, with `h0` retained as a data column.

## Why
On the internal Ceph endpoint each partition file costs ~0.8s of object-write overhead **regardless of cell count**, so coarse levels (a few thousand cells) paid 60–100s to write 122 near-empty partitions. h0 file-pruning only earns its keep on the finest level (high-zoom tiles hit a huge level); coarse levels are served at low zoom and are small.

## Benchmarked (in-cluster, internal Ceph, 48 threads)
- **Builds ~2.6–3× faster** — finest=6 (14.1M cells): 531.6s → 174.9s; finest=5 (2M): 360.8s → 138.8s.
- **Coarse tiles serve ~1.6× faster** single-file (415ms vs 682ms warm) — one file beats globbing/opening 122.
- Per-level write (finest=6): coarse rollups 62–98s each → 0.7–7.1s.

## Correctness / compat
- `h0` stays recoverable on every level — from the path on the finest, from the data column on coarse levels — so the serve `SEMI JOIN … USING (h0)` is unchanged. Verified (test + in-cluster serve).
- **Backward-compatible:** the endpoint reads both layouts; cache-gating means existing tilesets keep their layout (no forced rebuilds) and only new registrations get the optimized one. No `_LAYOUT_VERSION` bump needed.

## Test
`test_finest_h0_partitioned_coarse_levels_single_file` — finest has h0= subdirs, coarse levels don't, and h0 is correct on both a partitioned and a single-file level. Full suite 110 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)