### PR TITLE
k8s(prod): promote v0.7.13 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.12@sha256:f6b0609197967b3e722f1e2385177dd1fee437e4ea4defe55cc82062122a2cfb
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.13@sha256:5da3f35c60c191ecbdbbb1fef5f57b6f97ac125a5b5c97c746a05133cf5bbb9f
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod to the `v0.7.13` release (main HEAD `3691da8`), pinned by digest `sha256:5da3f35c…`.

**Why:** establishes a clean, formally-tracked baseline where **main == latest tag (v0.7.13) == prod image**. Resolves the drift where prod ran `v0.7.12` and dev ran a stale `:main` (both at commit `e5c9d8a`) while main sat 2 commits ahead with no release.

**Risk:** none functional — v0.7.13 over v0.7.12 is benchmark additions + a comment-only refresh in `tiles/db.py`; DuckDB settings are byte-identical.

Digest verified against GHCR registry; v0.7.12's digest cross-checked to match the currently-pinned value. Rollout (`kubectl apply` + `rollout restart`) follows on merge per AGENTS.md.