### PR TITLE
Lower GeoJSON auto-select cutoff 100k → 30k cells (#190 step 2)

### DIFF
--- a/tests/test_tile_geojson.py
+++ b/tests/test_tile_geojson.py
@@ -42,6 +42,14 @@ def local_bucket(tmp_path, monkeypatch):
 
 
 class TestAutoSelect:
+    def test_default_cutoff_is_30k(self):
+        # The GeoJSON/MVT routing cutoff is a measured decision (#190 step 2):
+        # single-res GeoJSON is client-render-bound and only looks right at its
+        # native zoom, so bounded sets above ~30k cells go to the MVT pyramid.
+        # Guard the value so a change is deliberate, not accidental.
+        from tiles import pyramid
+        assert pyramid._GEOJSON_MAX_FEATURES == 30000
+
     def test_small_set_selects_geojson(self, con, local_bucket):
         result = register_hex_tiles(con=con, sql=SMALL_SQL, agg="COUNT")
         assert result["format"] == "geojson"

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -34,7 +34,17 @@ _LOCK_STALE_SECONDS = int(os.environ.get("TILE_LOCK_STALE_SECONDS", "120"))
 # GeoJSON FeatureCollection (streamed straight to object storage, fetched
 # client-side by MapLibre from the public gateway) instead of building an MVT
 # tile pyramid. Larger sets fall back to the pyramid. Env-overridable. See #178.
-_GEOJSON_MAX_FEATURES = int(os.environ.get("TILE_GEOJSON_MAX_FEATURES", "100000"))
+#
+# 30k (was 100k): set from #190 step-2 measurement. Single-res GeoJSON is bound
+# by client-side time-to-interactive — MapLibre tessellates every cell on the
+# main thread on *every* view (measured ~4s at 25k, ~10s at 100k, ~18s at 200k
+# on a 4-core client), and having no pyramid it only shows real hexes near the
+# data's native zoom (sub-pixel blob otherwise). MVT now builds about as fast
+# for bounded sets (~6s flat, post-#207) and renders correctly at every zoom
+# with progressive ~viewport-bound loads, so it wins above this point on both
+# latency and appearance. GeoJSON stays the simpler choice only for small,
+# bounded sets viewed at their native extent. Full data on #190.
+_GEOJSON_MAX_FEATURES = int(os.environ.get("TILE_GEOJSON_MAX_FEATURES", "30000"))
 
 
 def build_pyramid_statements(


### PR DESCRIPTION
## What
Default `_GEOJSON_MAX_FEATURES` 100000 → 30000 (env `TILE_GEOJSON_MAX_FEATURES`). Server-only default, no API change.

## Why (measured, #190 step 2)
The GeoJSON path serves a **single-resolution** FeatureCollection (no pyramid):
- It shows real hexes only near the data's **native zoom** — elsewhere each hex falls below a pixel and merges into a blob (confirmed by eye).
- The **whole set re-tessellates on the client on every view** — measured load-to-interactive ~4s @25k, ~10s @100k, ~18s @200k on a 4-core client.

MVT builds about as fast for bounded sets now (the pyramid is ~cheap post-#207: 1.5–8.5s) and renders correctly at **every** zoom with progressive, viewport-bound loads. So MVT wins above a small bounded size. Lowering the cutoff keeps GeoJSON only for small, native-zoom maps; everything larger gets MVT.

## Scope
One-line default + a test pinning the value. Existing GeoJSON tests unchanged (their fixtures are well under 30k).

## Related
Whether to **retain the GeoJSON path at all** is under separate assessment — MVT may dominate enough to drop the dual path on both server and client. This PR is a safe interim shrink regardless of that decision.