### PR TITLE
Opt-in degraded start so the server boots during a Ceph outage (#260)

### DIFF
--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -30,6 +30,12 @@ spec:
           value: "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
         - name: MCP_PUBLIC_BASE_URL
           value: "https://dev-duckdb-mcp.nrp-nautilus.io"
+        # Boot even if the Ceph STAC catalog is unreachable at startup, so the
+        # server can serve the source.coop mirror during a Ceph outage (#260).
+        # Discovery is empty until Ceph returns; known/inline datasets still work.
+        # Dev-only for now; prod keeps the default fail-fast until proven out.
+        - name: STAC_ALLOW_DEGRADED_START
+          value: "true"
         resources:
           # Requests intentionally kept small (≤2 GiB memory, ≤1 CPU) to land in
           # NRP's "Ignored" bucket for utilization violations. Limits stay high so

--- a/server.py
+++ b/server.py
@@ -817,19 +817,49 @@ async def _version(_request):
 # -------------------------------------------------------------------------
 # 10. SERVER START
 # -------------------------------------------------------------------------
-if __name__ == "__main__":
-    # If the STAC root catalog was unreachable at startup, serving would give
-    # clients a useless empty catalog. Exit non-zero so Kubernetes restarts the
-    # pod and gets a fresh attempt against whatever S3 looks like now. Child
-    # failures (partial catalog) are fine — the resilience design serves what
-    # loaded and records the rest in STAC_LOAD_ERRORS for list_datasets's footer.
-    if "__root__" in STAC_LOAD_ERRORS:
+def _enforce_stac_startup_gate() -> bool:
+    """Decide whether to boot when the STAC root catalog failed to load.
+
+    Normally, an unreachable root catalog means serving would give clients a
+    useless empty catalog, so we exit non-zero and let Kubernetes restart the
+    pod for a fresh attempt against whatever S3 looks like now. (Child failures —
+    a partial catalog — are fine: the resilience design serves what loaded and
+    records the rest in STAC_LOAD_ERRORS for list_datasets's footer.)
+
+    But during a sustained Ceph outage that fail-fast prevents the server from
+    booting at all — which defeats the source.coop mirror fallback (#260): a
+    running process can still serve known datasets and resolve source.coop STAC
+    entries directly. STAC_ALLOW_DEGRADED_START=true opts into booting anyway
+    with an empty catalog. Returns True if starting degraded, False if the root
+    loaded fine. Default behavior (flag unset) is unchanged: exit(1).
+    """
+    if "__root__" not in STAC_LOAD_ERRORS:
+        return False
+    reason = STAC_LOAD_ERRORS["__root__"]
+    allow_degraded = os.environ.get("STAC_ALLOW_DEGRADED_START", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    if allow_degraded:
         print(
-            "💀 STAC root catalog unreachable at startup — exiting so k8s can "
-            f"restart and retry. Reason: {STAC_LOAD_ERRORS['__root__']}",
+            "⚠️ STAC root catalog unreachable at startup — booting in DEGRADED mode "
+            "(STAC_ALLOW_DEGRADED_START set). Discovery (browse_stac_catalog / "
+            "list_datasets) will be empty until the catalog is reachable; clients can "
+            "still query known datasets and pass source.coop STAC entries directly. "
+            f"Reason: {reason}",
             file=sys.stderr,
         )
-        sys.exit(1)
+        return True
+    print(
+        "💀 STAC root catalog unreachable at startup — exiting so k8s can restart "
+        "and retry. Set STAC_ALLOW_DEGRADED_START=true to boot anyway (e.g. to serve "
+        f"the source.coop mirror during a Ceph outage). Reason: {reason}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    _enforce_stac_startup_gate()
 
     app = mcp.streamable_http_app()
     app.router.redirect_slashes = False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -955,5 +955,40 @@ class TestBuildFailureMarker:
         assert "synthetic build failure" in failed["error"]
 
 
+class TestStacStartupGate:
+    """_enforce_stac_startup_gate: fail-fast on an unreachable root catalog, with
+    an opt-in degraded start for serving the source.coop mirror during an outage (#260)."""
+
+    def test_boots_normally_when_root_loaded(self, monkeypatch):
+        import server
+        monkeypatch.setattr(server, "STAC_LOAD_ERRORS", {})
+        assert server._enforce_stac_startup_gate() is False
+
+    def test_exits_when_root_failed_and_flag_unset(self, monkeypatch):
+        import server
+        monkeypatch.setattr(server, "STAC_LOAD_ERRORS", {"__root__": "ConnectTimeout"})
+        monkeypatch.delenv("STAC_ALLOW_DEGRADED_START", raising=False)
+        with pytest.raises(SystemExit) as exc:
+            server._enforce_stac_startup_gate()
+        assert exc.value.code == 1
+
+    def test_degraded_start_when_flag_set(self, monkeypatch):
+        import server
+        monkeypatch.setattr(server, "STAC_LOAD_ERRORS", {"__root__": "ConnectTimeout"})
+        monkeypatch.setenv("STAC_ALLOW_DEGRADED_START", "true")
+        assert server._enforce_stac_startup_gate() is True
+
+    def test_flag_is_case_and_value_tolerant(self, monkeypatch):
+        import server
+        monkeypatch.setattr(server, "STAC_LOAD_ERRORS", {"__root__": "boom"})
+        for val in ("1", "TRUE", "Yes", "on"):
+            monkeypatch.setenv("STAC_ALLOW_DEGRADED_START", val)
+            assert server._enforce_stac_startup_gate() is True
+        # A non-truthy value still fails fast.
+        monkeypatch.setenv("STAC_ALLOW_DEGRADED_START", "false")
+        with pytest.raises(SystemExit):
+            server._enforce_stac_startup_gate()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Follow-up to #261. Deploying the mirror fallback to dev surfaced a gap: the server's startup **fail-fast** (`sys.exit(1)` when the Ceph STAC root catalog is unreachable) means **no fresh pod can boot during a Ceph outage** — which defeats the whole point of a mirror fallback, since a *running* process can still serve known datasets and resolve source.coop STAC entries directly.

The fail-fast is a sensible health check in normal operation (an empty catalog is a useless server; restart and retry). This just adds an opt-in escape hatch.

## Changes

- **`server.py`** — factor the check into `_enforce_stac_startup_gate()`. Default behavior is **unchanged**: `exit(1)` on an unreachable root. `STAC_ALLOW_DEGRADED_START=true` boots anyway with an empty catalog and a loud warning.
- **`k8s/dev-deployment.yaml`** — set `STAC_ALLOW_DEGRADED_START=true` on **dev only**. Prod keeps the default fail-fast until this is proven out.
- **tests** — gate returns `False` on a healthy root, `exit(1)` when the flag is unset, boots degraded when set, tolerant of flag value/case.

## Known limitation (Phase 2)

Even in degraded mode, discovery (`browse_stac_catalog` / `list_datasets`) is **empty** during an outage, because the pre-warm is Ceph-sourced and Ceph-pointing. The fallback therefore works only for clients that pass a source.coop STAC entry directly (the "apps link those directly" model). Making failover automatic *through discovery* needs (a) a catalog that survives the outage — a baked-into-image snapshot or last-good persisted to a PVC (source.coop has no top-level catalog to walk) — and (b) a `public-<name>` → `us-west-2.opendata.source.coop/cboettig/<name>` bucket rewrite on the Ceph-pointing entries. Tracked separately.

Unblocks deploying #261 to dev for testing.