### PR TITLE
k8s(prod): promote v0.7.10 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.9@sha256:34d51474fde0055d060b3781d56f20bb1aa475275a038ea664d332c61ba3a166
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.10@sha256:e0083f6559327afab9bed1e434ed8453aa60618bd22274d3af53b80287327be5
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod from v0.7.9 → **v0.7.10** by digest.

## What's in v0.7.10
- **#168** — h3-guide distance-between-hexes pattern (`h3_great_circle_distance` takes coordinates, not cell indices). The only runtime (prompt-artifact) change since v0.7.9.

## Verification
- Functional: corrected pattern runs on dev against real PADUS data; old form errors as reported.
- Model-generation: ran the distance question through **glm-5** and **kimi** (the two models that originally failed) via the headless harness against dev — both emit the correct coordinate form, ~81 km, zero regressions.

## Pin
`ghcr.io/boettiger-lab/mcp-data-server:v0.7.10@sha256:e0083f6559327afab9bed1e434ed8453aa60618bd22274d3af53b80287327be5`

Digest fetched from GHCR and method validated against the currently-pinned v0.7.9 (exact match). After merge: `kubectl apply -f k8s/deployment.yaml` + `rollout restart deployment/duckdb-mcp`.