### PR TITLE
Advertise app version on the running server (#221, part 1)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,10 +47,17 @@ jobs:
               tags="$repo:main"
               ;;
           esac
+          # Version stamp baked into the image: the tag on release builds, else "main".
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            app_version="${{ github.ref_name }}"
+          else
+            app_version="main"
+          fi
           {
             echo "tags<<EOF"
             echo "$tags"
             echo "EOF"
+            echo "app_version=$app_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
@@ -60,6 +67,9 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            APP_VERSION=${{ steps.tags.outputs.app_version }}
+            GIT_SHA=${{ github.sha }}
           # Pushes reuse the cached deps layer (fast code-only builds). The weekly
           # cron sets no-cache + pull so it re-resolves unpinned deps and pulls a
           # fresh base image (security patches); cache-to still warms the cache.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,11 @@ RUN python -c "import duckdb; c = duckdb.connect(); c.sql('INSTALL httpfs; INSTA
 # Application code last, so a code change rebuilds only this cheap layer.
 COPY . /app
 
+# Version stamp, passed by docker.yml (APP_VERSION = the git tag on release builds,
+# else "main"; GIT_SHA = the commit). Last so a version/sha change rebuilds only this
+# trivial layer, never the deps. Read at runtime by server.py (issue #221).
+ARG APP_VERSION=dev
+ARG GIT_SHA=unknown
+ENV APP_VERSION=$APP_VERSION GIT_SHA=$GIT_SHA
+
 CMD ["python", "server.py"]

--- a/server.py
+++ b/server.py
@@ -29,11 +29,28 @@ BaseSession.send_notification = _resilient_send_notification
 # -------------------------------------------------------------------------
 # 1. INITIALIZATION
 # -------------------------------------------------------------------------
+# App version + git SHA, baked at build time from the git tag (Dockerfile ARGs set
+# by docker.yml). The tag is the single source of truth — no version string lives in
+# source, so nothing can drift from what was actually tagged/built. Defaults mark a
+# local/un-stamped run. See issue #221.
+APP_VERSION = os.environ.get("APP_VERSION", "dev")
+GIT_SHA = os.environ.get("GIT_SHA", "unknown")
+
 mcp = FastMCP(
     "DuckDB-S3-Geo-Isolated",
     stateless_http=True,
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False)
 )
+
+# Report APP_VERSION in the MCP `initialize` handshake (serverInfo.version) so clients
+# learn it in-band, no extra request. FastMCP has no version kwarg, so set it on the
+# wrapped low-level server. `mcp` is unpinned (the weekly cron re-resolves it), so guard
+# against a future internal rename rather than crash startup — /version and /healthz
+# still carry the version regardless.
+try:
+    mcp._mcp_server.version = APP_VERSION
+except Exception:
+    pass
 
 # -------------------------------------------------------------------------
 # 2. CONFIGURATION & FILE LOADING
@@ -724,8 +741,9 @@ _MCP_AUTH_TOKEN = os.environ.get("MCP_AUTH_TOKEN", "").strip()
 
 class _BearerAuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        # /healthz must remain reachable to the kubelet probe even with auth on.
-        if request.url.path == "/healthz":
+        # /healthz must remain reachable to the kubelet probe even with auth on;
+        # /version is deliberately public too (version discovery is the whole point).
+        if request.url.path in ("/healthz", "/version"):
             return await call_next(request)
         auth = request.headers.get("Authorization", "")
         supplied = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
@@ -739,7 +757,13 @@ async def _healthz(_request):
     # (e.g. a runaway DuckDB query saturating CPU/memory on the pod). That's the
     # signal we want: a wedged pod becomes NotReady within ~15s and HAProxy
     # stops routing to it. See issue #157.
-    return JSONResponse({"ok": True})
+    return JSONResponse({"ok": True, "version": APP_VERSION})
+
+
+async def _version(_request):
+    # App version + git SHA of the running image (issue #221). Lets consumers and
+    # ops confirm what's deployed without cluster access.
+    return JSONResponse({"version": APP_VERSION, "git_sha": GIT_SHA})
 
 # -------------------------------------------------------------------------
 # 10. SERVER START
@@ -762,6 +786,7 @@ if __name__ == "__main__":
     app.router.redirect_slashes = False
     mount_tiles(app)
     app.add_route("/healthz", _healthz, methods=["GET"])
+    app.add_route("/version", _version, methods=["GET"])
 
     if _MCP_AUTH_TOKEN:
         app.add_middleware(_BearerAuthMiddleware)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -400,11 +400,12 @@ class TestHealthz:
     Replaces a TCP-only probe so a wedged uvicorn event loop fails fast."""
 
     def _build_app(self, with_auth_middleware=False):
-        from server import mcp, _healthz, _BearerAuthMiddleware, mount_tiles
+        from server import mcp, _healthz, _version, _BearerAuthMiddleware, mount_tiles
         app = mcp.streamable_http_app()
         app.router.redirect_slashes = False
         mount_tiles(app)
         app.add_route("/healthz", _healthz, methods=["GET"])
+        app.add_route("/version", _version, methods=["GET"])
         if with_auth_middleware:
             app.add_middleware(_BearerAuthMiddleware)
         return app
@@ -416,13 +417,16 @@ class TestHealthz:
         assert "/healthz" in paths
 
     def test_healthz_returns_ok_fast(self):
-        """GET /healthz returns 200 with {"ok": true}. Async handler does no I/O
-        and no executor work — fails only if the event loop itself is starved."""
+        """GET /healthz returns 200 with ok=true (plus the app version). Async
+        handler does no I/O and no executor work — fails only if the event loop
+        itself is starved."""
         from starlette.testclient import TestClient
         client = TestClient(self._build_app())
         r = client.get("/healthz")
         assert r.status_code == 200
-        assert r.json() == {"ok": True}
+        body = r.json()
+        assert body["ok"] is True
+        assert "version" in body
 
     def test_healthz_bypasses_auth_middleware(self):
         """When MCP_AUTH_TOKEN is set, the kubelet still needs to probe — but the
@@ -437,11 +441,40 @@ class TestHealthz:
             # /healthz works with no auth header.
             r = client.get("/healthz")
             assert r.status_code == 200, r.text
-            assert r.json() == {"ok": True}
+            assert r.json()["ok"] is True
             # /mcp without a valid token is rejected — confirms the middleware
             # IS installed and gating other paths.
             r2 = client.post("/mcp", json={"jsonrpc": "2.0", "method": "ping", "id": 1})
             assert r2.status_code == 401
+        finally:
+            server._MCP_AUTH_TOKEN = original
+
+    def test_version_returns_app_version_and_sha(self):
+        """GET /version reports the build-stamped app version + git SHA (issue #221)."""
+        import server
+        from starlette.testclient import TestClient
+        orig_v, orig_s = server.APP_VERSION, server.GIT_SHA
+        server.APP_VERSION, server.GIT_SHA = "v9.9.9", "deadbeef"
+        try:
+            client = TestClient(self._build_app())
+            r = client.get("/version")
+            assert r.status_code == 200
+            assert r.json() == {"version": "v9.9.9", "git_sha": "deadbeef"}
+        finally:
+            server.APP_VERSION, server.GIT_SHA = orig_v, orig_s
+
+    def test_version_bypasses_auth_middleware(self):
+        """/version is public (version discovery is the point) — reachable with no
+        token even when auth is on."""
+        import server
+        from starlette.testclient import TestClient
+        original = server._MCP_AUTH_TOKEN
+        server._MCP_AUTH_TOKEN = "test-token"
+        try:
+            client = TestClient(self._build_app(with_auth_middleware=True))
+            r = client.get("/version")
+            assert r.status_code == 200, r.text
+            assert "version" in r.json()
         finally:
             server._MCP_AUTH_TOKEN = original
 


### PR DESCRIPTION
Closes the "advertise app version" half of #221. (Release-notes/backfill is a separate PR.)

### Problem
No version string existed anywhere in the repo. Confirming what's deployed meant a `kubectl` dig into the pinned image tag, because:
- `serverInfo.version` reported the **mcp SDK** version (FastMCP took no version) — not the app
- `/healthz` → `{"ok":true}` (no version); `/version` → 404

### Approach: git tag = single source of truth, baked at build
No source-side version file (which would drift from the tag). Instead the tag flows tag → build-arg → ENV → server:
- **docker.yml**: passes `APP_VERSION` (the git tag on `v*` builds, else `main`) and `GIT_SHA` (`github.sha`) as build-args
- **Dockerfile**: `ARG`/`ENV` as the last layer (a version/sha change rebuilds only that trivial layer, never deps)
- **server.py**: reads both and surfaces the version **three ways**
  - `serverInfo.version` (via the wrapped low-level `Server` — MCP clients like geo-agent get it in-band on `initialize`). Guarded: `mcp` is unpinned, so a future internal rename degrades gracefully rather than crashing startup.
  - `GET /version` → `{version, git_sha}` — public (bypasses the bearer-auth middleware, like `/healthz`)
  - `version` added to `/healthz`

Dev/`main` builds honestly report `main`; prod (pinned to `:v0.7.8`) reports `v0.7.8`. Nothing to hand-bump.

### Tests
+2 (`/version` returns version+sha; `/version` bypasses auth). Relaxed the two `/healthz` exact-equality asserts for the added `version` field. **65 passed.**

### Verify after merge
`curl https://duckdb-mcp.nrp-nautilus.io/version` and the MCP `initialize` `serverInfo.version`.