### PR TITLE
feat(#264): anonymous bring-your-own-bucket for query

### DIFF
--- a/server.py
+++ b/server.py
@@ -126,14 +126,26 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
                 conn.sql(stmt)
             except Exception as e:
                 print(f"⚠️ Setup statement skipped: {stmt!r}: {e}", file=sys.stderr)
-        if s3_key and s3_secret:
+        # Bring-your-own-bucket. Two symmetric cases, both routed through one
+        # per-request `client_s3` secret:
+        #   - credentialed: both s3_key and s3_secret given (private data).
+        #   - anonymous:    only s3_endpoint given, no creds (a public mirror,
+        #     e.g. MinIO/source.coop during a Ceph outage — #264). We key off
+        #     s3_endpoint here because an anonymous bucket has no other signal.
+        # Pass s3_scope (e.g. 's3://public-') so this secret wins for those paths
+        # over the default `s3` secret; without a scope, routing between two
+        # unscoped secrets is ambiguous.
+        credentialed = bool(s3_key and s3_secret)
+        if credentialed or s3_endpoint:
             endpoint = s3_endpoint or "s3-west.nrp-nautilus.io"
+            key = s3_key if credentialed else ""
+            secret = s3_secret if credentialed else ""
             use_ssl = "false" if endpoint.startswith("rook") else "true"
             scope_clause = f", SCOPE '{s3_scope}'" if s3_scope else ""
-            # Credentials injected here; intentionally not logged
+            # Credentials (if any) injected here; intentionally not logged.
             conn.sql(
                 f"CREATE OR REPLACE SECRET client_s3 ("
-                f"TYPE S3, KEY_ID '{s3_key}', SECRET '{s3_secret}', "
+                f"TYPE S3, KEY_ID '{key}', SECRET '{secret}', "
                 f"ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL '{use_ssl}'"
                 f"{scope_clause})"
             )
@@ -255,8 +267,9 @@ BEFORE writing any SQL:
 3. Use ONLY paths returned by those tools — never guess or hardcode any S3 URLs.
 
 For private data, pass s3_key, s3_secret, and optionally s3_endpoint and s3_scope alongside the SQL query.
-Use s3_scope (e.g. 's3://private-wyoming') when the query mixes private and public S3 paths so DuckDB routes each to the correct endpoint.
-Credentials are scoped to this request only and never persisted.
+For an anonymous public source (e.g. a read-only mirror), pass s3_endpoint alone (no key/secret) with s3_scope — useful to read a mirror like s3://public-* from a backup endpoint when the primary is unavailable.
+Use s3_scope (e.g. 's3://private-wyoming' or 's3://public-') so DuckDB routes those paths to your endpoint rather than the server default; supply it whenever a query mixes sources.
+Credentials, when given, are scoped to this request only and never persisted.
 
 {TOOL_INJECTED_CONTEXT}
 """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -273,6 +273,43 @@ class TestS3Credentials:
         assert "MY_SECRET_VALUE" not in captured.err
 
 
+class TestAnonymousBYOBucket:
+    """Anonymous bring-your-own-bucket: s3_endpoint with no credentials, symmetric
+    with the credentialed path — routes reads to an anonymous public mirror (#264)."""
+
+    def test_anon_endpoint_creates_secret(self):
+        """s3_endpoint alone (no creds) creates the client_s3 secret."""
+        with get_isolated_db(s3_endpoint="minio.example.org") as conn:
+            names = [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+            assert "client_s3" in names
+
+    def test_anon_scope_routes_only_scoped_paths(self):
+        """A scoped anonymous secret wins for its prefix; other paths keep the default."""
+        with get_isolated_db(s3_endpoint="minio.example.org", s3_scope="s3://public-") as conn:
+            def which(p):
+                return conn.sql(f"SELECT name FROM which_secret('{p}', 's3')").fetchone()[0]
+            assert which("s3://public-carbon/x.parquet") == "client_s3"
+            assert which("s3://private-foo/x.parquet") == "s3"
+
+    def test_query_with_anon_endpoint_succeeds(self):
+        """query accepts an anonymous endpoint (no creds) without error."""
+        result = query("SELECT 7 as n", s3_endpoint="minio.example.org", s3_scope="s3://public-")
+        assert "7" in result
+
+    def test_endpoint_with_partial_creds_is_anonymous(self):
+        """s3_endpoint + only a key (no secret) still creates a secret (treated anonymous),
+        rather than injecting a half-credential or erroring."""
+        with get_isolated_db(s3_endpoint="minio.example.org", s3_key="ONLY_KEY") as conn:
+            names = [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+            assert "client_s3" in names
+
+    def test_no_endpoint_no_creds_still_no_secret(self):
+        """The anonymous path must not fire without an endpoint (no accidental secret)."""
+        with get_isolated_db() as conn:
+            names = [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+            assert "client_s3" not in names
+
+
 class TestTileRouteMounted:
     def test_tile_route_exists_in_starlette_app(self):
         """After importing server, the streamable_http_app should have a /tiles route."""


### PR DESCRIPTION
Closes #264.

Makes anonymous **bring-your-own-bucket** symmetric with the existing credentialed path, so a client can route the `query` (SQL-over-parquet) path to any anonymous public mirror (MinIO, source.coop, future backups) with **no per-source server code** — no source registry, no host-specific href rewrite, no bespoke per-mirror secret.

## The gap

`get_isolated_db` only created the per-request `client_s3` secret when **both** `s3_key` and `s3_secret` were non-empty, so `s3_endpoint` was ignored for anonymous (empty-cred) sources. You could bring your own *credentialed* bucket but not your own *anonymous* one — which is why every anonymous mirror so far needed a hardcoded server secret (#261, #266).

## The change

Create `client_s3` when `s3_endpoint` is given **or** both creds are present; use empty `KEY_ID`/`SECRET` in the anonymous case. A client then reads a mirror by passing `s3_endpoint=minio.carlboettiger.info` + `s3_scope='s3://public-'` and `s3://public-*` paths — DuckDB routes those to the mirror while everything else keeps the default (Ceph) secret.

- Credentialed path unchanged.
- Partial creds (only key or only secret) + an endpoint are treated as **anonymous** rather than injecting a half-credential.
- No endpoint and no creds stays a no-op.
- `query` docstring now documents the anonymous case.

## Why this (and not a server-side registry / per-source secret)

Per the catalog-sourcing analysis (`docs/architecture/catalog-sourcing.md`): app-layer resilience (collection JSON, PMTiles, COG-via-titiler) is entirely client-side and already handled by pointing apps at a self-consistent mirror. The **only** server-touching gap for multi-source was this anonymous-endpoint asymmetry in `query`. Fixing it once is the durable, generic answer; it subsumes #266 (which becomes an optional outage ops lever, not a requirement).

## Verification

- Full suite: 295 passing (incl. 5 new anon-BYO tests + existing credential/isolation tests).
- Live against MinIO during the Ceph outage: scoped anonymous secret routes `s3://public-*` to `minio.carlboettiger.info` and reads `public-carbon` hex — 4,842,432,842 rows, ~1s. Non-scoped paths still resolve to the default secret.

## Scope notes

- Read-only/anonymous mirrors; write paths (`register_hex_tiles` output, caches) still target a writable bucket.
- Keeps `URL_STYLE 'path'` and the rook→no-SSL heuristic; a future `s3_url_style`/`s3_use_ssl` param could generalize further if a non-path-style anonymous source appears.