### PR TITLE
fix: surface STAC asset-level descriptions in get_stac_details

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -163,6 +163,11 @@ def _extract_parquet_assets(col) -> list[str]:
             size = asset.extra_fields.get("file:size")
             size_note = f" ({size/1024**3:.2f} GiB)" if size and size > 1024**2 else ""
             assets.append(f"  - {title}{size_note}: `read_parquet('{s3}')`")
+            # Asset-level description — carries per-asset facts (e.g. "this file has
+            # duplicate rows per feature; dedup by <id>") that the model needs at
+            # column-choice time. Without this line they never reach the prompt.
+            if asset.description:
+                assets.append(f"    - {asset.description}")
             # Asset-level STAC extension fields (h3, raster, vector)
             for ext_key in (
                 "h3:native_resolution",


### PR DESCRIPTION
## Why

The layering model (AGENTS.md) routes per-dataset facts to the dataset's STAC, surfaced by `get_stac_details` at column-choice time. But `_extract_parquet_assets` ([stac.py](stac.py)) rendered each asset's title, size, h3 fields, and `table:columns` — and **silently dropped the asset's own `description`**. 

The data-workflows STAC agent correctly put the Ramsar polygon dedup note in the `ramsar-parquet` **asset description** (data-workflows#309), but the MCP never rendered it — so the dedup fix had zero effect on the model even though it was in exactly the right STAC location. The existing hex note only showed because it happens to live in the *collection* description (which is rendered).

## Change

Render `asset.description` directly under the asset path line. One conditional, 5 lines.

## Verified

Locally against the live catalog (using the external S3 endpoint so stac.py runs off-cluster):
```
get_stac_details('wetlands-ramsar') now includes:
  - Ramsar Sites (GeoParquet): read_parquet('s3://.../ramsar_wetlands.parquet')
    - Ramsar Sites of International Importance — global vector polygons. This file has
      multiple rows per site: 8,347 rows but only 2,551 distinct sites (ramsarid)...
      use COUNT(DISTINCT ramsarid)...
```
83 stac tests pass.

## Unblocks
The #243 dedup re-validation — the per-dataset signal now actually reaches qwen3/qwen3-small. Sequence after merge: dev redeploy → confirm note in `get_stac_details` on dev → re-run qwen3 + qwen3-small on Q1/Q3 + baselines.

## Note
This surfaces asset descriptions for **all** datasets that have them — generally short and useful, but worth a glance that no dataset has an unexpectedly huge asset description bloating the tool output.