### PR TITLE
GeoJSON builder: drop globe-spanning pole/dateline rings (#196)

### DIFF
--- a/tests/test_tile_geojson.py
+++ b/tests/test_tile_geojson.py
@@ -85,6 +85,29 @@ class TestGeoJSONOutput:
         assert len(f0["geometry"]["coordinates"][0]) == 7
         assert "count" in f0["properties"]
 
+    def test_globe_spanning_pole_cell_is_dropped(self, con, local_bucket):
+        """A South-Pole (lat=-90) junk cell — the kind GBIF coordinate noise
+        produces — has a boundary that wraps every longitude and renders in
+        MapLibre as a smear across the whole map. The GeoJSON builder must drop
+        such globe-spanning cells while keeping the legitimate ones (#196)."""
+        # 24 distinct Berkeley cells + one South-Pole cell = 25 input cells.
+        sql = (
+            "SELECT h3_latlng_to_cell(37.87 + (i * 0.01), -122.27 + (j * 0.01), 8) AS h8 "
+            "FROM range(5) t1(i), range(5) t2(j) "
+            "UNION ALL SELECT h3_latlng_to_cell(-90.0, 0.0, 8) AS h8"
+        )
+        result = register_hex_tiles(con=con, sql=sql, agg="COUNT")
+        assert result["format"] == "geojson"
+        # The metadata count reflects the input (the pole cell is real data)...
+        assert result["feature_count_finest"] == 25
+        path = local_bucket / "hex" / result["hash"] / "data.geojson"
+        gj = json.loads(path.read_text())
+        # ...but the rendered FeatureCollection has the smear-causing cell dropped.
+        assert len(gj["features"]) == 24
+        for feat in gj["features"]:
+            lngs = [pt[0] for ring in feat["geometry"]["coordinates"] for pt in ring]
+            assert max(lngs) - min(lngs) <= 180  # no globe-spanning ring survives
+
     def test_value_column_lands_in_properties(self, con, local_bucket):
         sql = (
             "SELECT h3_latlng_to_cell(37.87 + (i * 0.01), -122.27, 8) AS h8, "

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -172,6 +172,19 @@ def _to_public_http_url(uri: str) -> str:
     return uri
 
 
+# A cell's H3 boundary "spans the globe" when its longitude extent exceeds
+# 180 deg. Two kinds of cell trip this, both from un-clipped/noisy point data:
+#   - pole cells (latitude ~+/-90, e.g. GBIF coordinate junk at the South Pole)
+#     whose ring wraps every longitude;
+#   - cells whose raw boundary straddles the antimeridian (longitude jumps
+#     +179.9 -> -179.9, #164).
+# Emitted as raw GeoJSON, MapLibre draws either as a horizontal smear across the
+# whole map ("the layer isn't rendering"). The MVT serve path handles these
+# (#164/#201); the GeoJSON builder never did. Dropping them is the GeoJSON-path
+# analog of that robustness fix (#196). `g` is the boundary GEOMETRY column.
+_GEOJSON_GLOBE_SPANNING = "(ST_XMax(g) - ST_XMin(g)) > 180"
+
+
 def build_geojson_statement(finest_uri: str, geojson_uri: str, value_columns: List[str]) -> str:
     """COPY that writes the finest-res hexes as one valid GeoJSON FeatureCollection.
 
@@ -179,18 +192,38 @@ def build_geojson_statement(finest_uri: str, geojson_uri: str, value_columns: Li
     scalar, NOT the GDAL-backed ST_Write — so it streams to s3:// over httpfs.
     A single output row becomes one line that is the whole FeatureCollection
     object; json_group_array nests each cell's GeoJSON geometry and properties.
+
+    Globe-spanning pole/dateline cells are dropped (see _GEOJSON_GLOBE_SPANNING)
+    so noisy/un-clipped data never renders as a smear (#196).
     """
     props = ", ".join(f"'{c}', \"{c}\"" for c in value_columns)
+    cols = ", ".join(f'"{c}"' for c in value_columns)
     return (
         "COPY (\n"
+        "  WITH _cells AS (\n"
+        f"    SELECT {cols}, h3_cell_to_boundary_wkt(h)::GEOMETRY AS g\n"
+        f"    FROM read_parquet('{finest_uri}')\n"
+        "  )\n"
         "  SELECT 'FeatureCollection' AS type,\n"
         "         coalesce(json_group_array(json_object(\n"
         "           'type', 'Feature',\n"
-        "           'geometry', CAST(ST_AsGeoJSON(h3_cell_to_boundary_wkt(h)::GEOMETRY) AS JSON),\n"
+        "           'geometry', CAST(ST_AsGeoJSON(g) AS JSON),\n"
         f"           'properties', json_object({props})\n"
         "         )), '[]'::JSON) AS features\n"
-        f"  FROM read_parquet('{finest_uri}')\n"
+        "  FROM _cells\n"
+        f"  WHERE NOT {_GEOJSON_GLOBE_SPANNING}\n"
         f") TO '{geojson_uri}' (FORMAT JSON)"
+    )
+
+
+def count_globe_spanning_statement(finest_uri: str) -> str:
+    """COUNT of the globe-spanning cells build_geojson_statement drops — for a
+    log line so a smear-free render that silently shed junk cells is still
+    visible in the build logs (#196)."""
+    return (
+        "SELECT count(*) FROM (\n"
+        f"  SELECT h3_cell_to_boundary_wkt(h)::GEOMETRY AS g FROM read_parquet('{finest_uri}')\n"
+        f") WHERE {_GEOJSON_GLOBE_SPANNING}"
     )
 
 
@@ -553,9 +586,16 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
     if serve_format == "geojson":
         gj_t0 = time.perf_counter()
         geojson_uri = f"{output_uri}data.geojson"
+        dropped = con.sql(count_globe_spanning_statement(finest_uri)).fetchone()[0]
         con.sql(build_geojson_statement(finest_uri, geojson_uri, value_columns))
         geojson_url = _to_public_http_url(geojson_uri)
         geojson_seconds = time.perf_counter() - gj_t0
+        if dropped:
+            print(
+                f"[tile-build] hash={h} geojson dropped {dropped} globe-spanning "
+                f"(pole/dateline) cells of {feature_count} (#196)",
+                file=sys.stderr,
+            )
 
     print(
         f"[tile-build] hash={h} DONE format={serve_format} "


### PR DESCRIPTION
Fixes the server-robustness half of #196.

## Problem

The GeoJSON fast path (`build_geojson_statement`) streamed every finest-res cell to a FeatureCollection via raw `h3_cell_to_boundary_wkt`, with **no antimeridian/pole handling** — the #164/#201 fixes only ever went into the MVT serve path. So un-clipped/noisy point data produces a ring that wraps every longitude, which MapLibre draws as a horizontal smear across the whole map ("the layer isn't rendering"). The original #196 case: a Peru GBIF layer with a **South-Pole (lat=−90) junk cell**.

## Fix

Drop cells whose boundary longitude extent exceeds 180° in the builder (compute the boundary once in a CTE, filter on `ST_XMax(g) - ST_XMin(g) > 180`), and log how many were shed so a silently-cleaned render still shows up in the build logs. This is the GeoJSON-path analog of the MVT robustness fixes.

Confirmed against real H3 cells:

| cell | lng-span | action |
|------|---------:|--------|
| antimeridian (lng=180, res5) | 359.97 | **drop** |
| South Pole (lat=−90, res8) | 324.82 | **drop** |
| null island (0,0, res8) | 0.01 | keep |
| Berkeley (res8) | 0.01 | keep |

## Scope

Only **smear-causing globe-spanning** cells are dropped. Ordinary outliers (null island, country centroids) have small boundaries and are kept — removing those is the agent spatial-clip lane (#209), not server robustness. The metadata `feature_count_finest` still reflects the input (the cell is real data); only the rendered FeatureCollection sheds it.

## Tests

New `test_globe_spanning_pole_cell_is_dropped`: a South-Pole junk cell mixed with 24 legitimate Berkeley cells is dropped from `data.geojson`; no surviving feature has a globe-spanning ring. Full suite: 267 passed.

## Rollout

Test on **dev** (`dev-duckdb-mcp`, tracks `:main`), then promote to prod (batched with #210's query offload, since prod is still v0.7.6).