### PR TITLE
k8s(prod): promote v0.7.12 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.11@sha256:8b55282bcdbad497c070db772201805281a2b0627513284ac377018618d4cf8a
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.12@sha256:f6b0609197967b3e722f1e2385177dd1fee437e4ea4defe55cc82062122a2cfb
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Pins prod to `v0.7.12@sha256:f6b0609…`.

Bundles since v0.7.11: the #243 dedup work (#244, #246, #247) plus #240, #241 (GeoJSON→MVT), #242.

**Validation:** dedup fix confirmed on dev for qwen3 + qwen3-small (Q1 9/9, Q3 3/3 clean trials; baselines hold). Truncation footer works at runtime; its model-uptake re-test is deferred until the NRP model proxy/upstream stabilizes (two validation runs were gutted by upstream 'Provider returned 500' outages).

Digest verified via GHCR registry manifest HEAD (method cross-checked against the current v0.7.11 pin).