### PR TITLE
k8s(prod): promote v0.7.7 by digest (#176/#210 + #196)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.6@sha256:7cf6888efe44157c6f2c01edeeb976ab18680bc6d2326dabd5da2ff0a5ab6f55
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.7@sha256:da23c7ae64cd25d7bf221c21ab94668af1abc6ba4a6e940d0fc62cccdac35a98
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes **v0.7.7** to prod (`k8s/deployment.yaml`, by digest `@sha256:da23c7ae…`). Prev prod: v0.7.6.

Two backward-compatible fixes, both merged to main and dev-verified:

- **#210 (finishes #176)** — `query`, the last heavy sync-on-loop tool (DuckDB scans up to 300s), now runs off the event loop in a worker thread (bounded by `MCP_QUERY_CONCURRENCY`, default 8). So `/healthz`, tile GETs, and other MCP requests stay responsive during a long query. **Dev-verified:** a deliberate 110s query ran while 311/311 `/healthz` probes (same pod, via port-forward) returned 200 (median 56ms).
- **#196** — the GeoJSON builder drops globe-spanning pole/dateline rings (boundary lng-span > 180°) so noisy un-clipped data (e.g. a GBIF South-Pole junk cell) never renders as a smear across the whole map. **Dev-verified:** a South-Pole cell mixed with legit cells was dropped from the served `data.geojson` (24 served / 25 input, max lng-span 0.01).

Existing tilesets are unaffected (no layout/cache change). After merge: `kubectl apply -f k8s/deployment.yaml` + `rollout restart deployment/duckdb-mcp`, then verify both replicas converge on the digest.