### PR TITLE
ci: smoke-test built image for extension load and basic function calls

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,16 +85,16 @@ jobs:
         run: |
           image="ghcr.io/boettiger-lab/mcp-data-server@${{ steps.build.outputs.digest }}"
           docker pull "$image"
-          docker run --rm "$image" python -c "
+          docker run --rm -i "$image" python - <<'PYEOF'
 import duckdb
 c = duckdb.connect()
 c.sql('LOAD httpfs')
 c.sql('LOAD spatial')
 c.sql('LOAD h3')
-c.sql(\"SELECT ST_Area(ST_GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))'))\")
+c.sql("SELECT ST_Area(ST_GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))'))")
 c.sql('SELECT h3_latlng_to_cell(37.8, -122.4, 5)')
 print('OK: httpfs / spatial / h3 loaded and functional')
-"
+PYEOF
 
       - name: Report image digest
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,16 +85,7 @@ jobs:
         run: |
           image="ghcr.io/boettiger-lab/mcp-data-server@${{ steps.build.outputs.digest }}"
           docker pull "$image"
-          docker run --rm -i "$image" python - <<'PYEOF'
-import duckdb
-c = duckdb.connect()
-c.sql('LOAD httpfs')
-c.sql('LOAD spatial')
-c.sql('LOAD h3')
-c.sql("SELECT ST_Area(ST_GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))'))")
-c.sql('SELECT h3_latlng_to_cell(37.8, -122.4, 5)')
-print('OK: httpfs / spatial / h3 loaded and functional')
-PYEOF
+          docker run --rm "$image" python -c "import duckdb; c=duckdb.connect(); c.sql('LOAD httpfs'); c.sql('LOAD spatial'); c.sql('LOAD h3'); c.sql('SELECT h3_latlng_to_cell(37.8, -122.4, 5)'); c.sql('SELECT ST_Point(0, 0)'); print('OK: httpfs/spatial/h3 loaded and functional')"
 
       - name: Report image digest
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,6 +81,21 @@ jobs:
           no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           pull: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
+      - name: Smoke-test image
+        run: |
+          image="ghcr.io/boettiger-lab/mcp-data-server@${{ steps.build.outputs.digest }}"
+          docker pull "$image"
+          docker run --rm "$image" python -c "
+import duckdb
+c = duckdb.connect()
+c.sql('LOAD httpfs')
+c.sql('LOAD spatial')
+c.sql('LOAD h3')
+c.sql(\"SELECT ST_Area(ST_GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))'))\")
+c.sql('SELECT h3_latlng_to_cell(37.8, -122.4, 5)')
+print('OK: httpfs / spatial / h3 loaded and functional')
+"
+
       - name: Report image digest
         run: |
           {


### PR DESCRIPTION
## What

After every `docker/build-push-action`, pull the pushed image by digest and run:

```python
LOAD httpfs
LOAD spatial  → ST_Area(polygon)
LOAD h3       → h3_latlng_to_cell(37.8, -122.4, 5)
```

## Why

The bare-runner `Tests` job installs extensions fresh from the DuckDB registry at test time — it cannot catch a mismatch between what's baked into the image and what the registry currently serves. This smoke test runs inside the exact image artifact, so a broken `INSTALL` in the Dockerfile (wrong duckdb version, missing h3 community build, bad spatial bake like #231) fails the build job immediately rather than being discovered in prod.

## What it catches that bare-runner tests miss

- `INSTALL h3 FROM community` 404s for the pinned duckdb version
- spatial baked at a broken commit (the #231 regression class)  
- Any extension that was installed during the build but fails to LOAD at runtime