### PR TITLE
feat(#268): env-configurable default S3 endpoint (S3_DEFAULT_ENDPOINT)

### DIFF
--- a/query-setup.md
+++ b/query-setup.md
@@ -10,9 +10,12 @@ SET temp_directory='/tmp';
 LOAD httpfs;
 LOAD h3;
 LOAD spatial;
-CREATE OR REPLACE SECRET s3 (TYPE S3, ENDPOINT 'rook-ceph-rgw-nautiluss3.rook', URL_STYLE 'path', USE_SSL 'false', KEY_ID '', SECRET '');
 CREATE OR REPLACE SECRET source_coop (TYPE S3, SCOPE 's3://us-west-2.opendata.source.coop', REGION 'us-west-2', ENDPOINT 's3.us-west-2.amazonaws.com', URL_STYLE 'path', USE_SSL 'true', KEY_ID '', SECRET '');
 ```
+
+The default `s3` secret (for `s3://public-*` and other paths) is created by the
+server per request, with its endpoint set by the deployment (`S3_DEFAULT_ENDPOINT`,
+default the NRP Ceph internal endpoint). Do not create or override it in query SQL.
 
 **Why these settings?**
 
@@ -24,6 +27,6 @@ CREATE OR REPLACE SECRET source_coop (TYPE S3, SCOPE 's3://us-west-2.opendata.so
 - `spatial` - Required for `ST_*` functions (line-data exact mileage, GeoParquet inspection)
 - `source_coop` secret - Anonymous, prefix-scoped fallback for the public source.coop mirror. DuckDB routes `s3://us-west-2.opendata.source.coop/...` paths to it automatically; `s3://public-*` paths still go to Ceph. Use mirror paths (returned by the STAC tools as `s3://us-west-2.opendata.source.coop/cboettig/<dataset>/...`) when the primary Ceph endpoint is unavailable.
 
-**Note:** `rook-ceph-rgw-nautiluss3.rook` is an internal endpoint that only your tool running on k8s can access. The publicly accessible external endpoint is `s3-west.nrp-nautilus.io`, which requires `USE_SSL true` and `SET THREADS=2`. Always use the internal endpoint to run queries.
+**Note:** On the default NRP deployment, the server's `s3` secret points at the internal endpoint `rook-ceph-rgw-nautiluss3.rook` (only reachable from inside the k8s cluster; the public external endpoint is `s3-west.nrp-nautilus.io`, which needs `USE_SSL true` and `SET THREADS=2`). A deployment can repoint this default at another backend (e.g. a MinIO mirror) via `S3_DEFAULT_ENDPOINT` without any query changes.
 
 You must read parquet datasets with from S3 using read_parquet().  There are no local tables.

--- a/server.py
+++ b/server.py
@@ -126,6 +126,26 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
                 conn.sql(stmt)
             except Exception as e:
                 print(f"⚠️ Setup statement skipped: {stmt!r}: {e}", file=sys.stderr)
+        # Default S3 endpoint — server-owned and per-deployment configurable (#268).
+        # Lets you deploy this codebase as a data-access head pointed at any storage
+        # (Ceph / MinIO / source.coop) purely via env, no code change. Unset =
+        # the NRP Ceph internal endpoint (back-compat). USE_SSL is inferred from the
+        # endpoint (rook = in-cluster http) unless S3_DEFAULT_USE_SSL overrides it.
+        default_endpoint = os.environ.get("S3_DEFAULT_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+        default_url_style = os.environ.get("S3_DEFAULT_URL_STYLE", "path")
+        default_use_ssl = (
+            os.environ.get("S3_DEFAULT_USE_SSL")
+            or ("false" if default_endpoint.startswith("rook") else "true")
+        ).strip().lower()
+        try:
+            conn.sql(
+                f"CREATE OR REPLACE SECRET s3 ("
+                f"TYPE S3, KEY_ID '', SECRET '', "
+                f"ENDPOINT '{default_endpoint}', URL_STYLE '{default_url_style}', "
+                f"USE_SSL '{default_use_ssl}')"
+            )
+        except Exception as e:
+            print(f"⚠️ Default S3 secret setup skipped: {e}", file=sys.stderr)
         # Bring-your-own-bucket. Two symmetric cases, both routed through one
         # per-request `client_s3` secret:
         #   - credentialed: both s3_key and s3_secret given (private data).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -310,6 +310,42 @@ class TestAnonymousBYOBucket:
             assert "client_s3" not in names
 
 
+class TestDefaultEndpoint:
+    """S3_DEFAULT_ENDPOINT: per-deployment default storage endpoint, server-owned (#268).
+    Lets the codebase be deployed as a data-access head pointed at any backend via env."""
+
+    def _s3_secret_string(self, conn):
+        row = conn.sql("SELECT secret_string FROM duckdb_secrets() WHERE name='s3'").fetchone()
+        return row[0] if row else ""
+
+    def test_default_falls_back_to_rook(self, monkeypatch):
+        monkeypatch.delenv("S3_DEFAULT_ENDPOINT", raising=False)
+        monkeypatch.delenv("S3_DEFAULT_USE_SSL", raising=False)
+        with get_isolated_db() as conn:
+            s = self._s3_secret_string(conn)
+            assert "rook-ceph-rgw-nautiluss3.rook" in s
+            assert "use_ssl=false" in s  # inferred: rook = in-cluster http
+
+    def test_default_endpoint_from_env(self, monkeypatch):
+        monkeypatch.setenv("S3_DEFAULT_ENDPOINT", "minio.example.org")
+        monkeypatch.delenv("S3_DEFAULT_USE_SSL", raising=False)
+        with get_isolated_db() as conn:
+            s = self._s3_secret_string(conn)
+            assert "minio.example.org" in s
+            assert "use_ssl=true" in s  # inferred: non-rook = https
+
+    def test_default_use_ssl_override(self, monkeypatch):
+        monkeypatch.setenv("S3_DEFAULT_ENDPOINT", "minio.example.org")
+        monkeypatch.setenv("S3_DEFAULT_USE_SSL", "false")
+        with get_isolated_db() as conn:
+            assert "use_ssl=false" in self._s3_secret_string(conn)
+
+    def test_query_still_works_with_default_endpoint(self, monkeypatch):
+        """A deployment-configured default endpoint doesn't break normal queries."""
+        monkeypatch.setenv("S3_DEFAULT_ENDPOINT", "minio.example.org")
+        assert "5" in query("SELECT 5 as n")
+
+
 class TestTileRouteMounted:
     def test_tile_route_exists_in_starlette_app(self):
         """After importing server, the streamable_http_app should have a /tiles route."""


### PR DESCRIPTION
Closes #268.

Makes the default `s3` secret **server-owned and per-deployment configurable**, so this codebase can be deployed as a data-access head pointed at any storage backend (Ceph / MinIO / source.coop) **purely via env — no code change per source**. This is the enabler for the co-located cirrus MinIO head and for collaborators self-hosting their own copies.

## Change

- **`server.py`** — build the default `s3` secret in `get_isolated_db` from env:
  - `S3_DEFAULT_ENDPOINT` (default `rook-ceph-rgw-nautiluss3.rook` — back-compat)
  - `S3_DEFAULT_URL_STYLE` (default `path`)
  - `S3_DEFAULT_USE_SSL` (inferred from endpoint — rook=`false`/http, else `true`/https — overridable)
- **`query-setup.md`** — drop the hardcoded rook `s3` secret. It was executed server-side (not shown to the model — `TOOL_INJECTED_CONTEXT` embeds the optimization/H3 guides, not the setup SQL), so the env-driven secret is now the single source of truth. The scoped `source_coop` secret stays; the note is updated.

## Why (vs a per-source secret / registry)

Per `docs/architecture/catalog-sourcing.md`: app-layer resilience is client-side; the only server-touching gap for multi-source was endpoint routing on the `query` path. #264 covered the **per-request** client choice; this covers the **per-deployment default**. Together they retire the per-source-secret treadmill (#261/#266 become optional conveniences).

## Deploy examples

- **Cirrus co-located MinIO head:** `S3_DEFAULT_ENDPOINT=<local minio>` + `STAC_CATALOG_URL=<minio catalog>`. Apps point `mcp_url` here → `s3://public-*` transparently served from local NVMe-backed MinIO, no per-query args.
- **Collaborator self-host:** same image, their `S3_DEFAULT_ENDPOINT` + `STAC_CATALOG_URL`.
- **Default NRP:** unset → unchanged (Ceph internal).

## Verification

- Unset → `rook`/`use_ssl=false`; `S3_DEFAULT_ENDPOINT=minio.carlboettiger.info` → `minio`/`use_ssl=true`; a plain `s3://public-carbon/...` read with **no client args** resolves to MinIO (40,353,607 rows).
- Full suite **299 passing** (4 new default-endpoint tests + existing).

## Notes

- Read/anonymous default; credentialed/private and per-request anonymous BYO-bucket still go through the `client_s3` path (#264), which takes precedence via scope.
- `S3_DEFAULT_USE_SSL`/`S3_DEFAULT_URL_STYLE` cover non-path-style or http mirrors if one appears.