### PR TITLE
fix(#271): unscoped client_s3 disables the default s3 secret — deterministic endpoint routing

### DIFF
--- a/server.py
+++ b/server.py
@@ -117,6 +117,17 @@ TOOL_INJECTED_CONTEXT = f"""
 # -------------------------------------------------------------------------
 # 4. ISOLATION ENGINE
 # -------------------------------------------------------------------------
+def _sql_quote(value: str) -> str:
+    """Escape a value for embedding in a single-quoted SQL string literal.
+
+    Client-supplied secret parameters are interpolated into CREATE SECRET
+    statements; a stray quote would otherwise break the statement — and the
+    resulting parser error can echo the statement (credentials included) back
+    in the tool's "SQL Error" response (#271).
+    """
+    return (value or "").replace("'", "''")
+
+
 @contextmanager
 def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None):
     conn = duckdb.connect(database=":memory:")
@@ -126,49 +137,57 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
                 conn.sql(stmt)
             except Exception as e:
                 print(f"⚠️ Setup statement skipped: {stmt!r}: {e}", file=sys.stderr)
-        # Default S3 endpoint — server-owned and per-deployment configurable (#268).
-        # Lets you deploy this codebase as a data-access head pointed at any storage
-        # (Ceph / MinIO / source.coop) purely via env, no code change. Unset =
-        # the NRP Ceph internal endpoint (back-compat). USE_SSL is inferred from the
-        # endpoint (rook = in-cluster http) unless S3_DEFAULT_USE_SSL overrides it.
-        default_endpoint = os.environ.get("S3_DEFAULT_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
-        default_url_style = os.environ.get("S3_DEFAULT_URL_STYLE", "path")
-        default_use_ssl = (
-            os.environ.get("S3_DEFAULT_USE_SSL")
-            or ("false" if default_endpoint.startswith("rook") else "true")
-        ).strip().lower()
-        try:
-            conn.sql(
-                f"CREATE OR REPLACE SECRET s3 ("
-                f"TYPE S3, KEY_ID '', SECRET '', "
-                f"ENDPOINT '{default_endpoint}', URL_STYLE '{default_url_style}', "
-                f"USE_SSL '{default_use_ssl}')"
-            )
-        except Exception as e:
-            print(f"⚠️ Default S3 secret setup skipped: {e}", file=sys.stderr)
         # Bring-your-own-bucket. Two symmetric cases, both routed through one
         # per-request `client_s3` secret:
         #   - credentialed: both s3_key and s3_secret given (private data).
         #   - anonymous:    only s3_endpoint given, no creds (a public mirror,
         #     e.g. MinIO/source.coop during a Ceph outage — #264). We key off
         #     s3_endpoint here because an anonymous bucket has no other signal.
-        # Pass s3_scope (e.g. 's3://public-') so this secret wins for those paths
-        # over the default `s3` secret; without a scope, routing between two
-        # unscoped secrets is ambiguous.
+        # Pass s3_scope (e.g. 's3://public-') so this secret applies only to those
+        # paths and everything else keeps the deployment default below.
         credentialed = bool(s3_key and s3_secret)
-        if credentialed or s3_endpoint:
+        has_client = credentialed or bool(s3_endpoint)
+        if has_client:
             endpoint = s3_endpoint or "s3-west.nrp-nautilus.io"
             key = s3_key if credentialed else ""
             secret = s3_secret if credentialed else ""
             use_ssl = "false" if endpoint.startswith("rook") else "true"
-            scope_clause = f", SCOPE '{s3_scope}'" if s3_scope else ""
+            scope_clause = f", SCOPE '{_sql_quote(s3_scope)}'" if s3_scope else ""
             # Credentials (if any) injected here; intentionally not logged.
             conn.sql(
                 f"CREATE OR REPLACE SECRET client_s3 ("
-                f"TYPE S3, KEY_ID '{key}', SECRET '{secret}', "
-                f"ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL '{use_ssl}'"
+                f"TYPE S3, KEY_ID '{_sql_quote(key)}', SECRET '{_sql_quote(secret)}', "
+                f"ENDPOINT '{_sql_quote(endpoint)}', URL_STYLE 'path', USE_SSL '{use_ssl}'"
                 f"{scope_clause})"
             )
+        # Default S3 endpoint — server-owned and per-deployment configurable (#268).
+        # Lets you deploy this codebase as a data-access head pointed at any storage
+        # (Ceph / MinIO / source.coop) purely via env, no code change. Unset =
+        # the NRP Ceph internal endpoint (back-compat). USE_SSL is inferred from the
+        # endpoint (rook = in-cluster http) unless S3_DEFAULT_USE_SSL overrides it.
+        #
+        # Skipped when client_s3 exists UNSCOPED: DuckDB's pick between two unscoped
+        # secrets is an undocumented tie-break (empirically client_s3 captured every
+        # path on duckdb 1.5.4, regardless of creation order — #271). Rather than
+        # depend on that, make the de-facto semantic explicit and deterministic:
+        # without s3_scope, the client's endpoint/creds own ALL s3:// paths for this
+        # request; with s3_scope, the default serves everything outside the scope.
+        if not (has_client and not s3_scope):
+            default_endpoint = os.environ.get("S3_DEFAULT_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+            default_url_style = os.environ.get("S3_DEFAULT_URL_STYLE", "path")
+            default_use_ssl = (
+                os.environ.get("S3_DEFAULT_USE_SSL")
+                or ("false" if default_endpoint.startswith("rook") else "true")
+            ).strip().lower()
+            try:
+                conn.sql(
+                    f"CREATE OR REPLACE SECRET s3 ("
+                    f"TYPE S3, KEY_ID '', SECRET '', "
+                    f"ENDPOINT '{default_endpoint}', URL_STYLE '{default_url_style}', "
+                    f"USE_SSL '{default_use_ssl}')"
+                )
+            except Exception as e:
+                print(f"⚠️ Default S3 secret setup skipped: {e}", file=sys.stderr)
         yield conn
     finally:
         conn.close()
@@ -289,6 +308,7 @@ BEFORE writing any SQL:
 For private data, pass s3_key, s3_secret, and optionally s3_endpoint and s3_scope alongside the SQL query.
 For an anonymous public source (e.g. a read-only mirror), pass s3_endpoint alone (no key/secret) with s3_scope — useful to read a mirror like s3://public-* from a backup endpoint when the primary is unavailable.
 Use s3_scope (e.g. 's3://private-wyoming' or 's3://public-') so DuckDB routes those paths to your endpoint rather than the server default; supply it whenever a query mixes sources.
+WITHOUT s3_scope, your endpoint/credentials apply to EVERY s3:// path in the query and the server-default endpoint is disabled for this request — fine for a query touching only your bucket, wrong for a query mixing your bucket with catalog data. When mixing, always pass s3_scope.
 Credentials, when given, are scoped to this request only and never persisted.
 
 {TOOL_INJECTED_CONTEXT}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -310,6 +310,67 @@ class TestAnonymousBYOBucket:
             assert "client_s3" not in names
 
 
+class TestUnscopedClientRouting:
+    """Two unscoped S3 secrets must never coexist (#271). DuckDB's pick between
+    them is an undocumented tie-break (empirically client_s3 captured EVERY path
+    on duckdb 1.5.4, regardless of creation order), so the server makes that
+    de-facto semantic explicit: an unscoped client_s3 disables the default `s3`
+    secret for the request; a scoped one coexists with it."""
+
+    def _names(self, conn):
+        return [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+
+    def _which(self, conn, path):
+        return conn.sql(f"SELECT name FROM which_secret('{path}', 's3')").fetchone()[0]
+
+    def test_unscoped_creds_disable_default_secret(self):
+        with get_isolated_db(s3_key="K", s3_secret="S") as conn:
+            names = self._names(conn)
+            assert "client_s3" in names
+            assert "s3" not in names
+
+    def test_unscoped_anon_endpoint_disables_default_secret(self):
+        with get_isolated_db(s3_endpoint="minio.example.org") as conn:
+            names = self._names(conn)
+            assert "client_s3" in names
+            assert "s3" not in names
+
+    def test_unscoped_client_routes_all_paths(self):
+        """Deterministically, not via tie-break: the client owns every path."""
+        with get_isolated_db(s3_endpoint="minio.example.org") as conn:
+            assert self._which(conn, "s3://public-data/x.parquet") == "client_s3"
+            assert self._which(conn, "s3://anything-else/y.parquet") == "client_s3"
+
+    def test_scoped_client_keeps_default_secret(self):
+        with get_isolated_db(s3_endpoint="minio.example.org", s3_scope="s3://public-") as conn:
+            names = self._names(conn)
+            assert "client_s3" in names
+            assert "s3" in names
+
+    def test_no_client_keeps_default_secret(self):
+        with get_isolated_db() as conn:
+            assert "s3" in self._names(conn)
+
+    def test_scoped_source_coop_survives_unscoped_client(self):
+        """The prefix-scoped source_coop secret (SETUP_SQL) still wins its own
+        paths over an unscoped client_s3 — longest-scope match beats unscoped."""
+        with get_isolated_db(s3_key="K", s3_secret="S") as conn:
+            assert (
+                self._which(conn, "s3://us-west-2.opendata.source.coop/a.parquet")
+                == "source_coop"
+            )
+
+    def test_quote_in_credentials_does_not_break_secret_sql(self):
+        """A quote in a client-supplied value must not break out of the SQL
+        string literal (or echo the statement back in a parser error)."""
+        with get_isolated_db(s3_key="K'--", s3_secret="S'x") as conn:
+            assert "client_s3" in self._names(conn)
+
+    def test_quote_in_scope_does_not_break_secret_sql(self):
+        with get_isolated_db(s3_endpoint="minio.example.org", s3_scope="s3://pub'lic-") as conn:
+            assert "client_s3" in self._names(conn)
+
+
 class TestDefaultEndpoint:
     """S3_DEFAULT_ENDPOINT: per-deployment default storage endpoint, server-owned (#268).
     Lets the codebase be deployed as a data-access head pointed at any backend via env."""


### PR DESCRIPTION
Part of #271 (Finding 1 — the one active misrouting bug). First of a short PR series; the tiles/default-endpoint unification (Finding 2) follows stacked on this branch, and the #264 registry (Findings 3–5) comes separately after.

## Problem

`get_isolated_db` could create **two unscoped S3 secrets**: the deployment default `s3` and the per-request `client_s3` (when the caller passes creds/endpoint without `s3_scope`). The code comment called routing between them "ambiguous"; empirically (DuckDB 1.5.4, `FROM which_secret(...)`) it is worse — a **deterministic total capture**: `client_s3` wins for *every* path, regardless of creation order, via an undocumented tie-break. So a query mixing a client bucket with server-default paths, without a scope, silently reroutes the default paths to the client endpoint — breaking them outright whenever that endpoint isn't Ceph — and the behavior could flip under any DuckDB upgrade.

## Change

- **Never create two unscoped secrets.** When `client_s3` is created *without* `s3_scope`, the default `s3` secret is skipped for that request. This makes the current de-facto semantic explicit, deterministic, and DuckDB-version-independent: *no scope → your endpoint/creds own all `s3://` paths; with scope → the default serves everything outside it.* Zero behavior change for today's callers on duckdb 1.5.4; prefix-scoped secrets (e.g. `source_coop`) still win their own paths either way.
- **Docstring truth**: the `query` tool docs now state the no-scope semantics instead of implying mixed queries might work unscoped.
- **Quote-escape client-supplied secret parameters** (`_sql_quote`). Not a security boundary (the caller controls the SQL surface of their isolated connection anyway), but a stray quote previously broke the `CREATE SECRET` statement and the parser error could echo the statement — credentials included — back in the `SQL Error:` response.

## Tests

New `TestUnscopedClientRouting` (8 tests): unscoped creds/anon-endpoint disable the default secret and deterministically route all paths to `client_s3`; scoped client coexists with the default; no-client keeps the default; scoped `source_coop` survives an unscoped client (longest-scope match); quotes in credentials/scope don't break secret SQL. Full suite: 307 passed.

Not changed here (deliberately): the partial-credentials-treated-as-anonymous behavior pinned by #267's tests, and the `use_ssl`/`URL_STYLE`/`REGION` knobs for `client_s3` — both belong to the #264 registry discussion.
