### PR TITLE
feat(#271): single-source default S3 endpoint config; tiles honor S3_DEFAULT_ENDPOINT

### DIFF
--- a/s3config.py
+++ b/s3config.py
@@ -1,0 +1,55 @@
+"""Deployment-level S3 endpoint configuration.
+
+Single source of truth for the default S3 backend (#268/#271): one env surface
+(S3_DEFAULT_ENDPOINT / S3_DEFAULT_URL_STYLE / S3_DEFAULT_USE_SSL) drives both
+DuckDB connection factories — the per-request query engine
+(server.get_isolated_db) and the persistent tile connection
+(tiles.db.build_tile_connection) — so repointing a deployment at another
+backend (MinIO, source.coop, ...) via env covers query AND hex tiles.
+
+Precursor to the data-driven source registry (#264): when routing becomes
+registry-driven, this module is where the registry lives.
+"""
+import os
+
+
+def sql_quote(value: str) -> str:
+    """Escape a value for embedding in a single-quoted SQL string literal.
+
+    Secret parameters are interpolated into CREATE SECRET statements; a stray
+    quote would otherwise break the statement — and the resulting parser error
+    can echo the statement (credentials included) back to the caller (#271).
+    """
+    return (value or "").replace("'", "''")
+
+
+def default_endpoint() -> str:
+    """The deployment's default S3 endpoint (bare host, no scheme).
+
+    Unset = the NRP Ceph internal endpoint (back-compat)."""
+    return os.environ.get("S3_DEFAULT_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+
+
+def infer_use_ssl(endpoint: str) -> str:
+    """In-cluster rook endpoints are plain http; everything else defaults to SSL."""
+    return "false" if endpoint.startswith("rook") else "true"
+
+
+def default_s3_secret_sql(name: str = "s3") -> str:
+    """CREATE SECRET statement for the deployment's default (anonymous) S3 backend.
+
+    Env is read at call time, not import time, so per-request connections pick
+    up changes without a restart and tests can monkeypatch. USE_SSL is inferred
+    from the endpoint unless S3_DEFAULT_USE_SSL overrides it.
+    """
+    endpoint = default_endpoint()
+    url_style = os.environ.get("S3_DEFAULT_URL_STYLE", "path")
+    use_ssl = (
+        os.environ.get("S3_DEFAULT_USE_SSL") or infer_use_ssl(endpoint)
+    ).strip().lower()
+    return (
+        f"CREATE OR REPLACE SECRET {name} ("
+        f"TYPE S3, KEY_ID '', SECRET '', "
+        f"ENDPOINT '{sql_quote(endpoint)}', URL_STYLE '{sql_quote(url_style)}', "
+        f"USE_SSL '{sql_quote(use_ssl)}')"
+    )

--- a/server.py
+++ b/server.py
@@ -117,15 +117,7 @@ TOOL_INJECTED_CONTEXT = f"""
 # -------------------------------------------------------------------------
 # 4. ISOLATION ENGINE
 # -------------------------------------------------------------------------
-def _sql_quote(value: str) -> str:
-    """Escape a value for embedding in a single-quoted SQL string literal.
-
-    Client-supplied secret parameters are interpolated into CREATE SECRET
-    statements; a stray quote would otherwise break the statement — and the
-    resulting parser error can echo the statement (credentials included) back
-    in the tool's "SQL Error" response (#271).
-    """
-    return (value or "").replace("'", "''")
+from s3config import default_s3_secret_sql, infer_use_ssl, sql_quote as _sql_quote
 
 
 @contextmanager
@@ -151,7 +143,7 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
             endpoint = s3_endpoint or "s3-west.nrp-nautilus.io"
             key = s3_key if credentialed else ""
             secret = s3_secret if credentialed else ""
-            use_ssl = "false" if endpoint.startswith("rook") else "true"
+            use_ssl = infer_use_ssl(endpoint)
             scope_clause = f", SCOPE '{_sql_quote(s3_scope)}'" if s3_scope else ""
             # Credentials (if any) injected here; intentionally not logged.
             conn.sql(
@@ -160,11 +152,10 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
                 f"ENDPOINT '{_sql_quote(endpoint)}', URL_STYLE 'path', USE_SSL '{use_ssl}'"
                 f"{scope_clause})"
             )
-        # Default S3 endpoint — server-owned and per-deployment configurable (#268).
-        # Lets you deploy this codebase as a data-access head pointed at any storage
-        # (Ceph / MinIO / source.coop) purely via env, no code change. Unset =
-        # the NRP Ceph internal endpoint (back-compat). USE_SSL is inferred from the
-        # endpoint (rook = in-cluster http) unless S3_DEFAULT_USE_SSL overrides it.
+        # Default S3 endpoint — server-owned and per-deployment configurable (#268),
+        # built by s3config (shared with the tile subsystem). Lets you deploy this
+        # codebase as a data-access head pointed at any storage (Ceph / MinIO /
+        # source.coop) purely via env, no code change.
         #
         # Skipped when client_s3 exists UNSCOPED: DuckDB's pick between two unscoped
         # secrets is an undocumented tie-break (empirically client_s3 captured every
@@ -173,19 +164,8 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
         # without s3_scope, the client's endpoint/creds own ALL s3:// paths for this
         # request; with s3_scope, the default serves everything outside the scope.
         if not (has_client and not s3_scope):
-            default_endpoint = os.environ.get("S3_DEFAULT_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
-            default_url_style = os.environ.get("S3_DEFAULT_URL_STYLE", "path")
-            default_use_ssl = (
-                os.environ.get("S3_DEFAULT_USE_SSL")
-                or ("false" if default_endpoint.startswith("rook") else "true")
-            ).strip().lower()
             try:
-                conn.sql(
-                    f"CREATE OR REPLACE SECRET s3 ("
-                    f"TYPE S3, KEY_ID '', SECRET '', "
-                    f"ENDPOINT '{default_endpoint}', URL_STYLE '{default_url_style}', "
-                    f"USE_SSL '{default_use_ssl}')"
-                )
+                conn.sql(default_s3_secret_sql())
             except Exception as e:
                 print(f"⚠️ Default S3 secret setup skipped: {e}", file=sys.stderr)
         yield conn

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -558,6 +558,36 @@ class TestBuildTileConnection:
         finally:
             con.close()
 
+    def _s3_secret_string(self, con):
+        row = con.sql("SELECT secret_string FROM duckdb_secrets() WHERE name='s3'").fetchone()
+        return row[0] if row else ""
+
+    def test_default_endpoint_falls_back_to_rook(self, monkeypatch):
+        """Unset env keeps the NRP Ceph internal endpoint (back-compat)."""
+        monkeypatch.delenv("S3_DEFAULT_ENDPOINT", raising=False)
+        monkeypatch.delenv("S3_DEFAULT_USE_SSL", raising=False)
+        con = build_tile_connection()
+        try:
+            s = self._s3_secret_string(con)
+            assert "rook-ceph-rgw-nautiluss3.rook" in s
+            assert "use_ssl=false" in s
+        finally:
+            con.close()
+
+    def test_honors_s3_default_endpoint_env(self, monkeypatch):
+        """The tile connection uses the same deployment default as the query
+        tool (#268/#271) — previously hardcoded to rook, so a deployment
+        repointed via S3_DEFAULT_ENDPOINT broke hex tile reads and writes."""
+        monkeypatch.setenv("S3_DEFAULT_ENDPOINT", "minio.example.org")
+        monkeypatch.delenv("S3_DEFAULT_USE_SSL", raising=False)
+        con = build_tile_connection()
+        try:
+            s = self._s3_secret_string(con)
+            assert "minio.example.org" in s
+            assert "use_ssl=true" in s  # inferred: non-rook = https
+        finally:
+            con.close()
+
 
 class TestPyramidMathCorrectness:
     """Assert mathematical invariants on built pyramids — independent of

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -8,6 +8,8 @@ import os
 
 import duckdb
 
+from s3config import default_s3_secret_sql
+
 
 def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnection:
     """Create a :memory: connection with extensions loaded and S3 configured.
@@ -53,10 +55,9 @@ def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnecti
     # re-measure at 1-file/h0 (see benchmarks/s3-throughput-bench.py); drop if neutral.
     con.sql("SET prefetch_all_parquet_files=true")
 
-    # S3 access: use the cluster-internal Ceph endpoint (same as query tool).
-    con.sql(
-        "CREATE OR REPLACE SECRET s3 ("
-        "TYPE S3, ENDPOINT 'rook-ceph-rgw-nautiluss3.rook', "
-        "URL_STYLE 'path', USE_SSL 'false', KEY_ID '', SECRET '')"
-    )
+    # S3 access: the deployment default endpoint (S3_DEFAULT_ENDPOINT, same env
+    # surface as the query tool — #268/#271). Previously hardcoded to the
+    # cluster-internal Ceph endpoint, which broke hex tiles (source reads AND
+    # s3://public-output writes) on any deployment repointed via env.
+    con.sql(default_s3_secret_sql())
     return con


### PR DESCRIPTION
Part of #271 (Finding 2, tiles gap). **Stacked on #273** — based on `fix/271-unscoped-client-secret` so the diff shows only this change; retarget/rebase to `main` once #273 merges.

## Problem

#268 introduced `S3_DEFAULT_ENDPOINT` with the goal "deploy this codebase as a data-access head pointed at any storage purely via env" — but only the query path consumed it. `tiles/db.py` kept a hardcoded `rook-ceph-rgw-nautiluss3.rook` secret, so on a deployment repointed via env, `query` works while `register_hex_tiles` breaks on both its source reads and its `s3://public-output` writes (`TILE_BUCKET_BASE` rides the tile connection). This was one of the four hand-synced endpoint-config sites cataloged in #271.

## Change

New `s3config.py` — the single place the deployment default S3 backend is resolved (`S3_DEFAULT_ENDPOINT` / `S3_DEFAULT_URL_STYLE` / `S3_DEFAULT_USE_SSL`, env read at call time) — consumed by both DuckDB connection factories:

- `server.get_isolated_db` builds its default `s3` secret via `default_s3_secret_sql()` (behavior unchanged; the env logic just moved).
- `tiles.db.build_tile_connection` now uses the same statement instead of the hardcoded rook secret. **No-op on the NRP deployment** (default is still rook); only env-repointed deployments change, and they change from broken to working.
- The `use_ssl` rook-inference heuristic now exists once (`infer_use_ssl`) instead of twice.

This module is also the intended home for the #264 source registry, which will subsume the remaining two config sites (`_href_to_s3` rewrite table, `_TimeoutStacIO` metadata rewrite in `stac.py`).

## Tests

`TestBuildTileConnection` gains rook-fallback and env-override tests mirroring `TestDefaultEndpoint` on the server side. Full suite: 309 passed.
