### PR TITLE
k8s(prod): promote v0.7.9 by digest (#221)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.8@sha256:73df78740700220b6fa57296dfeb4ae0b722c647b7e83a277ba6ceb837ac15ba
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.9@sha256:34d51474fde0055d060b3781d56f20bb1aa475275a038ea664d332c61ba3a166
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod from v0.7.8 → **v0.7.9**, pinned by digest.

- Image: `ghcr.io/boettiger-lab/mcp-data-server:v0.7.9@sha256:34d51474fde0055d060b3781d56f20bb1aa475275a038ea664d332c61ba3a166`
- Digest fetched from GHCR and method cross-checked: `:v0.7.8` → `sha256:73df…`, matching the current prod pin exactly.
- v0.7.9 contents: `/version` + `serverInfo.version` + `/healthz` version (#223), auto-publish Releases on tags (#224).

Validated on dev (`:main`): `/version` → `{"version":"main","git_sha":"536c650e…"}`, `serverInfo.version` → `main`. On v0.7.9 it reports `v0.7.9`.

After merge: `kubectl apply -f k8s/deployment.yaml` then `kubectl rollout restart deployment/duckdb-mcp -n biodiversity`, then verify all replicas converge on the digest and `/version` reports v0.7.9.