### PR TITLE
feat(#238): log color scale + suggested_scale hint

### DIFF
--- a/server.py
+++ b/server.py
@@ -448,6 +448,7 @@ def register_hex_tiles(
     finest_res: int | None = None,
     min_res: int = 2,
     zoom_offset: int = 2,
+    color_scale: str = "linear",
 ) -> dict:
     """Aggregate an H3 hex visualization to public object storage and return a
     paste-ready MapLibre render recipe.
@@ -478,14 +479,22 @@ def register_hex_tiles(
         - "AVG" / "SUM" / "MIN" / "MAX": SQL must return at least one
           numeric value column after the H3 index; each is aggregated by
           `agg` at every coarser level.
+    - `color_scale`: "linear" (default) or "log". Controls how the viridis
+      ramp is spread across the data domain in the returned recipe; the tiles
+      themselves are identical either way. Use "log" for right-skewed data
+      (counts, populations) where a few hot cells otherwise wash everything
+      else out. `value_stats[<col>].suggested_scale` (see below) is a free
+      hint telling you when "log" is worth re-requesting — re-call with the
+      same SQL and `color_scale="log"` for a cache hit that just re-styles.
 
     Returns a dict with `status` ∈ {"done", "running", "failed"}:
     - status="done" (cache hit or fast build): includes the render recipe —
       `source` (pass to map.addSource) and `layer` (pass to map.addLayer),
-      both ready to use as-is with a default color ramp. Also `value_columns`
-      and `value_stats` ({<col>:
-      {"by_res": {"<res>": {"min","max"}}}}) if you want to customize the
-      palette, plus `hash`, `bounds`, `feature_count_finest`.
+      both ready to use as-is with a default viridis color ramp. Also
+      `value_columns` and `value_stats` ({<col>: {"by_res": {"<res>":
+      {"min","max","mean"}}, "suggested_scale": "linear"|"log"}}) if you want
+      to customize the palette or honor the log-scale hint, plus `hash`,
+      `bounds`, `feature_count_finest`.
     - status="running": being built in the background. You get `hash` and
       `tile_url_template`. Call `get_hex_tile_status(hash, wait_seconds=30)`
       to poll — it long-polls server-side, so one call returns either the
@@ -536,7 +545,7 @@ def register_hex_tiles(
     if plan["cached"] is not None:
         result = cached_result_dict(plan, plan["cached"])
         result["status"] = "done"
-        return result
+        return _apply_color_scale(result, color_scale)
 
     failed = read_failed(read_con, plan["output_uri"])
     if failed is not None:
@@ -568,7 +577,7 @@ def register_hex_tiles(
     try:
         result = future.result(timeout=_BUILD_INLINE_WAIT_SECONDS)
         result["status"] = "done"
-        return result
+        return _apply_color_scale(result, color_scale)
     except concurrent.futures.TimeoutError:
         return {
             "hash": plan["hash"],
@@ -590,13 +599,14 @@ async def _register_hex_tiles_tool(
     finest_res: int | None = None,
     min_res: int = 2,
     zoom_offset: int = 2,
+    color_scale: str = "linear",
 ) -> dict:
     # Served MCP tool. register_hex_tiles is sync (and the directly-tested core);
     # FastMCP would run a sync tool inline on the uvicorn event loop, where its
     # S3 marker I/O + bounded inline build-wait block /healthz and every other
     # request (#176). Offload it to a worker thread so the loop stays free.
     return await anyio.to_thread.run_sync(
-        register_hex_tiles, sql, agg, finest_res, min_res, zoom_offset
+        register_hex_tiles, sql, agg, finest_res, min_res, zoom_offset, color_scale
     )
 
 
@@ -608,6 +618,17 @@ mcp.tool(name="register_hex_tiles", description=register_hex_tiles.__doc__)(
 
 
 _STATUS_POLL_MAX_WAIT_SECONDS = 60
+
+
+def _apply_color_scale(result: dict, color_scale: str) -> dict:
+    """Re-render the recipe with a non-default color scale. color_scale is a
+    pure render choice — it never changes the tiles — so it is applied here at
+    the tool boundary by rebuilding {source, layer} from the already-populated
+    stats in `result`, rather than threaded through the content hash or build.
+    No-op unless status="done" and color_scale=="log"."""
+    if result.get("status") == "done" and (color_scale or "").lower() == "log":
+        result.update(render_recipe(result, result["tile_url_template"], color_scale="log"))
+    return result
 
 
 def _done_response(base: dict, meta: dict) -> dict:
@@ -674,7 +695,7 @@ def _status_check_once(hash: str, con=None):
     })
 
 
-def get_hex_tile_status(hash: str, wait_seconds: int = 0) -> dict:
+def get_hex_tile_status(hash: str, wait_seconds: int = 0, color_scale: str = "linear") -> dict:
     """Poll the status of a pyramid build started by register_hex_tiles.
 
     Call this when register_hex_tiles returned {status: "running"}.
@@ -686,6 +707,10 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0) -> dict:
     call again. Do NOT poll faster than this; rapid polling wastes turns
     without giving the build time to make progress. wait_seconds=0 returns
     immediately (the legacy non-blocking poll).
