### PR TITLE
Auto-publish GitHub Releases on version tags (#221, part 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Publish GitHub Release
+
+# When a vX.Y.Z tag is pushed, publish a matching GitHub Release with
+# auto-generated notes (the merged-PR list since the previous tag) so the
+# Releases page reflects what's actually shipped. See issue #221.
+# docker.yml builds the image for the same tag in parallel; this only creates
+# the Release entry.
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write  # create releases
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
Closes the "Releases lag the real versions" half of #221. (Version-advertising is #223.)

### Problem
The Releases page stopped at **v0.6.8** while git/container tags reached **v0.7.8** — v0.7.0–v0.7.8 shipped (images on ghcr.io) but were never published as GitHub Releases. Anyone reasoning from the Releases page concludes the whole v0.7.x line (incl. GeoJSON-hex) doesn't exist.

### Change
New `.github/workflows/release.yml`: on a `v*` tag push, run `gh release create <tag> --generate-notes --verify-tag`. Auto-generated notes = the merged-PR list since the previous tag, plus a Full Changelog compare link. Uses `gh` + the built-in `GITHUB_TOKEN` (no third-party action to pin). Runs alongside the existing docker.yml image build for the same tag.

Sample of what auto-notes produce (previewed via the generate-notes API):

> **v0.7.8**
> ## What's Changed
> * k8s(prod): promote v0.7.7 by digest (#176/#210 + #196) … #212
> * GeoJSON path: serve data.geojson gzip-compressed (#190) … #213
> **Full Changelog**: v0.7.7...v0.7.8

The repo's descriptive PR titles carry the consumer-coupling hints (`(#190)`, `format`/`geojson_url`) into the notes for free.

### Not included (deliberate)
- **Backfill of v0.7.0–v0.7.8**: a one-time set of `gh release create` calls against existing tags (this workflow only fires on *new* tag pushes). Holding that for explicit go-ahead since it publishes 9 public Releases.