### PR TITLE
feat(#238): 3D fill-extrusion layer_style

### DIFF
--- a/server.py
+++ b/server.py
@@ -449,6 +449,7 @@ def register_hex_tiles(
     min_res: int = 2,
     zoom_offset: int = 2,
     color_scale: str = "linear",
+    layer_style: str = "fill",
 ) -> dict:
     """Aggregate an H3 hex visualization to public object storage and return a
     paste-ready MapLibre render recipe.
@@ -486,6 +487,10 @@ def register_hex_tiles(
       else out. `value_stats[<col>].suggested_scale` (see below) is a free
       hint telling you when "log" is worth re-requesting — re-call with the
       same SQL and `color_scale="log"` for a cache hit that just re-styles.
+    - `layer_style`: "fill" (default, flat 2D) or "fill-extrusion" (3D — hex
+      height also encodes the value). Like color_scale this only restyles the
+      recipe, not the tiles. For 3D the map client must set pitch > 0 to see
+      the extrusions; the returned `layer` is a `fill-extrusion` layer.
 
     Returns a dict with `status` ∈ {"done", "running", "failed"}:
     - status="done" (cache hit or fast build): includes the render recipe —
@@ -545,7 +550,7 @@ def register_hex_tiles(
     if plan["cached"] is not None:
         result = cached_result_dict(plan, plan["cached"])
         result["status"] = "done"
-        return _apply_color_scale(result, color_scale)
+        return _apply_render_opts(result, color_scale, layer_style)
 
     failed = read_failed(read_con, plan["output_uri"])
     if failed is not None:
@@ -577,7 +582,7 @@ def register_hex_tiles(
     try:
         result = future.result(timeout=_BUILD_INLINE_WAIT_SECONDS)
         result["status"] = "done"
-        return _apply_color_scale(result, color_scale)
+        return _apply_render_opts(result, color_scale, layer_style)
     except concurrent.futures.TimeoutError:
         return {
             "hash": plan["hash"],
@@ -600,13 +605,14 @@ async def _register_hex_tiles_tool(
     min_res: int = 2,
     zoom_offset: int = 2,
     color_scale: str = "linear",
+    layer_style: str = "fill",
 ) -> dict:
     # Served MCP tool. register_hex_tiles is sync (and the directly-tested core);
     # FastMCP would run a sync tool inline on the uvicorn event loop, where its
     # S3 marker I/O + bounded inline build-wait block /healthz and every other
     # request (#176). Offload it to a worker thread so the loop stays free.
     return await anyio.to_thread.run_sync(
-        register_hex_tiles, sql, agg, finest_res, min_res, zoom_offset, color_scale
+        register_hex_tiles, sql, agg, finest_res, min_res, zoom_offset, color_scale, layer_style
     )
 
 
@@ -620,14 +626,19 @@ mcp.tool(name="register_hex_tiles", description=register_hex_tiles.__doc__)(
 _STATUS_POLL_MAX_WAIT_SECONDS = 60
 
 
-def _apply_color_scale(result: dict, color_scale: str) -> dict:
-    """Re-render the recipe with a non-default color scale. color_scale is a
-    pure render choice — it never changes the tiles — so it is applied here at
-    the tool boundary by rebuilding {source, layer} from the already-populated
-    stats in `result`, rather than threaded through the content hash or build.
-    No-op unless status="done" and color_scale=="log"."""
-    if result.get("status") == "done" and (color_scale or "").lower() == "log":
-        result.update(render_recipe(result, result["tile_url_template"], color_scale="log"))
+def _apply_render_opts(result: dict, color_scale: str, layer_style: str) -> dict:
+    """Re-render the recipe with non-default render options. color_scale and
+    layer_style are pure render choices — they never change the tiles — so they
+    are applied here at the tool boundary by rebuilding {source, layer} from the
+    already-populated stats in `result`, rather than threaded through the content
+    hash or build. No-op unless status="done" and at least one option is
+    non-default."""
+    cs = (color_scale or "linear").lower()
+    ls = (layer_style or "fill").lower()
+    if result.get("status") == "done" and (cs == "log" or ls == "fill-extrusion"):
+        result.update(render_recipe(
+            result, result["tile_url_template"], color_scale=cs, layer_style=ls,
+        ))
     return result
 
 
@@ -695,7 +706,9 @@ def _status_check_once(hash: str, con=None):
     })
 
 
-def get_hex_tile_status(hash: str, wait_seconds: int = 0, color_scale: str = "linear") -> dict:
+def get_hex_tile_status(
+    hash: str, wait_seconds: int = 0, color_scale: str = "linear", layer_style: str = "fill",
+) -> dict:
     """Poll the status of a pyramid build started by register_hex_tiles.
 
     Call this when register_hex_tiles returned {status: "running"}.
@@ -708,9 +721,10 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0, color_scale: str = "li
     without giving the build time to make progress. wait_seconds=0 returns
     immediately (the legacy non-blocking poll).
 
-    `color_scale` ("linear" default, or "log") restyles the recipe returned on
-    completion, exactly as in register_hex_tiles — pass it here so a build you
-    polled comes back with the log ramp without a second register call.
+    `color_scale` ("linear" default, or "log") and `layer_style` ("fill"
+    default, or "fill-extrusion") restyle the recipe returned on completion,
+    exactly as in register_hex_tiles — pass them here so a build you polled
+    comes back already styled, without a second register call.
 
     Returns one of:
     - {hash, tile_url_template, status: "done", bounds, value_stats, ...} —
@@ -736,11 +750,13 @@ def get_hex_tile_status(hash: str, wait_seconds: int = 0, color_scale: str = "li
     while True:
         kind, payload = _status_check_once(hash, con)
         if kind != "running" or time.time() >= deadline:
-            return _apply_color_scale(payload, color_scale)
+            return _apply_render_opts(payload, color_scale, layer_style)
         time.sleep(min(2.0, max(0.1, deadline - time.time())))
 
 
-async def _get_hex_tile_status_tool(hash: str, wait_seconds: int = 0, color_scale: str = "linear") -> dict:
+async def _get_hex_tile_status_tool(
+    hash: str, wait_seconds: int = 0, color_scale: str = "linear", layer_style: str = "fill",
+) -> dict:
     # Served MCP tool. Truly async long-poll: `await anyio.sleep` frees the
     # event loop (vs the old time.sleep-on-the-loop that blocked /healthz and
     # every other request for up to 60s per poll — #176), and each one-shot
@@ -751,7 +767,7 @@ async def _get_hex_tile_status_tool(hash: str, wait_seconds: int = 0, color_scal
     while True:
         kind, payload = await anyio.to_thread.run_sync(_status_check_once, hash, con)
         if kind != "running" or time.time() >= deadline:
-            return _apply_color_scale(payload, color_scale)
+            return _apply_render_opts(payload, color_scale, layer_style)
         await anyio.sleep(min(2.0, max(0.1, deadline - time.time())))
 
 

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -900,6 +900,45 @@ class TestRenderRecipe:
         linear = render_recipe(self._meta(0, 100), "https://x/{z}/{x}/{y}.pbf")
         assert weird["layer"]["paint"]["fill-color"] == linear["layer"]["paint"]["fill-color"]
 
+    def test_fill_extrusion_layer_shape(self):
+        recipe = render_recipe(
+            self._meta(0, 100), "https://x/{z}/{x}/{y}.pbf", layer_style="fill-extrusion"
+        )
+        layer = recipe["layer"]
+        assert layer["type"] == "fill-extrusion"
+        paint = layer["paint"]
+        # 3D paint props, not the 2D ones.
+        assert "fill-extrusion-color" in paint and "fill-extrusion-height" in paint
+        assert paint["fill-extrusion-base"] == 0
+        assert "fill-color" not in paint and "fill-opacity" not in paint
+        # Color encoding matches the 2D fill ramp (viridis endpoints).
+        assert paint["fill-extrusion-color"][4] == "#440154"
+        assert paint["fill-extrusion-color"][-1] == "#fde725"
+
+    def test_fill_extrusion_height_scales_with_value(self):
+        recipe = render_recipe(
+            self._meta(0, 100), "https://x/{z}/{x}/{y}.pbf", layer_style="fill-extrusion"
+        )
+        height = recipe["layer"]["paint"]["fill-extrusion-height"]
+        outputs = height[4::2]   # [interpolate,[linear],[get,col], v0,h0, v1,h1, ...]
+        assert outputs[0] == 0                    # lowest value → flat
+        assert outputs[-1] > outputs[0]           # highest value → tallest
+        assert outputs == sorted(outputs)         # monotonic with value
+
+    def test_extrusion_honors_log_scale(self):
+        recipe = render_recipe(
+            self._meta(1, 1000), "https://x/{z}/{x}/{y}.pbf",
+            color_scale="log", layer_style="fill-extrusion",
+        )
+        # height stop inputs use the same geometric spacing as the color ramp
+        height_inputs = recipe["layer"]["paint"]["fill-extrusion-height"][3::2]
+        color_inputs = recipe["layer"]["paint"]["fill-extrusion-color"][3::2]
+        assert height_inputs == color_inputs
+
+    def test_unknown_layer_style_falls_back_to_fill(self):
+        weird = render_recipe(self._meta(0, 1), "https://x/{z}/{x}/{y}.pbf", layer_style="globe")
+        assert weird["layer"]["type"] == "fill"
+
 
 class TestSuggestScale:
     def _by_res(self, mn, mx, mean, res=6):

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -179,37 +179,61 @@ def _suggest_scale(by_res: dict, finest_res: int) -> str:
     return "linear"
 
 
+# Max fill-extrusion height (meters) the largest value maps to. A starting
+# default for the 3D variant (#238) — the client owns pitch and can rescale
+# this paint property for its zoom range.
+_EXTRUSION_MAX_HEIGHT = 50000
+
+
+def _ramp_value(frac: float, vmin: float, vmax: float, color_scale: str) -> float:
+    """Map a ramp fraction (0..1) to a data value across [vmin, vmax].
+    color_scale="log" spaces inputs geometrically (low values get more of the
+    ramp — right for the skewed data hex maps usually show); log needs positive
+    inputs, so the low bound is floored to a positive value. Anything other than
+    "log" is linear."""
+    if color_scale == "log":
+        lo = vmin if vmin and vmin > 0 else (vmax / 1000.0 if vmax and vmax > 0 else 1.0)
+        hi = vmax if vmax and vmax > lo else lo * 10.0
+        return lo * ((hi / lo) ** frac)
+    return vmin + frac * (vmax - vmin)
+
+
 def _color_ramp_stops(vmin: float, vmax: float, color_scale: str = "linear") -> list:
     """Flatten the viridis ramp into a MapLibre `interpolate` stop list over
     [vmin, vmax]: [value0, color0, value1, color1, ...]. Inputs are strictly
     ascending (vmax > vmin is guaranteed by the caller's degenerate guard), as
-    MapLibre requires.
-
-    color_scale="log" spaces the stop *inputs* geometrically rather than
-    evenly, so low values get more of the ramp — the right default for the
-    right-skewed data (counts, populations) hex maps usually show. Log spacing
-    needs positive inputs, so the low bound is floored to a positive value."""
-    if color_scale == "log":
-        lo = vmin if vmin and vmin > 0 else (vmax / 1000.0 if vmax and vmax > 0 else 1.0)
-        hi = vmax if vmax and vmax > lo else lo * 10.0
-        ratio = hi / lo
-        stops: list = []
-        for frac, color in _VIRIDIS_STOPS:
-            stops.extend([lo * (ratio ** frac), color])
-        return stops
-    span = vmax - vmin
-    stops = []
+    MapLibre requires."""
+    stops: list = []
     for frac, color in _VIRIDIS_STOPS:
-        stops.extend([vmin + frac * span, color])
+        stops.extend([_ramp_value(frac, vmin, vmax, color_scale), color])
     return stops
 
 
-def render_recipe(meta: dict, tile_url_template: str, color_scale: str = "linear") -> dict:
-    """Return {source, layer}: a paste-ready MapLibre vector tile source + fill
-    layer with a viridis color ramp over the first value column.
+def _height_ramp_stops(vmin: float, vmax: float, color_scale: str, height_max: float) -> list:
+    """Like _color_ramp_stops but the outputs are extrusion heights (0..height_max)
+    instead of colors, over the same (possibly log-spaced) stop inputs — so the
+    3D height and the color encode the value identically."""
+    stops: list = []
+    for frac, _color in _VIRIDIS_STOPS:
+        stops.extend([_ramp_value(frac, vmin, vmax, color_scale), frac * height_max])
+    return stops
+
+
+def render_recipe(
+    meta: dict,
+    tile_url_template: str,
+    color_scale: str = "linear",
+    layer_style: str = "fill",
+) -> dict:
+    """Return {source, layer}: a paste-ready MapLibre vector tile source + layer
+    with a viridis color ramp over the first value column.
 
     color_scale ∈ {"linear", "log"} controls how the ramp is spread across the
-    data domain; anything other than "log" is treated as linear."""
+    data domain; anything other than "log" is treated as linear.
+
+    layer_style ∈ {"fill", "fill-extrusion"} picks a flat 2D fill (default) or a
+    3D extrusion whose height also encodes the value; anything other than
+    "fill-extrusion" is treated as "fill"."""
     col = meta["value_columns"][0]
     by_res = meta.get("value_stats", {}).get(col, {}).get("by_res", {})
     stats = by_res.get(str(meta["finest_res"])) or (next(iter(by_res.values())) if by_res else None)
@@ -217,12 +241,23 @@ def render_recipe(meta: dict, tile_url_template: str, color_scale: str = "linear
     vmax = stats["max"] if stats and stats.get("max") is not None else vmin
     if vmax == vmin:
         vmax = vmin + 1  # degenerate domain — keep the interpolate stops distinct
-    paint = {
-        "fill-color": ["interpolate", ["linear"], ["get", col], *_color_ramp_stops(vmin, vmax, color_scale)],
-        "fill-opacity": 0.7,
-    }
     source = {"type": "vector", "tiles": [tile_url_template], "minzoom": 0, "maxzoom": 14}
-    layer = {"type": "fill", "source-layer": meta.get("layer_name", MVT_LAYER_NAME), "paint": paint}
+    source_layer = meta.get("layer_name", MVT_LAYER_NAME)
+    color_stops = ["interpolate", ["linear"], ["get", col], *_color_ramp_stops(vmin, vmax, color_scale)]
+    if layer_style == "fill-extrusion":
+        paint = {
+            "fill-extrusion-color": color_stops,
+            "fill-extrusion-height": [
+                "interpolate", ["linear"], ["get", col],
+                *_height_ramp_stops(vmin, vmax, color_scale, _EXTRUSION_MAX_HEIGHT),
+            ],
+            "fill-extrusion-base": 0,
+            "fill-extrusion-opacity": 0.85,
+        }
+        layer = {"type": "fill-extrusion", "source-layer": source_layer, "paint": paint}
+    else:
+        paint = {"fill-color": color_stops, "fill-opacity": 0.7}
+        layer = {"type": "fill", "source-layer": source_layer, "paint": paint}
     return {"source": source, "layer": layer}
 
 


### PR DESCRIPTION
Part 3 of #238 (item 4) — completes the issue. Adds an optional **3D extrusion** render variant.

**New: `layer_style` parameter** on `register_hex_tiles` and `get_hex_tile_status` — `"fill"` (default, flat 2D) or `"fill-extrusion"` (3D).
- The 3D layer's `fill-extrusion-color` uses the **same viridis ramp** as the 2D fill, and `fill-extrusion-height` (0..50000 m) **also encodes the value**, so color and height agree.
- Honors `color_scale` — height and color share one spacing function (`_ramp_value`), so `color_scale="log"` + `layer_style="fill-extrusion"` compose.
- Pure render choice (like color_scale): applied at the tool boundary from `value_stats`, **no tile/hash/build change**, so it's a cache hit over existing tilesets. The map client must set **pitch > 0** to see extrusions.

**Refactor:** ramp helpers now share `_ramp_value` (one spacing function for color *and* height stops) — no behavior change to the 2D/log paths.

**Tests:** 3D layer + paint shape (3D props present, 2D props absent), height monotonic with value, log+extrusion composition (shared stop inputs), unknown-style → fill fallback.

With #252 (viridis) and #253 (log scale), this closes #238. Closes #238.