### PR TITLE
k8s(prod): promote v0.7.11 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.10@sha256:e0083f6559327afab9bed1e434ed8453aa60618bd22274d3af53b80287327be5
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.11@sha256:8b55282bcdbad497c070db772201805281a2b0627513284ac377018618d4cf8a
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod from `v0.7.10` → `v0.7.11`.

## Image

```
ghcr.io/boettiger-lab/mcp-data-server:v0.7.11@sha256:8b55282bcdbad497c070db772201805281a2b0627513284ac377018618d4cf8a
```

## What's in v0.7.11

- **#232** — `duckdb==1.5.4` (h3 community extension now ships for 1.5.4); `workflow_dispatch` gets no-cache + pull
- **#233** — Server uses `LOAD`-only for extensions; `INSTALL` stays in Dockerfile, eliminating per-connection network calls and the vector for silent extension drift
- **#234** — CI test session autouse fixture pre-installs extensions on bare runner
- **#235** — Image smoke test in `docker.yml`: pulls built image by digest and verifies all three extensions load and execute after every build

## Fixes

Closes #231 — the `stoi: no conversion` crash on unfiltered `ST_*` full-table-scans against large `OGC:CRS84` GeoParquet files was caused by spatial extension `b68b309` baked into `v0.7.10`. The no-cache rebuild with `duckdb==1.5.4` picks up the current v1.5-variegata tip which does not reproduce the crash.