+
+    `color_scale` ("linear" default, or "log") restyles the recipe returned on
+    completion, exactly as in register_hex_tiles — pass it here so a build you
+    polled comes back with the log ramp without a second register call.
 
     Returns one of:
     - {hash, tile_url_template, status: "done", bounds, value_stats, ...} —
@@ -711,11 +736,11 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0) -> dict:
     while True:
         kind, payload = _status_check_once(hash, con)
         if kind != "running" or time.time() >= deadline:
-            return payload
+            return _apply_color_scale(payload, color_scale)
         time.sleep(min(2.0, max(0.1, deadline - time.time())))
 
 
-async def _get_hex_tile_status_tool(hash: str, wait_seconds: int = 0) -> dict:
+async def _get_hex_tile_status_tool(hash: str, wait_seconds: int = 0, color_scale: str = "linear") -> dict:
     # Served MCP tool. Truly async long-poll: `await anyio.sleep` frees the
     # event loop (vs the old time.sleep-on-the-loop that blocked /healthz and
     # every other request for up to 60s per poll — #176), and each one-shot
@@ -726,7 +751,7 @@ async def _get_hex_tile_status_tool(hash: str, wait_seconds: int = 0) -> dict:
     while True:
         kind, payload = await anyio.to_thread.run_sync(_status_check_once, hash, con)
         if kind != "running" or time.time() >= deadline:
-            return payload
+            return _apply_color_scale(payload, color_scale)
         await anyio.sleep(min(2.0, max(0.1, deadline - time.time())))
 
 

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -1,5 +1,5 @@
 import pytest
-from tiles.pyramid import build_pyramid_statements, render_recipe
+from tiles.pyramid import build_pyramid_statements, render_recipe, _suggest_scale
 
 
 class TestBuildPyramidStatements:
@@ -477,6 +477,22 @@ class TestRegisterHexTiles:
         assert stats["val"]["by_res"]["5"]["min"] == 1.0
         assert stats["val"]["by_res"]["5"]["max"] == 5.0
 
+    def test_value_stats_includes_mean_and_suggested_scale(self, local_bucket, h3_conn):
+        # Right-skewed counts: one hot cell (100 points) plus 20 singleton cells
+        # far apart, so at the finest res max/mean (~100/5.7 ≈ 17) clears the
+        # log threshold (#238).
+        user_sql = (
+            "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5 FROM range(100) "
+            "UNION ALL "
+            "SELECT h3_latlng_to_cell(30.0 + i, -120.0, 5) AS h5 FROM range(20) t(i)"
+        )
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=5, min_res=3, agg="COUNT", zoom_offset=4,
+        )
+        col = result["value_stats"]["count"]
+        assert "mean" in col["by_res"]["5"]          # mean now computed per res
+        assert col["suggested_scale"] == "log"       # skewed → log hint
+
 
 import json as _json
 
@@ -859,3 +875,45 @@ class TestRenderRecipe:
         assert recipe["layer"]["type"] == "fill"
         assert recipe["layer"]["source-layer"] == "layer"
         assert recipe["layer"]["paint"]["fill-opacity"] == 0.7
