### PR TITLE
fix(#243): tighten SQL-trap guidance + require headless validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,12 +147,19 @@ instructions.
 ## Validating guidance changes (headless model-suite test)
 
 **Every change to a prompt artifact** (`h3-guide.md`, `query-optimization.md`,
-`query-setup.md`, `assistant-role.md`, `datasets.md`) **should be tested across the
-open-model suite before it's considered done.** These files are runtime instructions
-for small open models — the ground truth is not "does the SQL I write run," it's
-"does the model *generate* the right SQL after reading this guidance." Only running
-the models confirms that. A fix verified solely by running the corrected query
-yourself proves the pattern works, not that the guidance steers the model to it.
+`query-setup.md`, `assistant-role.md`, `datasets.md`) **must be validated against the
+open-model suite on dev before it ships to prod.** It is not done until the matrix
+shows **both**: (a) the targeted failure is fixed, and (b) no regression on the
+standing baseline set (below). These files are runtime instructions for small open
+models — the ground truth is not "does the SQL I write run," it's "does the model
+*generate* the right SQL after reading this guidance." Only running the models confirms that. A fix verified solely by
+running the corrected query yourself proves the pattern works, not that the guidance
+steers the model to it.
+
+Guidance is shared context: text added for one trap is read by every query. Tighter
+wording is safer wording — say it once, in the most-read place, and stop. Prefer
+editing an existing rule over adding a parallel one; never restate a rule the suite
+already passes.
 
 The harness lives in the sibling repo **`boettiger-lab/open-llm-proxy`** under
 `headless/` (see its `README.md`). It replays the real geo-agent tool-use loop from
@@ -173,15 +180,22 @@ the MCP transport stay in sync with the browser app by construction.
    cd ../open-llm-proxy/headless
    cat > runs/q.txt <<'EOF'
    <a question that forces the behavior the guidance governs>
+   <the standing baseline questions — unrelated to this change>
    EOF
    QUESTIONS_FILE="$PWD/runs/q.txt" TAG=<short-tag> \
      MODELS="glm-5 kimi qwen3 gpt-oss minimax-m2" TRIALS=2 \
      ./run-matrix-k8s.sh boettiger-lab/geo-agent-template
    ```
 
+   Run the trap question and the baseline set in the **same** matrix so the fix and the
+   regression check share one job and one set of transcripts.
+
 3. Read the transcripts from `kubectl -n biodiversity logs job/<JOB_NAME>`: confirm
-   the models emit the intended SQL pattern and the correct answer, and that the
-   prior failure form is gone (zero occurrences).
+   (a) the models emit the intended SQL pattern and the correct answer and the prior
+   failure form is gone (zero occurrences), **and** (b) every baseline question still
+   resolves to its known-good answer — no question the change wasn't aimed at got worse.
+   A regression on the baseline blocks promotion to prod even if the targeted trap is
+   fixed — fix forward or revert on dev first.
 
 **Pick the models deliberately.** Always include any model that previously exhibited
 the failure (the logs naming the symptom are the regression set), plus a spread of the
@@ -189,6 +203,13 @@ suite — model values come from `geo-agent-template/k8s/configmap.yaml` (`glm-5
 `kimi`, `qwen3`, `qwen3-small`, `gpt-oss`, `nemotron`, `gemma`, `minimax-m2`).
 Establish a ground-truth answer first by running the correct query yourself, so the
 transcripts have something to check against.
