### PR TITLE
perf(build): enable httpfs prefetch + metadata/connection caching (#190)

### DIFF
--- a/tiles/db.py
+++ b/tiles/db.py
@@ -39,6 +39,19 @@ def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnecti
     con.sql("SET enable_object_cache=true")
     con.sql("SET temp_directory='/tmp'")
 
+    # httpfs read tuning (#190 I/O characterization). The build/scan cost is bound
+    # by per-file-open latency over the pod->Ceph path, NOT CPU (a scan pegs ~2 of
+    # 64 cores; ~170 MB/s on a many-file scan vs ~370 MB/s few-file). GBIF hex is
+    # sharded up to ~126 files per h0, so a country/global scan opens ~all 923
+    # files and pays serial per-file round-trips. Prefetch every parquet footer
+    # up-front in parallel and cache HTTP metadata + connections so those opens
+    # overlap. Measured ~17-26% faster on real GBIF builds (concurrent, swapped-pod
+    # A/B), same bytes read. NOTE: prefetch_all_parquet_files prefetches all footers
+    # in the read glob — fine at GBIF's ~10^3 files; revisit if a dataset globs 10^4+.
+    con.sql("SET enable_http_metadata_cache=true")
+    con.sql("SET httpfs_connection_caching=true")
+    con.sql("SET prefetch_all_parquet_files=true")
+
     # S3 access: use the cluster-internal Ceph endpoint (same as query tool).
     con.sql(
         "CREATE OR REPLACE SECRET s3 ("


### PR DESCRIPTION
## What
Enable three DuckDB httpfs flags (off by default) in `build_tile_connection`:
`prefetch_all_parquet_files`, `enable_http_metadata_cache`, `httpfs_connection_caching`.

## Why
The #190 I/O characterization showed hex builds are **bound by per-file-open latency on the pod→Ceph path, not CPU**:
- A scan pegs only **~2 of 64 cores** — I/O-wait-bound.
- **~170 MB/s** on a many-file scan vs **~370 MB/s** reading a few large files.
- GBIF hex is sharded **up to ~126 parquet files per h0**, so a country/global scan opens ~all **923** files and pays serial per-file round-trips.

These flags prefetch every parquet footer up-front in parallel and cache HTTP metadata + connections, so the file-opens overlap instead of serializing.

## Measured (concurrent, swapped-pod A/B — controls cache-warming + node variance; same bytes read)
| query | default | tuned |
|---|--:|--:|
| US richness (5.0M cells) | 29.4s | **24.4s** |
| RU richness (1.0M cells) | 13.8s | **10.2s** |

~17–26% faster, larger gains on sparser/many-file scans. No query or output change.

## Notes
- Applies to the shared build/read connection (also helps the prepare probe and tile-serve reads; both are small so the prefetch is bounded there).
- `prefetch_all_parquet_files` prefetches all footers in the read glob — fine at GBIF's ~10³ files; revisit if a dataset ever globs 10⁴+ files.
- Complements the larger lever (#209 prune-to-few-files, ~2.3×) and the upstream GBIF-hex shard-compaction opportunity (data-workflows).