### PR TITLE
fix: pass _TimeoutStacIO class to set_default, not instance (#239)

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -114,7 +114,7 @@ class _TimeoutStacIO(DefaultStacIO):
         return super().read_text_from_href(href)
 
 
-pystac.StacIO.set_default(_TimeoutStacIO())
+pystac.StacIO.set_default(_TimeoutStacIO)
 
 
 def _href_to_s3(href: str) -> str:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -617,6 +617,20 @@ class TestFetchResilience:
         _, kwargs = mock_get.call_args
         assert kwargs.get("timeout") == 3
 
+    def test_pystac_default_stac_io_is_callable(self):
+        """pystac.StacIO.default() must return an instance, not raise TypeError.
+
+        Regression for #239: set_default() expects a class (factory), not an
+        instance.  Passing _TimeoutStacIO() caused StacIO.default() to call the
+        instance as a callable, raising '_TimeoutStacIO' object is not callable
+        whenever pystac resolved a child link without an explicit stac_io
+        (link.py fallback path).
+        """
+        import pystac
+        import stac  # noqa: ensure module-level set_default ran
+        io = pystac.StacIO.default()
+        assert isinstance(io, stac._TimeoutStacIO)
+
     def test_child_identifier_prefers_fetched_id(self):
         """When JSON parse succeeded and we have a real id, use it."""
         import stac


### PR DESCRIPTION
## Root cause

`stac.py:117` called `pystac.StacIO.set_default(_TimeoutStacIO())` — passing an **instance** where the API expects a **class** (factory callable). `StacIO.default()` does `cls._default_io()`, so it tried to invoke the stored instance as a function, raising `'_TimeoutStacIO' object is not callable`.

**Why intermittent:** pystac only falls back to the global default via `link.py:335` when it resolves a child link whose `owner_root._stac_io` is not set. Collections fetched with an explicit `stac_io=` argument propagate the io through the root chain and never hit this path. Collections fetched independently (e.g., in `get_collection`'s `get_child()` / `get_children()` traversal) can reach the fallback depending on whether the root was attached.

## Fix

One character: `set_default(_TimeoutStacIO)` instead of `set_default(_TimeoutStacIO())`. pystac calls the class as a factory and gets a fresh instance with the default args (`token=None, timeout=_STAC_CHILD_TIMEOUT`), which is correct for the global default.

## Test

Adds `test_pystac_default_stac_io_is_callable` to `TestFetchResilience`: asserts `pystac.StacIO.default()` returns a `_TimeoutStacIO` instance (would have raised `TypeError` before this fix).

Closes #239.