### PR TITLE
benchmarks: S3 read-throughput bench (NRP Ceph vs AWS us-west-2)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -56,10 +56,48 @@ kubectl apply -f k8s/concurrency-grid-job.yaml   # ~10–15 min
 kubectl logs -f job/duckdb-concurrency-grid
 ```
 
+### `s3-throughput-bench.py`
+
+Engine-independent (raw boto3, no DuckDB) read-throughput benchmark comparing the
+in-cluster Ceph West pool (`rook-ceph-rgw-nautiluss3.rook`), the public Ceph
+gateway (`s3-west.nrp-nautilus.io`), and the AWS us-west-2 source.coop mirror
+(`us-west-2.opendata.source.coop`, reached over Internet2/CENIC), all on the same
+carbon hex dataset. Reports: LIST latency, single-stream MB/s, **aggregate
+throughput vs concurrency {1,4,8,…}** (the headline — distinct objects per level
+to avoid cache warming), and per-object open latency (warm vs cold connection) as
+a secondary diagnostic.
+
+Framing note: this replaced an earlier per-object-latency MRE premised on
+"opening ~10³ Parquet footers". That premise was a now-fixed GBIF over-sharding
+bug — every queryable hex dataset is 1 file per h0 (carbon 122, padus 21, gbif
+2026 122), so a pruned query opens 1 footer and a global scan ≤122. The real open
+question is **bandwidth**, not open-latency, hence this throughput benchmark.
+
+```bash
+uv run --with boto3 python3 s3-throughput-bench.py
+MRE_ENDPOINTS=nrp-external,aws-sourcecoop uv run --with boto3 python3 s3-throughput-bench.py
+```
+
+### `k8s/s3-throughput-job.yaml`
+
+Runs `s3-throughput-bench.py` on N distinct us-west nodes (Indexed Job +
+podAntiAffinity on hostname → one pod per node) to check whether throughput is
+consistent across the heterogeneous NRP fleet vs driven by a few slow nodes. Each
+pod prints its node name. Fetches the script from `main` by raw URL, so commit
+first. Pins `topology.kubernetes.io/region=us-west` so the in-cluster-vs-WAN
+comparison is honest.
+
+```bash
+kubectl apply -f k8s/s3-throughput-job.yaml
+kubectl logs -l job-name=s3-throughput -f --max-log-requests=12 --prefix
+kubectl delete job s3-throughput
+```
+
 ## Key findings
 
 1. Always include `h0` in join conditions (e.g., `ON p.h8 = c.h8 AND p.h0 = c.h0`) — this is what enables DPP file-level pruning.
 2. Set `s3_allow_recursive_globbing=false` on DuckDB 1.5.0 when querying partitioned data on S3 to avoid reading all files at planning time.
 3. A static `WHERE c.h0 = X` literal is ~9s faster and ~200 fewer GETs than join-driven DPP for single-partition queries, due to build-side materialization overhead — but both open only 1 file.
+4. Queryable hex datasets are 1 file per h0 (carbon 122, padus 21, gbif-2026 122), so a pruned query opens 1 footer and a global scan ≤122. The historical "~923 files / ~126-per-h0" was a since-fixed GBIF over-sharding bug, not steady state — large scans are bandwidth-bound, not open-latency-bound. This retires the per-object-latency framing in older notes.
 
 See `../query-optimization.md` for the actionable rules derived from these findings.

--- a/benchmarks/k8s/s3-throughput-job.yaml
+++ b/benchmarks/k8s/s3-throughput-job.yaml
@@ -1,0 +1,91 @@
+# S3 read-throughput benchmark across multiple us-west nodes.
+#
+# Runs benchmarks/s3-throughput-bench.py on N DISTINCT nodes in us-west
+# (podAntiAffinity on hostname forces one pod per node), so we can see whether
+# read throughput from the in-cluster Ceph West pool is consistent across the
+# heterogeneous NRP fleet or varies node-to-node — and how it compares to the
+# AWS us-west-2 (source.coop) mirror over Internet2/CENIC. Each pod prints its
+# node name; correlate node -> throughput curve afterward.
+#
+# Requires benchmarks/s3-throughput-bench.py to be on `main` (the pod fetches it
+# by raw URL). Commit/push first, or edit RAW to point at your branch.
+#
+#   kubectl apply -f benchmarks/k8s/s3-throughput-job.yaml
+#   kubectl logs -l job-name=s3-throughput -f --max-log-requests=12 --prefix
+#   kubectl delete job s3-throughput
+#
+# completions/parallelism = number of nodes to sample. The Job stays pending if
+# fewer than `completions` schedulable us-west nodes satisfy one-pod-per-node.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: s3-throughput
+spec:
+  completions: 6
+  parallelism: 6
+  completionMode: Indexed
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        job-name: s3-throughput
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  # Pin to the region where the West Ceph pool lives, so the
+                  # in-cluster vs WAN comparison is honest (no cross-region Ceph).
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values: ["us-west"]
+                  # Stay off GPU nodes (match the other benchmark jobs).
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+        podAntiAffinity:
+          # One pod per node -> each completion samples a different node.
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  job-name: s3-throughput
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: bench
+        image: astral/uv:python3.12-bookworm-slim
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NODE_REGION       # guaranteed by nodeAffinity; recorded for the report
+            value: "us-west"
+          - name: MRE_CONCURRENCY   # push aggregate throughput harder in-cluster
+            value: "1,4,8,16"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            uv run --with boto3 python3 - << 'PYEOF'
+            import urllib.request, runpy
+            RAW = ("https://raw.githubusercontent.com/boettiger-lab/"
+                   "mcp-data-server/main/benchmarks/s3-throughput-bench.py")
+            urllib.request.urlretrieve(RAW, "/tmp/bench.py")
+            runpy.run_path("/tmp/bench.py", run_name="__main__")
+            PYEOF
+        resources:
+          # Throughput/network-bound, not CPU/RAM-bound: keep modest so it
+          # schedules widely and client CPU is never the explanation.
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"

--- a/benchmarks/k8s/s3-throughput-job.yaml
+++ b/benchmarks/k8s/s3-throughput-job.yaml
@@ -82,10 +82,11 @@ spec:
             PYEOF
         resources:
           # Throughput/network-bound, not CPU/RAM-bound: keep modest so it
-          # schedules widely and client CPU is never the explanation.
+          # schedules widely and client CPU is never the explanation. NRP requires
+          # limit/request ratio <=1.2, so requests==limits here.
           requests:
             cpu: "2"
             memory: "4Gi"
           limits:
-            cpu: "4"
-            memory: "8Gi"
+            cpu: "2"
+            memory: "4Gi"

--- a/benchmarks/s3-throughput-bench.py
+++ b/benchmarks/s3-throughput-bench.py
@@ -69,7 +69,12 @@ ALL_ENDPOINTS = {
     ),
     "aws-sourcecoop": dict(
         endpoint_url=None,  # default AWS endpoint (s3.us-west-2.amazonaws.com)
-        bucket="us-west-2.opendata.source.coop", prefix="cboettig/carbon/",
+        # NOTE: must be the hex sub-prefix, not "cboettig/carbon/" — the parent
+        # also holds large non-hex carbon products (irrecoverable/manageable/v2)
+        # which would make the comparison non-apples-to-apples. This mirror is
+        # byte-identical to the NRP path: 122 files, 1/h0, ~112 MB avg.
+        bucket="us-west-2.opendata.source.coop",
+        prefix="cboettig/carbon/vulnerable-carbon-2024/hex/",
         region="us-west-2", use_ssl=True,
     ),
 }

--- a/benchmarks/s3-throughput-bench.py
+++ b/benchmarks/s3-throughput-bench.py
@@ -1,0 +1,226 @@
+"""
+S3 read-throughput benchmark: NRP Ceph (internal/external) vs AWS us-west-2.
+
+Why throughput, not per-object latency
+--------------------------------------
+Our queryable hex datasets are 1 file per h0 (carbon: 122 files @112 MB;
+gbif 2026: 122 @3 GB; padus: 21 @356 MB). A pruned query opens ONE footer;
+a global scan opens <=122. So per-object open-latency is not the cost — the
+cost is streaming the bytes. (The old "~923 files / ~126-per-h0" figure was a
+now-fixed over-sharding bug in the GBIF pipeline, not steady state.)
+
+The open question this answers: how does sustained read throughput from the
+in-cluster Ceph West pool compare to the same data on AWS us-west-2 (the
+source.coop mirror) reached over Internet2/CENIC — and how far does aggregate
+throughput scale with concurrent streams (NRP docs claim parallel requests
+across storage servers hit high aggregate bandwidth).
+
+Measures, with raw boto3 (no query engine in the path):
+  1. LIST latency + key discovery.
+  2. Single-stream throughput   - one full object end-to-end -> MB/s.
+  3. Aggregate throughput curve - read a distinct block of objects at
+                                  concurrency {1,4,8,...}; aggregate MB/s +
+                                  per-stream median. THIS IS THE HEADLINE.
+  4. Per-object open latency     - N small ranged GETs, warm vs cold connection
+     (secondary diagnostic)        (cold-warm gap = TCP/TLS setup cost).
+
+Reported per endpoint; what matters is the SHAPE across endpoints and across
+nodes (run the k8s Job to sample multiple us-west nodes for fleet heterogeneity).
+
+Run
+---
+  uv run --with boto3 python3 s3-throughput-bench.py
+  # off-cluster, the rook internal host won't resolve and is skipped.
+  MRE_ENDPOINTS=nrp-external,aws-sourcecoop uv run --with boto3 python3 s3-throughput-bench.py
+
+Anonymous (unsigned) reads only; all buckets used here are public.
+"""
+import os
+import socket
+import statistics
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+
+# --- knobs (override via env) -----------------------------------------------
+CONCURRENCY_LEVELS = [int(x) for x in os.environ.get("MRE_CONCURRENCY", "1,4,8").split(",")]
+OBJS_PER_LEVEL = int(os.environ.get("MRE_OBJS_PER_LEVEL", "8"))  # distinct objects read at each level
+N_LATENCY = int(os.environ.get("MRE_N_LATENCY", "40"))          # small-GETs for the latency diagnostic
+FOOTER_BYTES = int(os.environ.get("MRE_FOOTER_BYTES", str(16 * 1024)))
+MAX_POOL = max(CONCURRENCY_LEVELS) + 4
+
+# --- endpoints --------------------------------------------------------------
+# Same logical dataset (vulnerable carbon hex, ~112 MB/file) in each location
+# so object sizes are comparable. The script discovers actual keys via LIST,
+# so prefixes only need to be a parent of the parquet objects.
+ALL_ENDPOINTS = {
+    "nrp-internal": dict(
+        endpoint_url="http://rook-ceph-rgw-nautiluss3.rook",
+        bucket="public-carbon", prefix="vulnerable-carbon-2024/hex/",
+        region="us-east-1", use_ssl=False,
+    ),
+    "nrp-external": dict(
+        endpoint_url="https://s3-west.nrp-nautilus.io",
+        bucket="public-carbon", prefix="vulnerable-carbon-2024/hex/",
+        region="us-east-1", use_ssl=True,
+    ),
+    "aws-sourcecoop": dict(
+        endpoint_url=None,  # default AWS endpoint (s3.us-west-2.amazonaws.com)
+        bucket="us-west-2.opendata.source.coop", prefix="cboettig/carbon/",
+        region="us-west-2", use_ssl=True,
+    ),
+}
+
+_selected = os.environ.get("MRE_ENDPOINTS")
+ENDPOINTS = (
+    {k: ALL_ENDPOINTS[k] for k in _selected.split(",") if k in ALL_ENDPOINTS}
+    if _selected else ALL_ENDPOINTS
+)
+
+
+def _client(cfg, pool=MAX_POOL):
+    config = Config(
+        signature_version=UNSIGNED,
+        s3={"addressing_style": "path"},  # bucket has dots -> path style for TLS
+        region_name=cfg["region"],
+        retries={"max_attempts": 1, "mode": "standard"},
+        connect_timeout=10,
+        read_timeout=300,
+        max_pool_connections=pool,
+    )
+    return boto3.client(
+        "s3", endpoint_url=cfg["endpoint_url"], use_ssl=cfg["use_ssl"], config=config
+    )
+
+
+def _reachable(cfg):
+    url = cfg["endpoint_url"]
+    if url is None:
+        return True
+    host = url.split("://", 1)[-1].split("/", 1)[0].split(":", 1)[0]
+    try:
+        socket.getaddrinfo(host, None)
+        return True
+    except socket.gaierror:
+        return False
+
+
+def _pct(xs, p):
+    if not xs:
+        return float("nan")
+    xs = sorted(xs)
+    k = (len(xs) - 1) * (p / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(xs) - 1)
+    return xs[lo] + (xs[hi] - xs[lo]) * (k - lo)
+
+
+def discover_keys(client, bucket, prefix, limit):
+    t0 = time.perf_counter()
+    keys, sizes = [], {}
+    pag = client.get_paginator("list_objects_v2")
+    for page in pag.paginate(Bucket=bucket, Prefix=prefix):
+        for o in page.get("Contents", []):
+            if o["Size"] > 0 and o["Key"].endswith(".parquet"):
+                keys.append(o["Key"])
+                sizes[o["Key"]] = o["Size"]
+                if len(keys) >= limit:
+                    return keys, sizes, time.perf_counter() - t0
+    return keys, sizes, time.perf_counter() - t0
+
+
+def timed_get(client, bucket, key, nbytes=None):
+    """GET (optionally a leading range), drain body; return (seconds, bytes)."""
+    kw = {"Bucket": bucket, "Key": key}
+    if nbytes is not None:
+        kw["Range"] = f"bytes=0-{nbytes - 1}"
+    t0 = time.perf_counter()
+    body = client.get_object(**kw)["Body"]
+    n = 0
+    for chunk in body.iter_chunks(1 << 20):
+        n += len(chunk)
+    return time.perf_counter() - t0, n
+
+
+def bench_endpoint(name, cfg):
+    print(f"\n{'=' * 72}\n[{name}]  endpoint={cfg['endpoint_url']}  "
+          f"bucket={cfg['bucket']}  prefix={cfg['prefix']}", flush=True)
+    if not _reachable(cfg):
+        print("  SKIP: endpoint host does not resolve from here.", flush=True)
+        return
+
+    client = _client(cfg)
+    need = max(N_LATENCY, OBJS_PER_LEVEL * len(CONCURRENCY_LEVELS) + 1)
+    try:
+        keys, sizes, list_dt = discover_keys(client, cfg["bucket"], cfg["prefix"], need)
+    except Exception as e:  # noqa: BLE001
+        print(f"  ERROR during LIST: {e!r}", flush=True)
+        return
+    if not keys:
+        print(f"  ERROR: no parquet under s3://{cfg['bucket']}/{cfg['prefix']}", flush=True)
+        return
+    med_mb = statistics.median(sizes.values()) / 1e6
+    print(f"  LIST: {list_dt * 1000:.0f}ms, {len(keys)} objects, median size {med_mb:.0f} MB", flush=True)
+
+    # 2. single-stream throughput
+    dt, nb = timed_get(client, cfg["bucket"], keys[0])
+    print(f"  single-stream throughput: {nb / 1e6 / dt:7.0f} MB/s "
+          f"({nb / 1e6:.0f} MB in {dt:.1f}s)", flush=True)
+
+    # 3. aggregate throughput vs concurrency (HEADLINE) — distinct objects per
+    #    level so we measure cold reads, not warmed Ceph/OS cache.
+    print("  aggregate throughput vs concurrency (distinct objects/level):", flush=True)
+    cursor = 0
+    for c in CONCURRENCY_LEVELS:
+        block = keys[cursor:cursor + OBJS_PER_LEVEL]
+        cursor += OBJS_PER_LEVEL
+        if len(block) < c:  # not enough distinct objects; reuse from start
+            block = (keys * ((c // len(keys)) + 1))[:max(c, OBJS_PER_LEVEL)]
+        cc = _client(cfg, pool=c + 4)
+        per_stream = []
+        t0 = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=c) as ex:
+            futs = [ex.submit(timed_get, cc, cfg["bucket"], k) for k in block]
+            tot = 0
+            for f in futs:
+                s, nbytes = f.result()
+                per_stream.append(nbytes / 1e6 / s)
+                tot += nbytes
+        wall = time.perf_counter() - t0
+        cc.close()
+        print(f"    conc={c:>3}: aggregate {tot / 1e6 / wall:7.0f} MB/s  "
+              f"per-stream median {statistics.median(per_stream):5.0f} MB/s  "
+              f"({tot / 1e6:.0f} MB, {len(block)} objs, wall {wall:.1f}s)", flush=True)
+
+    # 4. per-object open latency (secondary diagnostic)
+    small = keys[:N_LATENCY]
+    warm = [timed_get(client, cfg["bucket"], k, FOOTER_BYTES)[0] for k in small]
+    cold = []
+    for k in small:
+        c2 = _client(cfg, pool=1)
+        cold.append(timed_get(c2, cfg["bucket"], k, FOOTER_BYTES)[0])
+        c2.close()
+    print(f"  open latency ({FOOTER_BYTES // 1024} KiB GET): "
+          f"warm p50={_pct(warm, 50) * 1000:.0f}ms p95={_pct(warm, 95) * 1000:.0f}ms | "
+          f"cold p50={_pct(cold, 50) * 1000:.0f}ms p95={_pct(cold, 95) * 1000:.0f}ms | "
+          f"setup~{(_pct(cold, 50) - _pct(warm, 50)) * 1000:+.0f}ms", flush=True)
+
+
+def main():
+    print(f"boto3 {boto3.__version__}", flush=True)
+    print(f"node={os.environ.get('NODE_NAME', '?')}  region={os.environ.get('NODE_REGION', '?')}  "
+          f"pod={os.environ.get('POD_NAME', '?')}", flush=True)
+    print(f"knobs: CONCURRENCY={CONCURRENCY_LEVELS} OBJS_PER_LEVEL={OBJS_PER_LEVEL} "
+          f"N_LATENCY={N_LATENCY}", flush=True)
+    for name, cfg in ENDPOINTS.items():
+        try:
+            bench_endpoint(name, cfg)
+        except Exception as e:  # noqa: BLE001
+            print(f"  [{name}] FAILED: {e!r}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -38,17 +38,19 @@ def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnecti
     con.sql("SET enable_object_cache=true")
     con.sql("SET temp_directory='/tmp'")
 
-    # httpfs read tuning (#190 I/O characterization). The build/scan cost is bound
-    # by per-file-open latency over the pod->Ceph path, NOT CPU (a scan pegs ~2 of
-    # 64 cores; ~170 MB/s on a many-file scan vs ~370 MB/s few-file). GBIF hex is
-    # sharded up to ~126 files per h0, so a country/global scan opens ~all 923
-    # files and pays serial per-file round-trips. Prefetch every parquet footer
-    # up-front in parallel and cache HTTP metadata + connections so those opens
-    # overlap. Measured ~17-26% faster on real GBIF builds (concurrent, swapped-pod
-    # A/B), same bytes read. NOTE: prefetch_all_parquet_files prefetches all footers
-    # in the read glob — fine at GBIF's ~10^3 files; revisit if a dataset globs 10^4+.
+    # httpfs read tuning. NOTE: the "~126 files per h0 / ~923 files" figure behind
+    # the original #190 characterization was a since-fixed GBIF over-sharding bug,
+    # NOT steady state. Every queryable hex dataset is now 1 file per h0 (carbon:
+    # 122 files @112 MB; gbif 2026: 122 @3 GB; padus: 21 @356 MB), so a pruned query
+    # opens ONE footer and a global scan opens <=122 — per-file-open latency is no
+    # longer the dominant cost; large scans are bandwidth-bound on the byte stream.
+    # metadata + connection caching still help the long-lived tile-serve connection
+    # that re-reads the same files across tile requests, so they stay.
     con.sql("SET enable_http_metadata_cache=true")
     con.sql("SET httpfs_connection_caching=true")
+    # prefetch_all_parquet_files: no-op for a 1-file pruned read; its measured
+    # ~17-26% gain came entirely from the over-sharded case. Kept pending a
+    # re-measure at 1-file/h0 (see benchmarks/s3-throughput-bench.py); drop if neutral.
     con.sql("SET prefetch_all_parquet_files=true")
 
     # S3 access: use the cluster-internal Ceph endpoint (same as query tool).


### PR DESCRIPTION
Repivots the planned network benchmark from per-object latency to **throughput**, after verifying the premise was stale.

## Why
The `tiles/db.py` httpfs-tuning comment claimed "~923 files / ~126-per-h0" as steady state and that builds are per-file-open-latency bound. That was a **since-fixed GBIF over-sharding bug**. Verified actual layout:

| hex dataset | files | files/h0 | avg size |
|---|---|---|---|
| carbon | 122 | 1 | 112 MB |
| padus | 21 | 1 | 356 MB |
| gbif-2026 (`public-gbif/hex/`) | 122 | 1 | 3 GB |

So a pruned query opens **1** footer and a global scan **≤122** — large scans are bandwidth-bound, not open-latency-bound. The remaining open question is whether in-cluster Ceph throughput is competitive with the AWS us-west-2 source.coop mirror over Internet2/CENIC, and whether it's consistent across the heterogeneous fleet.

## Changes
- `benchmarks/s3-throughput-bench.py` — raw-boto3 throughput bench (NRP internal/external vs AWS source.coop); headline = aggregate MB/s vs concurrency, latency kept as diagnostic.
- `benchmarks/k8s/s3-throughput-job.yaml` — runs it on N distinct us-west nodes (one pod per node) for heterogeneity.
- `tiles/db.py` — correct the stale comment; flag `prefetch_all_parquet_files` as a no-op for pruned reads pending re-measure (behavior unchanged).
- README + key findings updated.