### PR TITLE
Offload the query tool off the event loop (finishes #176)

### DIFF
--- a/server.py
+++ b/server.py
@@ -235,7 +235,33 @@ Credentials are scoped to this request only and never persisted.
 {TOOL_INJECTED_CONTEXT}
 """
 
-mcp.tool()(query)
+# query runs a DuckDB scan up to 300s. FastMCP runs a *sync* tool inline on the
+# uvicorn event loop, so a long query would freeze the whole pod: /healthz goes
+# unanswered (readiness pulls the pod, a long-enough scan risks the liveness
+# SIGKILL), tile GETs stall, and other MCP requests queue behind it (#176). #185
+# offloaded the hex tools the same way; query was the remaining sync-on-loop tool.
+# A CapacityLimiter bounds concurrent scans so a burst can't oversubscribe the
+# pod's CPU/memory or starve the hex tools sharing anyio's default thread pool.
+_QUERY_LIMITER = anyio.CapacityLimiter(int(os.environ.get("MCP_QUERY_CONCURRENCY", "8")))
+
+
+async def _query_tool(
+    sql_query: str,
+    s3_key: str = None,
+    s3_secret: str = None,
+    s3_endpoint: str = None,
+    s3_scope: str = None,
+) -> str:
+    # Mirrors query()'s signature so FastMCP derives the identical tool schema.
+    return await anyio.to_thread.run_sync(
+        query, sql_query, s3_key, s3_secret, s3_endpoint, s3_scope,
+        limiter=_QUERY_LIMITER,
+    )
+
+
+# Register the async wrapper under the tool name, reusing the sync function's
+# docstring as the LLM-facing description (mirroring the hex-tool pattern, #185).
+mcp.tool(name="query", description=query.__doc__)(_query_tool)
 
 # -------------------------------------------------------------------------
 # 8b. TILE ENDPOINT — dynamic MVT for H3 hex visualization (see issue #4)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -302,6 +302,66 @@ class TestTileRouteMounted:
         assert tools["register_hex_tiles"].description == register_hex_tiles.__doc__
         assert tools["get_hex_tile_status"].description == get_hex_tile_status.__doc__
 
+    def test_query_is_served_async(self):
+        """query runs a DuckDB scan up to 300s; it must be a coroutine so FastMCP
+        awaits it off the event loop instead of running it inline (#176). #185
+        offloaded the hex tools the same way; this finishes the job for query."""
+        import inspect, server
+        assert inspect.iscoroutinefunction(server._query_tool)
+
+    def test_query_tool_preserves_name_schema_and_docstring(self):
+        """Wrapping must not change the LLM-facing tool: same name, same input
+        schema (derived from the mirrored signature), same description."""
+        from server import mcp, query
+        import anyio
+        tools = {t.name: t for t in anyio.run(mcp.list_tools)}
+        assert "query" in tools
+        assert tools["query"].description == query.__doc__
+        assert sorted(tools["query"].inputSchema["properties"]) == [
+            "s3_endpoint", "s3_key", "s3_scope", "s3_secret", "sql_query",
+        ]
+
+    def test_query_tool_matches_sync_core(self):
+        """The async wrapper returns the same payload as the sync query()."""
+        import anyio, server
+        sql = "SELECT 1 AS one"
+        sync_result = server.query(sql)
+        async_result = anyio.run(server._query_tool, sql)
+        assert async_result == sync_result
+
+    def test_query_tool_keeps_event_loop_responsive(self):
+        """While the wrapped (blocking) query runs in a worker thread, the event
+        loop must keep ticking. If it ran on the loop, the concurrent sleeps
+        below could not make progress until it finished (#176)."""
+        import threading, anyio, server
+
+        gate = threading.Event()
+
+        def blocking_query(sql_query, *a, **k):
+            gate.wait(2.0)
+            return "done"
+
+        # Patch the sync core; the wrapper offloads whatever query() points at.
+        orig = server.query
+        server.query = blocking_query
+        try:
+            async def main():
+                ticks = 0
+                result = {}
+                async with anyio.create_task_group() as tg:
+                    async def runner():
+                        result["r"] = await server._query_tool("SELECT 1")
+                    tg.start_soon(runner)
+                    for _ in range(5):
+                        await anyio.sleep(0.02)
+                        ticks += 1
+                    gate.set()  # release the worker thread so runner finishes
+                assert ticks == 5
+                return result["r"]
+            assert anyio.run(main) == "done"
+        finally:
+            server.query = orig
+
     def test_async_status_wrapper_matches_sync_core_for_unknown(self):
         """The async tool returns the same payload as the sync core."""
         import anyio, server


### PR DESCRIPTION
Finishes #176.

## What

`query` (a DuckDB scan, up to 300s) was the last MCP tool still running **inline on the uvicorn event loop**. FastMCP runs *sync* tool functions on the loop, so a long query froze the whole pod: `/healthz` went unanswered (readiness pulls the pod; a long-enough scan risks the liveness SIGKILL), tile GETs stalled, and other MCP requests queued behind it. Effective per-pod concurrency was 1 for the duration.

#185 already offloaded the hex tools (`register_hex_tiles`, `get_hex_tile_status`) to worker threads. `query` was the remaining sync-on-loop tool — and the heaviest blocking call in the server. This wraps it the same way.

## How

- `_query_tool` — async wrapper that runs `query` via `anyio.to_thread.run_sync`. It **mirrors `query()`'s signature exactly**, so FastMCP derives the identical tool name + JSON schema, and it reuses `query.__doc__` as the LLM-facing description (same idiom as the #185 hex wrappers).
- Per-tool `CapacityLimiter` — `MCP_QUERY_CONCURRENCY` (default 8) bounds concurrent scans so a burst of heavy queries can't oversubscribe the pod's CPU/memory or starve the hex tools sharing anyio's default thread pool.

## Relationship to #177

#177 (opened Jun 10, before #185 landed) set out to offload all three tools. #185 since solved register/status by a different — and for the long-poll, better (`await anyio.sleep` vs holding a worker thread) — route, leaving #177 ~80% redundant and conflicting with main. This PR takes only the still-relevant slice: the `query` offload (+ the capacity-limiter hardening). #177 should be closed in favor of this.

## Tests

- `query` is served as a coroutine (FastMCP awaits it off-loop).
- Wrapping preserves the tool name, input schema, and description.
- The async wrapper returns the same payload as the sync core.
- The event loop stays responsive while a blocking query runs in a worker thread.
- Full suite: 266 passed.

## Rollout

Test on **dev** (`dev-duckdb-mcp`, tracks `:main`) before promoting to prod: fire a deliberate multi-minute `query` and confirm `/healthz` keeps returning 200 and tiles keep serving during it.