### PR TITLE
fix: surface collection_url in dataset listings (#216)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.10@sha256:e0083f6559327afab9bed1e434ed8453aa60618bd22274d3af53b80287327be5
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.11@sha256:8b55282bcdbad497c070db772201805281a2b0627513284ac377018618d4cf8a
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL

--- a/stac.py
+++ b/stac.py
@@ -205,6 +205,9 @@ def _format_collection(col, sub_children: list = None) -> str:
     lines = []
     lines.append(f"**{col.title or col.id}**")
     lines.append(f"Collection ID: `{col.id}`")
+    self_href = col.get_self_href()
+    if self_href:
+        lines.append(f"collection_url: `{self_href}`")
     if col.description:
         lines.append(col.description)
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -7,7 +7,7 @@ import os
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from stac import list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict, _fuzzy_lookup
+from stac import list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict, _fuzzy_lookup, _format_collection
 
 
 class TestCatalogUrlParameter:
@@ -1366,6 +1366,41 @@ class TestInlineCollectionContent:
             mock_get.assert_not_called()
             mock_cat.assert_not_called()
         assert result["id"] == "inline-col"
+
+
+class TestFormatCollectionUrl:
+    """_format_collection surfaces the collection self href as collection_url."""
+
+    def _make_col(self, self_href=None):
+        col = MagicMock()
+        col.id = "test-ds"
+        col.title = "Test Dataset"
+        col.description = "A test."
+        col.assets = {}
+        col.extra_fields = {}
+        col.links = []
+        col.get_self_href.return_value = self_href
+        return col
+
+    def test_collection_url_present_when_self_href_known(self):
+        col = self._make_col(
+            self_href="https://s3-west.nrp-nautilus.io/public-data/stac/test-ds/stac-collection.json"
+        )
+        result = _format_collection(col, sub_children=[])
+        assert "collection_url" in result
+        assert "https://s3-west.nrp-nautilus.io/public-data/stac/test-ds/stac-collection.json" in result
+
+    def test_collection_url_absent_when_no_self_href(self):
+        col = self._make_col(self_href=None)
+        result = _format_collection(col, sub_children=[])
+        assert "collection_url" not in result
+
+    def test_sub_child_url_is_childs_own_href(self):
+        """Sub-children surface their own self href, not the parent's."""
+        child_href = "https://s3-west.nrp-nautilus.io/public-data/stac/parent/child/stac-collection.json"
+        col = self._make_col(self_href=child_href)
+        result = _format_collection(col, sub_children=[])
+        assert child_href in result
 
 
 class TestExtractParquetAssetsExtensions:


### PR DESCRIPTION
## Summary

- `_format_collection` now emits `collection_url: \`<href>\`` right after `Collection ID` when the STAC self href is available
- Uses `col.get_self_href()` — zero extra network calls, the URL is already on the parsed object
- Inline/coerced collections (no self href) silently omit the line
- Sub-children surface their own URL since each was fetched from its own path

## Why

Agents reading `get_stac_details` / `list_datasets` had only a bare collection ID. For nested collections (not direct children of the root catalog), they assumed root-catalog traversal would resolve the ID — which silently fails. Real incident: 15 ca-30x30 layers dropped with no error raised.

## Test plan

- [ ] `TestFormatCollectionUrl.test_collection_url_present_when_self_href_known` — URL appears in output
- [ ] `TestFormatCollectionUrl.test_collection_url_absent_when_no_self_href` — no spurious line for inline collections
- [ ] `TestFormatCollectionUrl.test_sub_child_url_is_childs_own_href` — sub-children get their own URL, not the parent's
- [ ] Full test suite: `python -m pytest tests/test_stac.py` (82 tests)

Closes #216.