### PR TITLE
docs: catalog sourcing architecture (carry-the-links vs whole-catalog)

### DIFF
--- a/docs/architecture/catalog-sourcing.md
+++ b/docs/architecture/catalog-sourcing.md
@@ -1,0 +1,92 @@
+# Catalog sourcing: "carry the links" vs "the whole catalog"
+
+How this server and its client apps discover and read datasets — and what that
+means for swapping, mixing, and backing up data sources (e.g. Ceph ↔ source.coop
+mirror ↔ minio). Reference/design note; the actionable follow-ups are tracked in
+[#263](https://github.com/boettiger-lab/mcp-data-server/issues/263) and
+[#264](https://github.com/boettiger-lab/mcp-data-server/issues/264).
+
+## Two models
+
+- **Whole catalog** — a component holds/traverses a single root catalog (the
+  server's startup pre-warm of the Ceph root `STAC_CATALOG_URL`).
+- **Carry the links** — a component holds direct per-dataset links
+  (`collection_url` / inline `collection`), from *any* source, needing no root.
+
+**The architecture is fundamentally "carry the links."** The whole-catalog
+pre-warm is a thin, swappable discovery/default convenience — it is *not*
+load-bearing for the dominant workflows. Treat per-collection links as the
+primary contract; keep the whole-catalog optional.
+
+## Reliance map
+
+| Surface | Whole-catalog reliance | Notes |
+|---|---|---|
+| MCP `query` | **None** | No catalog references in the query path; runs SQL on whatever paths it's given. ~85% of MCP calls. |
+| MCP `get_stac_details` / `get_collection` | **Fallback only** | Resolution is inline `collection` → `catalog_url` → default cache. In production ~always inline (via `get_schema` + the `injectInlineStac` wrapper), bypassing the pre-warm. |
+| MCP `browse_stac_catalog`, `catalog://list/{id}` | **Full** | Served from the pre-warmed `STAC_DATASETS`; Ceph-bound and Ceph-pointing. ~1.4% of calls, optional discovery. |
+| MCP startup | **Soft** | Pre-warm + fail-fast; `STAC_ALLOW_DEGRADED_START` (#262) removed the hard dependency. |
+| geo-agent CDN lib | **~None for its own data** | Builds its own `DatasetCatalog` from config (`collection_url`s + `catalog`, fetched client-side from any host) and forwards them inline to MCP. Touches the server's whole-catalog only via optional `browse_stac_catalog`. |
+
+So the Ceph-root pre-warm is load-bearing for only `browse_stac_catalog` + the
+`catalog://` resources + the default-resolution fallback — a thin slice.
+
+## Key operational consequence for app resilience
+
+**A geo-agent app's data source is its *own* config, not the MCP server's
+`STAC_CATALOG_URL`.** It fetches each `collection_url`'s STAC JSON *client-side*
+and builds map layers directly from it (not via the MCP `get_collection` tool);
+the paths the agent reasons about come from that config, forwarded inline to MCP.
+
+Therefore:
+
+- The **server-side** source.coop fallback (`_href_to_s3` rewrite + `source_coop`
+  secret) covers the **MCP `query` and STAC-tool** paths — the flows that go
+  *through* the server. It does **not** cover an app's client-side layer fetches.
+- To make an app itself resilient to a Ceph outage, **repoint its config** (the
+  `catalog` + `collection_url`s in `layers-input.json`) at the backup source —
+  *or* route its layer/collection fetches through the MCP so the server-side
+  fallback applies. This is a per-app decision, not something the server can do
+  for it.
+
+## Swap / mix / match
+
+- **Swap a backup catalog during an outage.** App: repoint its config (instant,
+  client-side, no server change). Server: swap `STAC_CATALOG_URL` to a backup
+  root to restore `browse`/resources/default-resolution (the hot path doesn't
+  need it). Because there is no top-level catalog on source.coop, the source.coop
+  case is handled per-collection; a minio backup can provide a real root.
+- **Mix sources.** Natural *at the link level* — each dataset carries its own
+  `collection_url` from any host, and MCP `get_stac_details` renders whatever
+  inline STAC it's given. Two chokepoints trip up *novel* sources (tracked in
+  [#264](https://github.com/boettiger-lab/mcp-data-server/issues/264)):
+  1. **Query endpoint secrets** — `query()` routes `s3://` paths to DuckDB
+     secrets, and only `s3` (Ceph) + `source_coop` (mirror) are wired. A new
+     source needs its own secret or per-call `s3_endpoint`/creds.
+  2. **href → `s3://` rewriting** — `_href_to_s3` only special-cases `s3-west`
+     and `data.source.coop`; other hosts pass through as HTTPS, which DuckDB
+     can't glob.
+  Composition by **linking whole catalogs** (catalog-of-catalogs) is separately
+  blocked by the catalog-walk limits in
+  [#263](https://github.com/boettiger-lab/mcp-data-server/issues/263); composition
+  by **listing collections** (the geo-agent pattern) works today.
+
+## Does this trip up existing workflows?
+
+Largely no. The dominant flows (query, schema-via-inline) are
+whole-catalog-independent, so swapping/mixing sources doesn't break them —
+*provided query has a secret for each endpoint*. `browse` + `catalog://` +
+default-resolution depend on a reachable whole catalog (empty during a Ceph
+outage under degraded start; restored by swapping `STAC_CATALOG_URL`); these are
+low-volume and optional. The one historical hard dependency (startup fail-fast)
+is already addressed.
+
+## Design north star
+
+Lean into "carry the links" as the primary contract; keep the whole-catalog a
+thin, swappable discovery/default. Make arbitrary mix/match clean by replacing
+host-string special-casing with **data-driven routing** — a source registry that
+drives both the query secrets and the href rewrite (#264) — and, if
+catalog-of-catalogs composition is ever wanted, a recursive type-agnostic walk
+(#263). The fully STAC-native end state carries endpoint/routing on the asset
+(storage extension) rather than in server-side tables.


### PR DESCRIPTION
Captures the architecture framing from the source.coop-fallback design discussion that isn't tracked in the task issues (#263 catalog walk, #264 data-driven routing) — it's reference/decision material, not a work item.

`docs/architecture/catalog-sourcing.md` covers:
- **The two models** — "carry the links" (per-dataset `collection_url` from any source) vs "the whole catalog" (Ceph-root pre-warm) — and the finding that the architecture is fundamentally carry-the-links; the pre-warm is a thin, swappable convenience.
- **A per-surface reliance map** — MCP `query` (none), `get_stac_details`/`get_collection` (inline-first, fallback only), `browse_stac_catalog`/`catalog://` (full), startup (soft since #262), geo-agent CDN lib (~none for its own data).
- **The key operational insight** (not in any issue): a geo-agent app's data source is *its own config*, not the server's `STAC_CATALOG_URL` — layers are fetched client-side — so the server-side fallback doesn't cover app layer fetches. App resilience means repointing the app's config (or routing its fetches through MCP).
- **Swap / mix / match playbook** and the two chokepoints (query secrets, href rewrite) that point to #264, plus the catalog-of-catalogs limit that points to #263.

Docs-only; no code or runtime change.