+
+    def test_log_scale_spaces_stops_geometrically(self):
+        recipe = render_recipe(self._meta(1, 1000), "https://x/{z}/{x}/{y}.pbf", color_scale="log")
+        values = recipe["layer"]["paint"]["fill-color"][3::2]
+        colors = recipe["layer"]["paint"]["fill-color"][4::2]
+        assert colors[0] == "#440154" and colors[-1] == "#fde725"  # same viridis ramp
+        assert values[0] == pytest.approx(1) and values[-1] == pytest.approx(1000)  # spans domain
+        # Geometric spacing → constant ratio between consecutive stop inputs.
+        ratios = [values[i + 1] / values[i] for i in range(len(values) - 1)]
+        assert all(r == pytest.approx(ratios[0]) for r in ratios)
+        # Distinctly different from linear spacing (which would step by 199.8).
+        assert values[1] < 500  # log puts the 2nd stop low, not near the midpoint
+
+    def test_log_scale_floors_nonpositive_min(self):
+        # vmin=0 is illegal for a log scale; the floor must keep all inputs > 0.
+        recipe = render_recipe(self._meta(0, 500), "https://x/{z}/{x}/{y}.pbf", color_scale="log")
+        values = recipe["layer"]["paint"]["fill-color"][3::2]
+        assert values[0] > 0
+        assert values == sorted(values) and len(set(values)) == len(values)
+
+    def test_unknown_scale_falls_back_to_linear(self):
+        weird = render_recipe(self._meta(0, 100), "https://x/{z}/{x}/{y}.pbf", color_scale="bogus")
+        linear = render_recipe(self._meta(0, 100), "https://x/{z}/{x}/{y}.pbf")
+        assert weird["layer"]["paint"]["fill-color"] == linear["layer"]["paint"]["fill-color"]
+
+
+class TestSuggestScale:
+    def _by_res(self, mn, mx, mean, res=6):
+        return {str(res): {"min": mn, "max": mx, "mean": mean}}
+
+    def test_right_skewed_suggests_log(self):
+        # max/mean = 100 > 10 → log.
+        assert _suggest_scale(self._by_res(0, 1000, 10), 6) == "log"
+
+    def test_even_distribution_stays_linear(self):
+        # max/mean = 2 → linear.
+        assert _suggest_scale(self._by_res(1, 10, 5), 6) == "linear"
+
+    def test_zero_or_missing_mean_is_linear(self):
+        assert _suggest_scale(self._by_res(0, 0, 0), 6) == "linear"
+        assert _suggest_scale({"6": {"min": 1, "max": 9, "mean": None}}, 6) == "linear"
+        assert _suggest_scale({}, 6) == "linear"

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -167,21 +167,49 @@ _VIRIDIS_STOPS = (
 )
 
 
-def _color_ramp_stops(vmin: float, vmax: float) -> list:
+def _suggest_scale(by_res: dict, finest_res: int) -> str:
+    """Heuristic scale hint (#238): right-skewed data (max far above the mean)
+    reads better on a log color ramp. Computed from the finest-res stats already
+    scanned, so it costs nothing extra. Informational only — render_recipe stays
+    linear unless the caller explicitly passes color_scale="log"."""
+    finest = by_res.get(str(finest_res), {})
+    mx, mean = finest.get("max"), finest.get("mean")
+    if mean and mean > 0 and mx is not None and mx / mean > 10:
+        return "log"
+    return "linear"
+
+
+def _color_ramp_stops(vmin: float, vmax: float, color_scale: str = "linear") -> list:
     """Flatten the viridis ramp into a MapLibre `interpolate` stop list over
     [vmin, vmax]: [value0, color0, value1, color1, ...]. Inputs are strictly
     ascending (vmax > vmin is guaranteed by the caller's degenerate guard), as
-    MapLibre requires."""
+    MapLibre requires.
+
+    color_scale="log" spaces the stop *inputs* geometrically rather than
+    evenly, so low values get more of the ramp — the right default for the
+    right-skewed data (counts, populations) hex maps usually show. Log spacing
+    needs positive inputs, so the low bound is floored to a positive value."""
+    if color_scale == "log":
+        lo = vmin if vmin and vmin > 0 else (vmax / 1000.0 if vmax and vmax > 0 else 1.0)
+        hi = vmax if vmax and vmax > lo else lo * 10.0
+        ratio = hi / lo
+        stops: list = []
+        for frac, color in _VIRIDIS_STOPS:
+            stops.extend([lo * (ratio ** frac), color])
+        return stops
     span = vmax - vmin
-    stops: list = []
+    stops = []
     for frac, color in _VIRIDIS_STOPS:
         stops.extend([vmin + frac * span, color])
     return stops
 
 
-def render_recipe(meta: dict, tile_url_template: str) -> dict:
+def render_recipe(meta: dict, tile_url_template: str, color_scale: str = "linear") -> dict:
     """Return {source, layer}: a paste-ready MapLibre vector tile source + fill