+
+**The standing baseline set** is a small, fixed list of questions with computed
+golden answers, kept in the harness repo, that every guidance change is re-run
+against to catch collateral damage. Seed it from the #243 ground-truth set (the
+6-model × 34-question sweep with Opus-computed answers); when a change fixes a new
+trap, add the question that exposed it to the baseline so future changes can't
+silently reintroduce it. Keep the set small enough to run on every change.
 
 To A/B-test app-level *system prompt* wording (not the MCP-injected guides) without
 forking the app, `run-matrix-k8s.sh` takes `SYSTEM_PROMPT_APPEND_FILE`.

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -67,8 +67,12 @@ The constants below are latitude/distortion-averaged, not true per-cell values (
 |---|---|---|
 | h5 | 252.9 | 62,502 |
 | h6 | 36.13 | 8,929 |
+| h7 | 5.161 | 1,275 |
 | h8 | 0.7373 | 182.2 |
+| h9 | 0.1053 | 26.02 |
 | h10 | 0.01505 | 3.718 |
+
+Use the constant for the dataset's **native** resolution — the column it is actually indexed on (check with `DESCRIBE`). Multiplying a cell count by the constant for a different resolution is off by ~7× per level.
 
 ## Coordinates from H3 Cells
 
@@ -148,6 +152,8 @@ JOIN gfw ON h3_cell_to_parent(wdpa.h8, 6) = gfw.h6
 ```
 
 When one side lacks h0, omit it from that side. Prefer hex-partitioned variants (with h0) when available for partition pruning.
+
+Some datasets carry NULL in their finest pre-computed parent column for very large features (e.g. WDPA's largest protected areas have h8 but NULL h9). Joining on that finer column silently drops those features and undercounts coverage. Join at the coarsest resolution both sides share, or fall back to `h3_cell_to_parent()` which is always populated.
 
 ## Multiple Rows per Hex: Four Different Problems
 

--- a/query-optimization.md
+++ b/query-optimization.md
@@ -128,3 +128,20 @@ single quote inside a SQL string literal — do not use a backslash:
 WHERE site = 'O''Brien Ranch'   -- correct
 WHERE site = 'O'Brien Ranch'    -- parse error
 ```
+
+## 7. Filter no-data values before SUM / AVG
+
+A single `NaN` turns the entire aggregate into `NaN` — one no-data cell poisons a
+whole `SUM` or `AVG`. No-data shows up as literal `NaN`, or as sentinel codes a
+dataset reserves for "no data" (e.g. land-cover classes 0, 80, 200). Exclude both
+before aggregating:
+
+```sql
+SELECT SUM(value) AS total
+FROM read_parquet('<hex>')
+WHERE value IS NOT NULL AND NOT isnan(value)
+  AND lc_class NOT IN (0, 80, 200);   -- dataset's no-data sentinels
+```
+
+Take the sentinel codes from the dataset's STAC description. A `NaN` total or a
+total far smaller than expected is the signature of this trap.

--- a/server.py
+++ b/server.py
@@ -105,6 +105,14 @@ TOOL_INJECTED_CONTEXT = f"""
    WHERE a.lc_class IS NOT NULL
    GROUP BY a.h8;
    ```
+5. **DEDUP BEFORE YOU COUNT OR SUM.** Vector and hex parquet routinely repeat
+   a feature across many rows (one row per hex cell, or per overlapping
+   feature). On such data `COUNT(*)` counts rows, not features, and `SUM()`
+   multiplies every value by its row count. Count and sum the distinct feature
+   instead: `COUNT(DISTINCT <feature_id>)`, and `SELECT DISTINCT <id>, h0 ...`
+   before any join or aggregate. See *Multiple Rows per Hex* below for the
+   per-shape fix. A 50-row result preview is never a count — read the actual
+   number off a `COUNT(...)`, never off the displayed row count.
 
 ### ⚡ OPTIMIZATION RULES
 {OPTIM_RAW}
@@ -230,9 +238,18 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
                 keep = [f'"{c}"' for c in result.columns if c not in geom_cols]
                 result = result.select(", ".join(keep))
 
-            df = result.limit(50).df()
+            # Fetch one extra row to detect truncation without a second COUNT scan.
+            df = result.limit(51).df()
             if df.empty: return "No results found."
-            return df.to_markdown(index=False)
+            truncated = len(df) > 50
+            md = df.head(50).to_markdown(index=False)
+            if truncated:
+                md += (
+                    "\n\n⚠️ Showing the first 50 rows only — this is a preview, not the"
+                    " full result and NOT a count. The true number of matching rows is"
+                    " larger; use COUNT(...) / COUNT(DISTINCT ...) / SUM(...) for totals."
+                )
+            return md
 
     except Exception as e:
         return f"SQL Error: {str(e)}"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,6 +137,17 @@ class TestQueryFunction:
         # Markdown table: header + separator + up to 50 rows
         assert len(lines) <= 55
 
+    def test_query_truncation_footer_when_over_50_rows(self):
+        """A result wider than the 50-row preview gets an explicit truncation note."""
+        result = query("SELECT range as num FROM range(100)")
+        assert "preview" in result.lower()
+        assert "COUNT" in result
+
+    def test_query_no_footer_when_50_rows_or_fewer(self):
+        """An un-truncated result must not claim to be a preview."""
+        result = query("SELECT range as num FROM range(50)")
+        assert "preview" not in result.lower()
+
 
 class TestResourceFunctions:
     """Test MCP resource functions."""


### PR DESCRIPTION
Closes #243 (pending headless validation — see below).

## What

The 6-model × 34-question accuracy sweep in #243 traced most *wrong* answers (not just slow ones) to a handful of data-shape SQL traps. The H3 guide already covers much of this, so per the tightness rule this PR writes **only the deltas** the existing guides miss.

| Trap | Change | File |
|---|---|---|
| **2** — silent truncation read as a count (the decisive miss) | `query` now appends a "⚠️ first 50 rows — preview, not a count" footer when results exceed the preview. Detected by fetching 51 rows; no extra COUNT scan. | `server.py` + tests |
| **1** — duplicate-row inflation (`COUNT(*)`/`SUM` over repeated rows) — #1 error source | Promote dedup to a top-line **CRITICAL SQL RULE** (detail already in h3-guide "Multiple Rows per Hex") | `server.py` |
| **3** — cell-area guessing at wrong resolution | Complete the cell-area table with **h7/h9** + a "use the native resolution" note | `h3-guide.md` |
| **4** — NULL parent cells on large features (WDPA h9) silently drop rows | One note in the *Joining Different Resolutions* section | `h3-guide.md` |
| **5** — NaN poisoning a whole SUM/AVG | New tight rule: filter NaN / no-data sentinels before aggregating | `query-optimization.md` |

**Out of scope:** trap 6 (server-side detection/refusal of unmasked global scans) is a feature, not a docs fix — leave on #243 or split out.

## Bundled: required headless validation (AGENTS.md)

Also strengthens the "Validating guidance changes" section so model-suite testing is a **requirement**, with two parts to "done": (a) targeted trap fixed, (b) **no regression on a standing baseline set** (seeded from the #243 ground-truth sweep). This PR is deliberately the **first change to go through that gate** — the guidance edits here are its inaugural test case.

## Validation status

- ✅ `pytest` — 266 passed (incl. new truncation-footer tests)
- ⏳ **Headless model-suite run on dev — required before this is "done."** Per the new AGENTS.md gate, after merge → dev picks up `:main`, then run the matrix over the trap questions + baseline set and confirm both the fixes land and nothing regresses.