### PR TITLE
docs(AGENTS): drop hardcoded replica counts, defer to k8s configs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ Do **not** `git pull` on `main` when local `main` has commits matching the just-
 
 The MCP server runs on the NRP Nautilus Kubernetes cluster.
 
-- **Prod:** `https://duckdb-mcp.nrp-nautilus.io` — 2 replicas, `k8s/deployment.yaml`
-- **Dev:** `https://dev-duckdb-mcp.nrp-nautilus.io` — 2 replicas, `k8s/dev-deployment.yaml` (must stay ≥2 so cross-pod bugs surface here before prod)
+- **Prod:** `https://duckdb-mcp.nrp-nautilus.io` — `k8s/deployment.yaml` (replica count and image pin live there)
+- **Dev:** `https://dev-duckdb-mcp.nrp-nautilus.io` — `k8s/dev-deployment.yaml`; must stay ≥2 replicas so cross-pod bugs surface here before prod
 - **Resources:** 16 Gi RAM requested, up to 160 Gi / 16 CPU per pod
 - **STAC catalog:** `https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json` (set via `STAC_CATALOG_URL` env var)
 - **Ingress:** HAProxy with CORS enabled, 10-minute query timeout, 1-hour SSE tunnel timeout


### PR DESCRIPTION
Prod was documented as "2 replicas" but actually runs 6 (caught during the v0.7.9 rollout). Rather than hand-sync a count that drifts, the deployment manifests are the record — so the Prod/Dev lines now point to `k8s/deployment.yaml` / `k8s/dev-deployment.yaml` instead of stating a number. Kept the one meaningful constraint: dev must stay ≥2 so cross-pod bugs surface before prod.