### PR TITLE
fix(#243): move dedup guidance to its proper layer + document the layering model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,42 @@ instructions.
 
 ---
 
+## Where guidance lives (layering model)
+
+All of `query-optimization.md` and `h3-guide.md` are injected **verbatim into the
+`query` tool description** (`TOOL_INJECTED_CONTEXT` in `server.py`), right after the
+hardcoded CRITICAL block. So putting a rule in the server.py CRITICAL block instead of
+an `.md` file does **not** make it more available to the model — it's the same blob.
+The only differences are *maintainability* (hardcoded Python vs the designated runtime
+artifacts) and *prominence* (the CRITICAL block is first and stamped MUST-FOLLOW —
+scarce attention that every addition dilutes).
+
+So choose the home by **what kind of fact it is**, and pick the **most specific** layer
+that fits. Redundancy across layers is a cost (drift + diluted attention), not a
+feature — state a thing once, in one layer, and point to detail rather than copy it.
+
+| Layer | Owns | Examples |
+|---|---|---|
+| **dataset STAC** (in `boettiger-lab/data-workflows`) | facts true of *one dataset* — surfaced by `get_stac_details` exactly when the model is choosing columns | "this file repeats sites — dedup by `ramsarid`"; no-data sentinel codes; which column is the feature id; native resolution |
+| **`h3-guide.md`** | general H3 / hex model & patterns | resolution direction, cell-area table, parent-resolution joins, multiple-rows-per-*hex* |
+| **`query-optimization.md`** | general SQL-writing rules, cross-dataset | include `h0` in joins, NaN poisons `SUM`, fuzzy vs exact text match |
+| **server.py CRITICAL block** | the few foundational invariants, read first, ~never change | no tables, use `read_parquet`, trust STAC paths verbatim, DPP mask-before-aggregate |
+| **server.py code** | runtime tool *behavior* | the 50-row truncation footer, geometry-column drop |
+
+Decision rule when you catch a model error:
+- A wrong answer caused by a **property of one dataset** (duplicate rows, sentinel
+  values, an id column) → fix the **dataset STAC**, not the global prompt. A global rule
+  asserting "geoparquet has duplicate feature rows" is false for clean files and pollutes
+  every query; the per-dataset note is true exactly where it's needed.
+- A **general hex/SQL pattern** → the matching `.md` file. Use a concrete dataset only as
+  an *illustrative example* of the general pattern, never as the rule itself.
+- The **server.py CRITICAL block is not a priority flag.** "This error is the most common"
+  is not a reason to hardcode a rule there — that just crowds the invariants. Put the
+  guidance in its proper layer; if it's a per-dataset fact, STAC is what surfaces it at
+  the right moment.
+
+---
+
 ## Validating guidance changes (headless model-suite test)
 
 **Every change to a prompt artifact** (`h3-guide.md`, `query-optimization.md`,

--- a/server.py
+++ b/server.py
@@ -105,14 +105,6 @@ TOOL_INJECTED_CONTEXT = f"""
    WHERE a.lc_class IS NOT NULL
    GROUP BY a.h8;
    ```
-5. **DEDUP BEFORE YOU COUNT OR SUM.** Vector and hex parquet routinely repeat
-   a feature across many rows (one row per hex cell, or per overlapping
-   feature). On such data `COUNT(*)` counts rows, not features, and `SUM()`
-   multiplies every value by its row count. Count and sum the distinct feature
-   instead: `COUNT(DISTINCT <feature_id>)`, and `SELECT DISTINCT <id>, h0 ...`
-   before any join or aggregate. See *Multiple Rows per Hex* below for the
-   per-shape fix. A 50-row result preview is never a count — read the actual
-   number off a `COUNT(...)`, never off the displayed row count.
 
 ### ⚡ OPTIMIZATION RULES
 {OPTIM_RAW}


### PR DESCRIPTION
Follow-up to #244, course-correcting on **where guidance belongs**.

## Why

#244's Q1/Q3 failures in the headless sweep (Ramsar "USA 3,111"; India area inflated to 2.29M ha) were caused by a **per-dataset fact** — `ramsar_wetlands.parquet` stores ~3.3 rows per site (8,347 rows / 2,551 `ramsarid`) — not by a missing global rule. #244 compensated by hardcoding a `DEDUP` rule into the **server.py CRITICAL block**. That's the wrong layer:

- the **hex** dedup case already lives in `h3-guide.md` → *Multiple Rows per Hex* (don't duplicate it);
- the **polygon** dedup case is a property of one dataset → belongs in its **STAC** metadata, surfaced by `get_stac_details` when the model is choosing columns. Asserting it globally is false for clean one-row-per-feature files and pollutes every query.

## Changes

- **Remove rule #5** from the `server.py` CRITICAL block.
- **Add "Where guidance lives (layering model)" to `AGENTS.md`** — the decision model: dataset STAC for per-dataset facts · `.md` files for general patterns · server.py CRITICAL reserved for invariants · server.py code for runtime behavior. Most-specific layer wins; redundancy is a cost, not a priority flag.

## Per-dataset fixes handed off
→ **boettiger-lab/data-workflows#309** (Ramsar polygon dedup, WDPA NULL `h9`, land-cover no-data sentinels).

## ⚠️ Merge ordering (do not squash-merge yet)
The `server.py` removal should land **after** data-workflows#309 so the dedup signal is in STAC *before* the global rule is withdrawn — otherwise Ramsar Q1/Q3 regress (no dedup signal anywhere). Sequence:
1. data-workflows#309 updates Ramsar STAC
2. merge this → dev
3. re-validate **qwen3 + qwen3-small** (3–4 trials) on Q1/Q3 + baselines

The `AGENTS.md` section is a process doc (not injected into the model) and is safe to land independently if you'd rather take it now.

## Tests
`pytest` query/truncation suite green; `server.py` parses.