### PR TITLE
source.coop mirror fallback for public data reads (#260)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -93,11 +93,45 @@ kubectl logs -l job-name=s3-throughput -f --max-log-requests=12 --prefix
 kubectl delete job s3-throughput
 ```
 
+### `source-coop-endpoint-bench.py`
+
+Compares the two front doors to the *same* source.coop objects: the **direct AWS
+S3 bucket** (`us-west-2.opendata.source.coop`, a CNAME straight to
+`s3.us-west-2.amazonaws.com` — what the #260/#261 fallback maps to) vs the
+**`data.source.coop` gateway** (Cloudflare-fronted CDN proxy over the same S3
+origin, the host that appears in the source.coop STAC hrefs). Raw HTTP probes
+(footer latency, single-stream MB/s, aggregate MB/s) isolate transport; DuckDB
+`count(*)` and single-column `sum()` over the whole dataset show the query-path
+impact. Cold and warm passes both reported (Cloudflare may edge-cache).
+
+```bash
+uv run --with 'duckdb>=1.1' --with requests python3 source-coop-endpoint-bench.py
+```
+
+Result (2026-07-03, run from **UC Berkeley campus egress — not NRP**; relative
+comparison holds directionally, absolute numbers differ on-cluster over
+Internet2/CENIC — re-run the k8s form for production numbers):
+
+| metric | aws-direct | data.source.coop proxy |
+|---|---|---|
+| footer latency (median) | 133 ms | 138 ms |
+| single-stream throughput (median) | **80.8 MB/s** | 64.5 MB/s |
+| aggregate throughput (c=8) | 96.9 MB/s | 108.9 MB/s (n=1, noisy) |
+| DuckDB `count(*)` (warm) | 2.7 s | 2.9 s |
+| DuckDB `sum(1 col)` (warm) | **176 s** | 224 s |
+
+Direct AWS is as-good-or-better on every robust metric and ~25–27% faster on the
+throughput-bound cases (single-stream, full-column scan). Cloudflare edge caching
+did **not** help — these large, rarely-requested files aren't hot, so the proxy is
+just an extra hop to the same origin. Conclusion: **map to the direct AWS bucket**
+(which the fallback already does); the proxy buys nothing here.
+
 ## Key findings
 
 1. Always include `h0` in join conditions (e.g., `ON p.h8 = c.h8 AND p.h0 = c.h0`) — this is what enables DPP file-level pruning.
 2. Set `s3_allow_recursive_globbing=false` on DuckDB 1.5.0 when querying partitioned data on S3 to avoid reading all files at planning time.
 3. A static `WHERE c.h0 = X` literal is ~9s faster and ~200 fewer GETs than join-driven DPP for single-partition queries, due to build-side materialization overhead — but both open only 1 file.
 4. Queryable hex datasets are 1 file per h0 (carbon 122, padus 21, gbif-2026 122), so a pruned query opens 1 footer and a global scan ≤122. The historical "~923 files / ~126-per-h0" was a since-fixed GBIF over-sharding bug, not steady state — large scans are bandwidth-bound, not open-latency-bound. This retires the per-object-latency framing in older notes.
+5. For the source.coop mirror, read the **direct AWS bucket** (`us-west-2.opendata.source.coop` → AWS S3), not the `data.source.coop` Cloudflare proxy: direct is ~25–27% faster on throughput-bound reads and the CDN provides no caching benefit for these large, cold objects. The #260/#261 fallback already maps to the direct bucket.
 
 See `../query-optimization.md` for the actionable rules derived from these findings.

--- a/benchmarks/source-coop-endpoint-bench.py
+++ b/benchmarks/source-coop-endpoint-bench.py
@@ -1,0 +1,180 @@
+"""
+source.coop endpoint comparison: direct AWS S3 bucket vs the data.source.coop proxy.
+
+The mirror fallback (#260, #261) rewrites STAC hrefs to the S3 bucket form
+`s3://us-west-2.opendata.source.coop/...`, which is a CNAME straight to AWS S3
+(s3.us-west-2.amazonaws.com) — i.e. DIRECT AWS. The STAC assets themselves are
+published under the `data.source.coop` HTTPS gateway, which is Cloudflare-fronted
+(a CDN PROXY in front of the same S3 origin). Same bytes, two front doors.
+
+This measures whether it's worth going direct to AWS vs through the CDN proxy:
+
+  RAW HTTP (isolates transport; both are plain HTTPS GETs of the same object):
+    1. footer latency  - many small ranged GETs (last 16 KiB) -> median ms.
+    2. single-stream   - one full object end-to-end -> MB/s.
+    3. aggregate       - K distinct objects at concurrency C -> aggregate MB/s.
+
+  DuckDB (how the server actually reads — s3:// vs https:// read_parquet):
+    4. count(*)        - footer-only across the whole dataset (latency-bound).
+    5. sum(1 column)   - column-pruned scan across the whole dataset (throughput).
+
+Cold vs warm matters here: Cloudflare can edge-cache, so the proxy may *win*
+on warm reads and lose on cold. Both passes are reported.
+
+CAVEAT: numbers are relative to WHERE THIS RUNS. From NRP the path to AWS is
+Internet2/CENIC; from a laptop/campus it is commodity egress. Run the k8s Job
+form on-cluster for production-representative numbers.
+
+Run
+---
+  uv run --with 'duckdb>=1.1' --with requests python3 source-coop-endpoint-bench.py
+  MRE_DATASET=cboettig/gbif/... MRE_THREADS=16 uv run ... python3 source-coop-endpoint-bench.py
+
+Anonymous (unsigned) reads only; the source.coop mirror is public.
+"""
+import os
+import statistics
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import duckdb
+import requests
+
+# --- knobs (override via env) -----------------------------------------------
+# Prefix under the mirror bucket whose h0=*/data_0.parquet files are compared.
+DATASET = os.environ.get("MRE_DATASET", "cboettig/carbon/vulnerable-carbon-2024/hex")
+COLUMN = os.environ.get("MRE_COLUMN", "carbon")   # column for the pruned-scan test
+THREADS = int(os.environ.get("MRE_THREADS", "16"))
+N_LATENCY = int(os.environ.get("MRE_N_LATENCY", "20"))   # small ranged GETs
+N_STREAM = int(os.environ.get("MRE_N_STREAM", "5"))      # distinct full-object GETs
+AGG_OBJS = int(os.environ.get("MRE_AGG_OBJS", "16"))     # objects in the aggregate test
+AGG_CONC = int(os.environ.get("MRE_AGG_CONC", "8"))      # concurrency for aggregate test
+FOOTER_BYTES = int(os.environ.get("MRE_FOOTER_BYTES", str(16 * 1024)))
+
+BUCKET = "us-west-2.opendata.source.coop"
+AWS_HOST = "https://s3.us-west-2.amazonaws.com"          # direct AWS, path-style
+PROXY_HOST = "https://data.source.coop"                  # Cloudflare CDN proxy
+
+# key -> URL for each front door (same underlying object)
+def aws_url(key):   return f"{AWS_HOST}/{BUCKET}/{key}"
+def proxy_url(key): return f"{PROXY_HOST}/{key}"
+
+# key -> DuckDB read_parquet target for each front door
+def aws_s3(key):    return f"s3://{BUCKET}/{key}"
+def proxy_https(key): return proxy_url(key)
+
+ENDPOINTS = {"aws-direct": (aws_url, aws_s3), "sourcecoop-proxy": (proxy_url, proxy_https)}
+
+
+def _new_con():
+    con = duckdb.connect()
+    con.sql("INSTALL httpfs; LOAD httpfs;")
+    con.sql(f"SET threads={THREADS};")
+    # Anonymous, path-style secret for the direct AWS bucket; https reads need none.
+    con.sql(
+        "CREATE OR REPLACE SECRET sc (TYPE S3, KEY_ID '', SECRET '', "
+        "REGION 'us-west-2', ENDPOINT 's3.us-west-2.amazonaws.com', "
+        "URL_STYLE 'path', USE_SSL 'true');"
+    )
+    return con
+
+
+def discover_keys():
+    con = _new_con()
+    rows = con.sql(
+        f"SELECT file FROM glob('s3://{BUCKET}/{DATASET}/h0=*/data_0.parquet') ORDER BY file"
+    ).df()["file"].tolist()
+    keys = [f.split(f"{BUCKET}/", 1)[1] for f in rows]
+    if not keys:
+        raise SystemExit(f"no files under s3://{BUCKET}/{DATASET}")
+    return keys
+
+
+# --- raw HTTP probes --------------------------------------------------------
+def footer_latency_ms(url_for, keys):
+    """Median wall time of a small ranged GET (last FOOTER_BYTES). Warm session."""
+    sess = requests.Session()
+    samples = []
+    for key in keys[:N_LATENCY]:
+        url = url_for(key)
+        # find size once, then range the tail
+        h = sess.head(url, timeout=30)
+        size = int(h.headers.get("Content-Length", "0")) or None
+        rng = f"bytes=-{FOOTER_BYTES}" if size is None else f"bytes={max(0,size-FOOTER_BYTES)}-{size-1}"
+        t = time.perf_counter()
+        r = sess.get(url, headers={"Range": rng}, timeout=30)
+        r.content  # force read
+        samples.append((time.perf_counter() - t) * 1000)
+    return statistics.median(samples), min(samples)
+
+
+def single_stream_mbps(url_for, keys):
+    """Median MB/s over N distinct full-object GETs (distinct keys avoid caching)."""
+    sess = requests.Session()
+    rates = []
+    for key in keys[:N_STREAM]:
+        url = url_for(key)
+        t = time.perf_counter()
+        n = 0
+        with sess.get(url, stream=True, timeout=120) as r:
+            for chunk in r.iter_content(1 << 20):
+                n += len(chunk)
+        dt = time.perf_counter() - t
+        rates.append((n / 1e6) / dt)
+    return statistics.median(rates), max(rates)
+
+
+def aggregate_mbps(url_for, keys):
+    """Aggregate MB/s reading AGG_OBJS distinct objects at AGG_CONC concurrency."""
+    sel = keys[:AGG_OBJS]
+
+    def fetch(key):
+        n = 0
+        with requests.get(url_for(key), stream=True, timeout=120) as r:
+            for chunk in r.iter_content(1 << 20):
+                n += len(chunk)
+        return n
+
+    t = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=AGG_CONC) as ex:
+        total = sum(ex.map(fetch, sel))
+    dt = time.perf_counter() - t
+    return (total / 1e6) / dt
+
+
+# --- DuckDB query probes ----------------------------------------------------
+def duckdb_query(target_for, keys, sql_template):
+    """Run a query over all files via a fresh connection. Returns seconds."""
+    con = _new_con()
+    targets = [target_for(k) for k in keys]
+    lst = "[" + ",".join(f"'{t}'" for t in targets) + "]"
+    t = time.perf_counter()
+    con.sql(sql_template.format(files=lst)).fetchall()
+    return time.perf_counter() - t
+
+
+def main():
+    print(f"dataset : {DATASET}")
+    keys = discover_keys()
+    print(f"files   : {len(keys)}   threads={THREADS}\n")
+
+    COUNT_SQL = "SELECT count(*) FROM read_parquet({files})"
+    SUM_SQL = f"SELECT sum({COLUMN}) FROM read_parquet({{files}})"
+
+    for name, (url_for, target_for) in ENDPOINTS.items():
+        print(f"=== {name} ===")
+        med_ms, min_ms = footer_latency_ms(url_for, keys)
+        print(f"  footer latency (last {FOOTER_BYTES//1024}KiB) : median {med_ms:6.1f} ms   best {min_ms:6.1f} ms  (n={min(N_LATENCY,len(keys))})")
+        med_mbps, max_mbps = single_stream_mbps(url_for, keys)
+        print(f"  single-stream throughput           : median {med_mbps:6.1f} MB/s  peak {max_mbps:6.1f} MB/s  (n={N_STREAM})")
+        agg = aggregate_mbps(url_for, keys)
+        print(f"  aggregate throughput (c={AGG_CONC}, {AGG_OBJS} obj) : {agg:6.1f} MB/s")
+        for label, sql in (("count(*) [footers]", COUNT_SQL), (f"sum({COLUMN}) [1-col scan]", SUM_SQL)):
+            cold = duckdb_query(target_for, keys, sql)
+            warm = min(duckdb_query(target_for, keys, sql) for _ in range(2))
+            print(f"  duckdb {label:<22} : cold {cold:5.1f}s   warm {warm:5.1f}s")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/query-setup.md
+++ b/query-setup.md
@@ -11,6 +11,7 @@ LOAD httpfs;
 LOAD h3;
 LOAD spatial;
 CREATE OR REPLACE SECRET s3 (TYPE S3, ENDPOINT 'rook-ceph-rgw-nautiluss3.rook', URL_STYLE 'path', USE_SSL 'false', KEY_ID '', SECRET '');
+CREATE OR REPLACE SECRET source_coop (TYPE S3, SCOPE 's3://us-west-2.opendata.source.coop', REGION 'us-west-2', ENDPOINT 's3.us-west-2.amazonaws.com', URL_STYLE 'path', USE_SSL 'true', KEY_ID '', SECRET '');
 ```
 
 **Why these settings?**
@@ -21,6 +22,7 @@ CREATE OR REPLACE SECRET s3 (TYPE S3, ENDPOINT 'rook-ceph-rgw-nautiluss3.rook', 
 - `httpfs` - Required for S3 access
 - `h3` - Required for H3 functions
 - `spatial` - Required for `ST_*` functions (line-data exact mileage, GeoParquet inspection)
+- `source_coop` secret - Anonymous, prefix-scoped fallback for the public source.coop mirror. DuckDB routes `s3://us-west-2.opendata.source.coop/...` paths to it automatically; `s3://public-*` paths still go to Ceph. Use mirror paths (returned by the STAC tools as `s3://us-west-2.opendata.source.coop/cboettig/<dataset>/...`) when the primary Ceph endpoint is unavailable.
 
 **Note:** `rook-ceph-rgw-nautiluss3.rook` is an internal endpoint that only your tool running on k8s can access. The publicly accessible external endpoint is `s3-west.nrp-nautilus.io`, which requires `USE_SSL true` and `SET THREADS=2`. Always use the internal endpoint to run queries.
 

--- a/stac.py
+++ b/stac.py
@@ -118,9 +118,19 @@ pystac.StacIO.set_default(_TimeoutStacIO)
 
 
 def _href_to_s3(href: str) -> str:
-    """Convert an HTTPS S3 URL to an s3:// path for DuckDB read_parquet()."""
+    """Convert an HTTPS S3 URL to an s3:// path for DuckDB read_parquet().
+
+    Handles both the primary NRP Ceph endpoint and the source.coop mirror. The
+    source.coop STAC entries publish assets under the `data.source.coop` HTTPS
+    gateway, which cannot list/glob; rewriting to the `us-west-2.opendata.source.coop`
+    S3 bucket form lets DuckDB expand `h0=*` globs against the mirror (see #260).
+    """
     if href.startswith("https://s3-west.nrp-nautilus.io/"):
         return href.replace("https://s3-west.nrp-nautilus.io/", "s3://")
+    if href.startswith("https://data.source.coop/"):
+        return href.replace(
+            "https://data.source.coop/", "s3://us-west-2.opendata.source.coop/"
+        )
     return href
 
 
@@ -282,11 +292,15 @@ def _collection_to_dict(col, sub_children=None) -> dict:
         },
     }
 
