### PR TITLE
feat(#238): viridis default color ramp for hex render recipe

### DIFF
--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -1,5 +1,5 @@
 import pytest
-from tiles.pyramid import build_pyramid_statements
+from tiles.pyramid import build_pyramid_statements, render_recipe
 
 
 class TestBuildPyramidStatements:
@@ -814,3 +814,48 @@ class TestFailedMarkers:
         msg = "table 't' doesn't exist; check 'schema'"
         write_failed(con, output_uri, error=msg)
         assert read_failed(con, output_uri)["error"] == msg
+
+
+class TestRenderRecipe:
+    """render_recipe is a pure function over the build metadata dict — no S3."""
+
+    def _meta(self, vmin, vmax, col="count", res=6):
+        return {
+            "value_columns": [col],
+            "finest_res": res,
+            "value_stats": {col: {"by_res": {str(res): {"min": vmin, "max": vmax}}}},
+            "layer_name": "layer",
+        }
+
+    def test_uses_viridis_endpoints_not_red(self):
+        recipe = render_recipe(self._meta(0, 100), "https://x/{z}/{x}/{y}.pbf")
+        stops = recipe["layer"]["paint"]["fill-color"]
+        # Old red ramp must be gone; viridis endpoints present.
+        assert "#fee5d9" not in stops and "#a50f15" not in stops
+        # structure: ["interpolate", ["linear"], ["get", col], v0, c0, ...]
+        assert stops[4] == "#440154"   # first color (lowest value)
+        assert stops[-1] == "#fde725"  # last color (highest value)
+
+    def test_stop_inputs_span_domain_and_ascend(self):
+        recipe = render_recipe(self._meta(10, 60), "https://x/{z}/{x}/{y}.pbf")
+        stops = recipe["layer"]["paint"]["fill-color"]
+        # structure: ["interpolate", ["linear"], ["get", col], v0, c0, v1, c1, ...]
+        values = stops[3::2]
+        colors = stops[4::2]
+        assert len(values) == len(colors) == 6
+        assert values[0] == 10 and values[-1] == 60          # span the data domain
+        assert values == sorted(values) and len(set(values)) == 6  # strictly ascending
+
+    def test_degenerate_domain_keeps_stops_distinct(self):
+        # vmin == vmax must not produce duplicate interpolate inputs (MapLibre errors).
+        recipe = render_recipe(self._meta(5, 5), "https://x/{z}/{x}/{y}.pbf")
+        values = recipe["layer"]["paint"]["fill-color"][3::2]
+        assert len(set(values)) == len(values)
+
+    def test_source_and_layer_shape(self):
+        recipe = render_recipe(self._meta(0, 1), "https://x/{z}/{x}/{y}.pbf")
+        assert recipe["source"]["type"] == "vector"
+        assert recipe["source"]["tiles"] == ["https://x/{z}/{x}/{y}.pbf"]
+        assert recipe["layer"]["type"] == "fill"
+        assert recipe["layer"]["source-layer"] == "layer"
+        assert recipe["layer"]["paint"]["fill-opacity"] == 0.7

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -153,9 +153,35 @@ def _public_base_url() -> str:
 
 
 
+# Viridis color ramp — matplotlib's `viridis` sampled at 6 evenly-spaced
+# points. Perceptually uniform and colorblind-safe, and legible on both light
+# and dark basemaps; replaces the old red ramp (#238). 6 stops is plenty for
+# MapLibre's linear interpolation to read as a smooth gradient.
+_VIRIDIS_STOPS = (
+    (0.0, "#440154"),
+    (0.2, "#414487"),
+    (0.4, "#2a788e"),
+    (0.6, "#22a884"),
+    (0.8, "#7ad151"),
+    (1.0, "#fde725"),
+)
+
+
+def _color_ramp_stops(vmin: float, vmax: float) -> list:
+    """Flatten the viridis ramp into a MapLibre `interpolate` stop list over
+    [vmin, vmax]: [value0, color0, value1, color1, ...]. Inputs are strictly
+    ascending (vmax > vmin is guaranteed by the caller's degenerate guard), as
+    MapLibre requires."""
+    span = vmax - vmin
+    stops: list = []
+    for frac, color in _VIRIDIS_STOPS:
+        stops.extend([vmin + frac * span, color])
+    return stops
+
+
 def render_recipe(meta: dict, tile_url_template: str) -> dict:
     """Return {source, layer}: a paste-ready MapLibre vector tile source + fill
-    layer with a default linear color ramp over the first value column."""
+    layer with a default linear viridis color ramp over the first value column."""
     col = meta["value_columns"][0]
     by_res = meta.get("value_stats", {}).get(col, {}).get("by_res", {})
     stats = by_res.get(str(meta["finest_res"])) or (next(iter(by_res.values())) if by_res else None)
@@ -164,7 +190,7 @@ def render_recipe(meta: dict, tile_url_template: str) -> dict:
     if vmax == vmin:
         vmax = vmin + 1  # degenerate domain — keep the interpolate stops distinct
     paint = {
-        "fill-color": ["interpolate", ["linear"], ["get", col], vmin, "#fee5d9", vmax, "#a50f15"],
+        "fill-color": ["interpolate", ["linear"], ["get", col], *_color_ramp_stops(vmin, vmax)],
         "fill-opacity": 0.7,
     }
     source = {"type": "vector", "tiles": [tile_url_template], "minzoom": 0, "maxzoom": 14}


### PR DESCRIPTION
Part 1 of #238. Replaces the hardcoded red ramp in `render_recipe` with a **viridis** default.

**What changed**
- `tiles/pyramid.py`: the `fill-color` interpolate expression now uses a 6-stop viridis gradient (`#440154`→`#fde725`) instead of the 2-stop red (`#fee5d9`→`#a50f15`). Stops are still interpolated over the data domain `[vmin, vmax]` from `value_stats`; the degenerate `vmin==vmax` guard is preserved so interpolate inputs stay strictly ascending.
- `tests/test_tile_pyramid.py`: new `TestRenderRecipe` (viridis endpoints, domain-spanning/ascending stops, degenerate guard, source/layer shape).

**Why viridis:** perceptually uniform, colorblind-safe, and legible on both light and dark basemaps — the better default called for in #238 item 2.

**Scope:** default palette only. Configurable `color_scale` (log) and `layer_style` (fill-extrusion) are the next two PRs for #238. No tile-format or storage changes.

Refs #238.