### PR TITLE
k8s(prod): promote v0.7.8 by digest (#190/#213 GeoJSON wire gzip)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.7@sha256:da23c7ae64cd25d7bf221c21ab94668af1abc6ba4a6e940d0fc62cccdac35a98
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.8@sha256:73df78740700220b6fa57296dfeb4ae0b722c647b7e83a277ba6ceb837ac15ba
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod from v0.7.7 → **v0.7.8**, pinned by digest.

**v0.7.8 = #213 (#190 step 1): GeoJSON `data.geojson` served gzip-compressed.** The public gateway doesn't negotiate `Accept-Encoding`, so the object is now PUT pre-gzipped with a `Content-Encoding: gzip` header → gateway serves it compressed, browsers inflate transparently. **No client changes.**

### Pin
`ghcr.io/boettiger-lab/mcp-data-server:v0.7.8@sha256:73df78740700220b6fa57296dfeb4ae0b722c647b7e83a277ba6ceb837ac15ba`

Same commit (`f1cf7e3`) already verified on dev (digest `5617d1e7`); v0.7.8 is a separate build run off that tag (expected digest difference, identical code).

### On-cluster benchmark (dev pod, internal RGW)
| cells | raw | gz (wire) | ratio | gzip CPU |
|---:|---:|---:|---:|---:|
| 2,062 | 0.5 MB | 0.11 MB | 5.0× | 0.02 s |
| 25,298 | 6.5 MB | 1.48 MB | 4.4× | 0.24 s |
| 58,665 | 15.2 MB | 3.47 MB | 4.4× | 0.56 s |
| 86,770 | 22.4 MB | 5.16 MB | 4.3× | 0.81 s |

Ratio stable ~4.3–4.4×; gzip CPU <0.85 s even near the 100k-feature cutoff. Gateway verified `content-encoding: gzip`, `content-type: application/json`, valid FeatureCollection.

### Backward compatibility
Existing prod GeoJSON tilesets keep their old uncompressed `data.geojson` (tile cache-control is immutable, keyed on data/registration hash, not code) — only newly-registered GeoJSON sets are gzipped. MVT path untouched.

Closes the wire-gzip lever of #190. Steps 2 (GeoJSON↔MVT routing) and 3 (compact `{h3,value}`, gated; geo-agent#256) remain.