-    # External links (exclude navigational rel types)
+    # External links (exclude navigational rel types). Use get_target_str()
+    # rather than lnk.href: the latter calls get_root(), which resolves the root
+    # link over the network — so rendering an inline collection whose root points
+    # at an unreachable catalog (e.g. the source.coop mirror path during a Ceph
+    # outage, #260) would crash. get_target_str() returns the raw href, no I/O.
     result["links"] = [
         {k: v for k, v in {
             "rel": lnk.rel,
-            "href": lnk.href,
+            "href": lnk.get_target_str(),
             "title": getattr(lnk, "title", None),
         }.items() if v is not None}
         for lnk in (col.links or [])

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -7,7 +7,7 @@ import os
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from stac import list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict, _fuzzy_lookup, _format_collection
+from stac import list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict, _fuzzy_lookup, _format_collection, _href_to_s3
 
 
 class TestCatalogUrlParameter:
@@ -354,6 +354,66 @@ class TestCollectionToDict:
         intervals = result["extent"]["temporal"]["interval"]
         assert intervals[0][0].startswith("2020-01-01")
         assert intervals[0][1] is None
+
+
+class TestSourceCoopFallback:
+    """Fallback to the public source.coop mirror when Ceph S3-west is down (#260)."""
+
+    def test_href_to_s3_ceph(self):
+        assert _href_to_s3("https://s3-west.nrp-nautilus.io/public-carbon/x.parquet") == \
+            "s3://public-carbon/x.parquet"
+
+    def test_href_to_s3_source_coop(self):
+        # source.coop STAC assets are published under the data.source.coop HTTPS
+        # gateway, which cannot list/glob. Rewrite to the S3 bucket form so DuckDB
+        # can expand h0=* globs against the mirror.
+        href = "https://data.source.coop/cboettig/carbon/vulnerable-carbon-2024/hex/h0=*/data_0.parquet"
+        assert _href_to_s3(href) == \
+            "s3://us-west-2.opendata.source.coop/cboettig/carbon/vulnerable-carbon-2024/hex/h0=*/data_0.parquet"
+
+    def test_href_to_s3_passthrough(self):
+        assert _href_to_s3("https://example.com/other.parquet") == \
+            "https://example.com/other.parquet"
+
+    def test_source_coop_asset_rewritten_in_collection(self):
+        col = MagicMock()
+        col.id, col.title, col.description = "carbon", "Carbon", "d"
+        col.license, col.keywords, col.providers = "CC-BY", [], []
+        col.links, col.summaries, col.extra_fields = [], None, {}
+        spatial = MagicMock(); spatial.bboxes = [[-180, -90, 180, 90]]
+        temporal = MagicMock(); temporal.intervals = []
+        col.extent = MagicMock(spatial=spatial, temporal=temporal)
+        asset = MagicMock()
+        asset.href = "https://data.source.coop/cboettig/carbon/vulnerable-carbon-2024/hex/h0=*/data_0.parquet"
+        asset.media_type = "application/x-parquet"
+        asset.title, asset.description, asset.extra_fields = "hex", None, {}
+        col.assets = {"hex": asset}
+        result = _collection_to_dict(col)
+        assert result["assets"]["hex"]["href"].startswith(
+            "s3://us-west-2.opendata.source.coop/cboettig/carbon/"
+        )
+
+    def test_link_render_does_not_resolve_root(self):
+        # Regression: rendering an inline collection must not touch the network.
+        # lnk.href resolves the (possibly unreachable) root; get_target_str() must
+        # be used instead so a Ceph outage doesn't crash mirror-backed rendering.
+        col = MagicMock()
+        col.id, col.title, col.description = "carbon", "Carbon", "d"
+        col.license, col.keywords, col.providers = "CC-BY", [], []
+        col.summaries, col.extra_fields, col.assets = None, {}, {}
+        spatial = MagicMock(); spatial.bboxes = [[-180, -90, 180, 90]]
+        temporal = MagicMock(); temporal.intervals = []
+        col.extent = MagicMock(spatial=spatial, temporal=temporal)
+        lnk = MagicMock()
+        lnk.rel = "derived_from"
+        lnk.title = None
+        lnk.get_target_str.return_value = "https://doi.org/10.5281/zenodo.4091029"
+        type(lnk).href = property(
+            lambda self: (_ for _ in ()).throw(Exception("root not reachable"))
+        )
+        col.links = [lnk]
+        result = _collection_to_dict(col)  # must not raise
+        assert result["links"][0]["href"] == "https://doi.org/10.5281/zenodo.4091029"
 
 
 class TestGetCollection:


### PR DESCRIPTION
Explores a clean fallback to the public **source.coop** mirror so the server stays usable when NRP Ceph **S3-west** is unavailable. Closes part of #260 (Phase 1).

## Approach

Additive and **always-on** — no server-side mode switch, no effect on the Ceph happy path. DuckDB routes reads by path prefix, so the mirror is simply an *additional* known source. This matches how apps already work (they link individual bucket `stac-collection.json` entries directly rather than walking a top-level catalog — there is no top-level catalog on source.coop).

## Changes

- **`query-setup.md`** — add an anonymous, prefix-scoped `source_coop` S3 secret. `s3://us-west-2.opendata.source.coop/*` routes to the mirror; `s3://public-*` still routes to Ceph.
- **`stac.py` `_href_to_s3`** — rewrite `https://data.source.coop/` asset hrefs to the `s3://us-west-2.opendata.source.coop/` bucket form, so DuckDB can expand `h0=*` globs (the `data.source.coop` HTTPS gateway cannot list).
- **`stac.py` `_collection_to_dict`** — use `lnk.get_target_str()` instead of `lnk.href`. `lnk.href` triggers `get_root()`, which resolves the collection's root link over the network — that crashes when rendering an inline source.coop collection during a Ceph outage (the whole point). `get_target_str()` returns the raw href with no I/O.

Net effect: pass a source.coop `stac-collection.json` to the STAC tools (inline `collection` or `catalog_url`) and every asset resolves to a queryable s3 mirror path — end-to-end during a Ceph outage.

## Verification (against live source.coop while Ceph was down)

- Two-secret prefix routing confirmed via `which_secret()`; the server's actual parsed `SETUP_SQL` produces correct routing + a real mirror read (carbon: 4.8B rows, ~2s).
- Full inline source.coop collection → every asset (parquet hex + COG) resolves to an s3 mirror path, structured and markdown paths.
- **271/271 tests pass**, incl. 5 new: `_href_to_s3` rewrite cases, asset rewrite in `_collection_to_dict`, and a regression guard that link rendering never resolves the root over the network.

## Deferred (Phase 2, follow-up)

Automatic Ceph-down detection + auto-resolving each dataset's source.coop entry. That needs a dataset↔bucket map, since source.coop collection ids differ from the bucket name (e.g. `irrecoverable-carbon` vs bucket `carbon`).