-    layer with a default linear viridis color ramp over the first value column."""
+    layer with a viridis color ramp over the first value column.
+
+    color_scale ∈ {"linear", "log"} controls how the ramp is spread across the
+    data domain; anything other than "log" is treated as linear."""
     col = meta["value_columns"][0]
     by_res = meta.get("value_stats", {}).get(col, {}).get("by_res", {})
     stats = by_res.get(str(meta["finest_res"])) or (next(iter(by_res.values())) if by_res else None)
@@ -190,7 +218,7 @@ def render_recipe(meta: dict, tile_url_template: str) -> dict:
     if vmax == vmin:
         vmax = vmin + 1  # degenerate domain — keep the interpolate stops distinct
     paint = {
-        "fill-color": ["interpolate", ["linear"], ["get", col], *_color_ramp_stops(vmin, vmax)],
+        "fill-color": ["interpolate", ["linear"], ["get", col], *_color_ramp_stops(vmin, vmax, color_scale)],
         "fill-opacity": 0.7,
     }
     source = {"type": "vector", "tiles": [tile_url_template], "minzoom": 0, "maxzoom": 14}
@@ -501,13 +529,19 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
         by_res = {}
         for res in stat_levels:
             # Recursive glob — h0 hive sub-partitions live under res=N/.
+            # MEAN comes free from the same scan as MIN/MAX and drives the
+            # log-scale suggestion below (#238).
             uri = f"{output_uri}res={res}/**/*.parquet"
             row = con.sql(
-                f'SELECT MIN("{col}") AS mn, MAX("{col}") AS mx '
+                f'SELECT MIN("{col}") AS mn, MAX("{col}") AS mx, AVG("{col}") AS av '
                 f"FROM read_parquet('{uri}')"
             ).fetchone()
-            by_res[str(res)] = {"min": _jsonable(row[0]), "max": _jsonable(row[1])}
-        value_stats[col] = {"by_res": by_res}
+            by_res[str(res)] = {
+                "min": _jsonable(row[0]),
+                "max": _jsonable(row[1]),
+                "mean": _jsonable(row[2]),
+            }
+        value_stats[col] = {"by_res": by_res, "suggested_scale": _suggest_scale(by_res, finest_res)}
     stats_seconds = time.perf_counter() - stats_t0
 
     print(


### PR DESCRIPTION
Part 2 of #238 (item 3). Adds optional **log color scaling** plus a free **log-scale hint**.

**New: `color_scale` parameter** on `register_hex_tiles` and `get_hex_tile_status` — `"linear"` (default) or `"log"`.
- `"log"` spaces the viridis stops **geometrically** across the data domain (low values get more of the ramp), flooring non-positive lows so inputs stay valid. Right for right-skewed data (counts, populations).
- It's a **pure render choice** — never enters the content hash or build. Applied at the tool boundary by re-rendering `{source, layer}` from the already-computed `value_stats`, so re-requesting `color_scale="log"` over the same SQL is a **cache hit that just re-styles**. Default behavior stays linear (no surprise for existing callers).

**New: `suggested_scale` hint.** The build's stats scan now also computes `mean` per resolution (free alongside min/max). `value_stats[<col>].suggested_scale` is `"log"` when finest-res `max/mean > 10`, else `"linear"` — informational only; the agent reads it and re-requests log if it wants.

**Shape change** (additive): `value_stats[<col>]` is now `{"by_res": {"<res>": {min,max,mean}}, "suggested_scale": ...}` (was `{"by_res": {"<res>": {min,max}}}`).

**Tests:** geometric spacing + constant ratio, non-positive floor, unknown-scale→linear fallback, the suggest heuristic (skewed/even/zero-mean), and end-to-end mean + suggested_scale on a skewed build.

Docstrings for both tools updated. Next: `layer_style` fill-extrusion (item 4). Refs #238.