### PR TITLE
build: bump duckdb 1.5.3 → 1.5.4, no-cache on workflow_dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,14 +71,15 @@ jobs:
             APP_VERSION=${{ steps.tags.outputs.app_version }}
             GIT_SHA=${{ github.sha }}
           # Pushes reuse the cached deps layer (fast code-only builds). The weekly
-          # cron sets no-cache + pull so it re-resolves unpinned deps and pulls a
-          # fresh base image (security patches); cache-to still warms the cache.
+          # cron and manual workflow_dispatch both set no-cache + pull so they
+          # re-resolve unpinned deps and pull a fresh base image (security patches);
+          # cache-to still warms the cache for subsequent pushes.
           # (When no-cache=true, cache-from is ignored by design; cache-to is kept
           # so the next code-push still gets a warm cache.)
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          no-cache: ${{ github.event_name == 'schedule' }}
-          pull: ${{ github.event_name == 'schedule' }}
+          no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          pull: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
       - name: Report image digest
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 mcp
 # Pinned: the community `h3` extension is built per exact DuckDB version and
-# lags new releases. Unpinned, CI/image builds pull the latest DuckDB (e.g.
-# 1.5.4) for which `INSTALL h3 FROM community` has no candidate, breaking every
-# tile path. 1.5.3 is the version our extensions (spatial + h3) are validated
-# against and what prod runs. Bump only once community h3 ships for the target.
-duckdb==1.5.3
+# lags new releases. Unpinned, CI/image builds pull the latest DuckDB for which
+# `INSTALL h3 FROM community` may have no candidate, breaking every tile path.
+# Bump only once community h3 ships for the target version.
+duckdb==1.5.4
 pandas
 uvicorn
 tabulate


### PR DESCRIPTION
## Summary

- Bumps `duckdb==1.5.3` → `1.5.4` — h3 community extension now ships for 1.5.4 so the version pin can advance
- Extends `no-cache` + `pull` in docker.yml to `workflow_dispatch` events (previously only `schedule`), so a manual trigger gets a fresh base image and re-resolved unpinned deps
- Closes #231 — floating `spatial` build is fixed by the no-cache rebuild that lands this change

## After merge

1. Merge → GHA builds `:main` with the new duckdb (cached push build, fast)
2. Trigger **workflow_dispatch** from the Actions UI → full no-cache + pull rebuild (fresh `python:3.12-slim`, fresh `spatial` for duckdb 1.5.4)
3. Verify: run both queries from #231 against the MCP — unfiltered `ST_*` scan should no longer crash
4. Tag `v0.7.11` → get digest from GHA summary → update `k8s/deployment.yaml` to lock prod to new image