### PR TITLE
feat(#264): data-driven source registry for S3 endpoint routing

### DIFF
--- a/docs/architecture/catalog-sourcing.md
+++ b/docs/architecture/catalog-sourcing.md
@@ -58,14 +58,19 @@ Therefore:
   case is handled per-collection; a minio backup can provide a real root.
 - **Mix sources.** Natural *at the link level* — each dataset carries its own
   `collection_url` from any host, and MCP `get_stac_details` renders whatever
-  inline STAC it's given. Two chokepoints trip up *novel* sources (tracked in
-  [#264](https://github.com/boettiger-lab/mcp-data-server/issues/264)):
-  1. **Query endpoint secrets** — `query()` routes `s3://` paths to DuckDB
-     secrets, and only `s3` (Ceph) + `source_coop` (mirror) are wired. A new
-     source needs its own secret or per-call `s3_endpoint`/creds.
-  2. **href → `s3://` rewriting** — `_href_to_s3` only special-cases `s3-west`
-     and `data.source.coop`; other hosts pass through as HTTPS, which DuckDB
-     can't glob.
+  inline STAC it's given. The two chokepoints that tripped up *novel* sources
+  ([#264](https://github.com/boettiger-lab/mcp-data-server/issues/264)) are now
+  handled by the **source registry** (`s3config.py`, extensible per deployment
+  via `S3_SOURCES`):
+  1. **Query endpoint secrets** — every registry source with a `secret` entry
+     gets a prefix-scoped DuckDB secret on every connection (query *and* tiles);
+     unregistered sources are reachable per-request via `s3_endpoint`/`s3_scope`
+     (+ creds if private).
+  2. **href → `s3://` rewriting** — registry-driven prefix rewrites (built-ins:
+     `s3-west`, `data.source.coop`). Hosts outside the registry still pass
+     through as HTTPS, but the STAC tools now surface a derived routing hint
+     alongside them (the s3:// form + the `s3_endpoint`/`s3_scope` to pass to
+     `query`), so carry-the-links works without pre-configuration.
   Composition by **linking whole catalogs** (catalog-of-catalogs) is separately
   blocked by the catalog-walk limits in
   [#263](https://github.com/boettiger-lab/mcp-data-server/issues/263); composition
@@ -84,9 +89,11 @@ is already addressed.
 ## Design north star
 
 Lean into "carry the links" as the primary contract; keep the whole-catalog a
-thin, swappable discovery/default. Make arbitrary mix/match clean by replacing
-host-string special-casing with **data-driven routing** — a source registry that
-drives both the query secrets and the href rewrite (#264) — and, if
-catalog-of-catalogs composition is ever wanted, a recursive type-agnostic walk
-(#263). The fully STAC-native end state carries endpoint/routing on the asset
-(storage extension) rather than in server-side tables.
+thin, swappable discovery/default. Data-driven routing shipped with #264: the
+`s3config.py` source registry drives the query/tile secrets, the href rewrite,
+and the STAC-metadata reroute, with per-request hints covering unregistered
+hosts. Remaining: a recursive type-agnostic walk if catalog-of-catalogs
+composition is ever wanted (#263), and a structured `s3_sources` query parameter
+for multi-endpoint bring-your-own requests. The fully STAC-native end state
+carries endpoint/routing on the asset (storage extension) rather than in
+server-side tables.

--- a/query-setup.md
+++ b/query-setup.md
@@ -10,12 +10,14 @@ SET temp_directory='/tmp';
 LOAD httpfs;
 LOAD h3;
 LOAD spatial;
-CREATE OR REPLACE SECRET source_coop (TYPE S3, SCOPE 's3://us-west-2.opendata.source.coop', REGION 'us-west-2', ENDPOINT 's3.us-west-2.amazonaws.com', URL_STYLE 'path', USE_SSL 'true', KEY_ID '', SECRET '');
 ```
 
-The default `s3` secret (for `s3://public-*` and other paths) is created by the
-server per request, with its endpoint set by the deployment (`S3_DEFAULT_ENDPOINT`,
-default the NRP Ceph internal endpoint). Do not create or override it in query SQL.
+S3 secrets are created by the server per connection, not in query SQL — do not
+create or override them here. The default `s3` secret (for `s3://public-*` and
+other paths) takes its endpoint from the deployment (`S3_DEFAULT_ENDPOINT`,
+default the NRP Ceph internal endpoint); prefix-scoped secrets for every other
+known source (e.g. the anonymous `source_coop` mirror) come from the source
+registry (`s3config.py`, extensible per deployment via `S3_SOURCES`).
 
 **Why these settings?**
 
@@ -25,7 +27,13 @@ default the NRP Ceph internal endpoint). Do not create or override it in query S
 - `httpfs` - Required for S3 access
 - `h3` - Required for H3 functions
 - `spatial` - Required for `ST_*` functions (line-data exact mileage, GeoParquet inspection)
-- `source_coop` secret - Anonymous, prefix-scoped fallback for the public source.coop mirror. DuckDB routes `s3://us-west-2.opendata.source.coop/...` paths to it automatically; `s3://public-*` paths still go to Ceph. Use mirror paths (returned by the STAC tools as `s3://us-west-2.opendata.source.coop/cboettig/<dataset>/...`) when the primary Ceph endpoint is unavailable.
+
+The registry-created `source_coop` secret is the anonymous, prefix-scoped
+fallback for the public source.coop mirror: DuckDB routes
+`s3://us-west-2.opendata.source.coop/...` paths to it automatically, while
+`s3://public-*` paths still go to Ceph. Use mirror paths (returned by the STAC
+tools as `s3://us-west-2.opendata.source.coop/cboettig/<dataset>/...`) when the
+primary Ceph endpoint is unavailable.
 
 **Note:** On the default NRP deployment, the server's `s3` secret points at the internal endpoint `rook-ceph-rgw-nautiluss3.rook` (only reachable from inside the k8s cluster; the public external endpoint is `s3-west.nrp-nautilus.io`, which needs `USE_SSL true` and `SET THREADS=2`). A deployment can repoint this default at another backend (e.g. a MinIO mirror) via `S3_DEFAULT_ENDPOINT` without any query changes.
 

--- a/s3config.py
+++ b/s3config.py
@@ -1,16 +1,48 @@
-"""Deployment-level S3 endpoint configuration.
+"""Deployment-level S3 configuration: the default backend and the source registry.
 
-Single source of truth for the default S3 backend (#268/#271): one env surface
-(S3_DEFAULT_ENDPOINT / S3_DEFAULT_URL_STYLE / S3_DEFAULT_USE_SSL) drives both
-DuckDB connection factories — the per-request query engine
-(server.get_isolated_db) and the persistent tile connection
-(tiles.db.build_tile_connection) — so repointing a deployment at another
-backend (MinIO, source.coop, ...) via env covers query AND hex tiles.
+Single source of truth (#268/#271/#264) for everything that maps STAC hrefs to
+DuckDB S3 access, consumed by the query engine (server.get_isolated_db), the
+tile subsystem (tiles.db.build_tile_connection), and the STAC renderer (stac.py):
 
-Precursor to the data-driven source registry (#264): when routing becomes
-registry-driven, this module is where the registry lives.
+- **Default backend** — one env surface (S3_DEFAULT_ENDPOINT / S3_DEFAULT_URL_STYLE /
+  S3_DEFAULT_USE_SSL) for the unscoped `s3` secret, so repointing a deployment at
+  another backend (MinIO, source.coop, ...) covers query AND hex tiles.
+
+- **Source registry** — data-driven routing for every *known* non-default source
+  (#264). Each entry can carry:
+    name                 registry key; sanitized into the DuckDB secret name
+    https_prefix         hrefs starting with this are rewritten to s3_prefix
+    s3_prefix            replacement prefix (s3:// form DuckDB can glob)
+    metadata_url_prefix  when set, STAC-JSON fetches for https_prefix are rerouted
+                         here instead (e.g. the NRP in-cluster fast path)
+    secret               when set, a prefix-scoped DuckDB secret is created on
+                         every connection: {endpoint, scope, region?, url_style?,
+                         use_ssl?, key_id?, secret?}
+  Built-ins cover the NRP Ceph endpoint (rewrite + in-cluster metadata reroute;
+  no secret of its own — its paths route via the default `s3` secret) and the
+  anonymous source.coop mirror (gateway rewrite + scoped `source_coop` secret).
+
+  Deployments extend/override via the S3_SOURCES env var: a JSON list of entries,
+  merged over the built-ins by name ("disabled": true removes one). Example:
+    S3_SOURCES='[{"name": "campus_minio",
+                  "https_prefix": "https://minio.example.edu/",
+                  "s3_prefix": "s3://",
+                  "secret": {"endpoint": "minio.example.edu",
+                             "scope": "s3://mirror-"}}]'
+
+- **Route hints** — for hrefs on hosts NOT in the registry, `route_hint()` derives
+  the (s3 path, endpoint, scope) a caller can pass per-request to `query`
+  (s3_endpoint/s3_scope), so "carry the links" works for endpoints nobody
+  pre-configured. Derivation, never a rewrite: unknown hrefs still pass through
+  unchanged; the hint is surfaced alongside them by the STAC tools.
+
+The fully STAC-native end state carries endpoint/routing on the asset itself
+(storage extension); this registry is the server-side stand-in until then.
 """
+import json
 import os
+import re
+import sys
 
 
 def sql_quote(value: str) -> str:
@@ -53,3 +85,169 @@ def default_s3_secret_sql(name: str = "s3") -> str:
         f"ENDPOINT '{sql_quote(endpoint)}', URL_STYLE '{sql_quote(url_style)}', "
         f"USE_SSL '{sql_quote(use_ssl)}')"
     )
+
+
+# -------------------------------------------------------------------------
+# Source registry
+# -------------------------------------------------------------------------
+def _builtin_sources() -> list[dict]:
+    # Computed per call (not module-level) so S3_ENDPOINT_URL is honored when it
+    # changes between calls — e.g. running stac.py locally against the external
+    # endpoint, or monkeypatching in tests.
+    return [
+        {
+            # Primary NRP Ceph. The STAC catalog publishes external SSL hrefs;
+            # rewriting strips the host so DuckDB can glob, and paths then route
+            # via the deployment-default `s3` secret (internal endpoint in-cluster)
+            # — which is why this entry has no secret of its own. Metadata (STAC
+            # JSON) fetches are invisibly rerouted to the in-cluster endpoint for
+            # speed; override with S3_ENDPOINT_URL outside the cluster.
+            "name": "nrp_ceph",
+            "https_prefix": "https://s3-west.nrp-nautilus.io/",
+            "s3_prefix": "s3://",
+            "metadata_url_prefix": (
+                os.environ.get("S3_ENDPOINT_URL", "http://rook-ceph-rgw-nautiluss3.rook").rstrip("/")
+                + "/"
+            ),
+        },
+        {
+            # Anonymous source.coop mirror (#260). STAC entries publish assets
+            # under the data.source.coop HTTPS gateway, which cannot list/glob;
+            # the AWS-bucket form can. The bucket name is endpoint-unique, so the
+            # prefix-scoped secret routes it unambiguously alongside Ceph paths.
+            "name": "source_coop",
+            "https_prefix": "https://data.source.coop/",
+            "s3_prefix": "s3://us-west-2.opendata.source.coop/",
+            "secret": {
+                "endpoint": "s3.us-west-2.amazonaws.com",
+                "region": "us-west-2",
+                "scope": "s3://us-west-2.opendata.source.coop",
+            },
+        },
+    ]
+
+
+def get_sources() -> list[dict]:
+    """The active source registry: built-ins merged with the S3_SOURCES env JSON.
+
+    Env entries merge over built-ins by name (top-level keys replace; new names
+    append; {"disabled": true} removes). A malformed S3_SOURCES is reported and
+    ignored rather than taking the server down. Parsed per call — the inputs are
+    tiny and this keeps env changes and tests cheap and correct.
+    """
+    sources = {s["name"]: s for s in _builtin_sources()}
+    raw = os.environ.get("S3_SOURCES", "").strip()
+    if raw:
+        try:
+            for entry in json.loads(raw):
+                name = entry.get("name")
+                if not name:
+                    print(f"⚠️ S3_SOURCES entry without a name skipped: {entry!r}", file=sys.stderr)
+                    continue
+                if entry.get("disabled"):
+                    sources.pop(name, None)
+                    continue
+                sources[name] = {**sources.get(name, {}), **entry}
+        except Exception as e:
+            print(f"⚠️ S3_SOURCES is not valid JSON — ignored: {e}", file=sys.stderr)
+    return list(sources.values())
+
+
+def rewrite_href(href: str) -> str:
+    """Registry-driven https→s3 prefix rewrite for data access (read_parquet).
+
+    Returns the href unchanged when no source matches — unknown hosts pass
+    through, they are never guessed at (see route_hint for the advisory path).
+    """
+    for src in get_sources():
+        hp, sp = src.get("https_prefix"), src.get("s3_prefix")
+        if hp and sp and href.startswith(hp):
+            return sp + href[len(hp):]
+    return href
+
+
+def metadata_href(href: str) -> str:
+    """Registry-driven reroute for STAC-metadata (JSON) fetches.
+
+    Distinct from rewrite_href: data reads want s3:// paths for DuckDB, while
+    metadata reads stay HTTP — just pointed at a faster/internal host when the
+    registry knows one (NRP in-cluster fast path).
+    """
+    for src in get_sources():
+        hp, mp = src.get("https_prefix"), src.get("metadata_url_prefix")
+        if hp and mp and href.startswith(hp):
+            return mp + href[len(hp):]
+    return href
+
+
+# Virtual-hosted AWS S3: BUCKET.s3.amazonaws.com or BUCKET.s3.REGION.amazonaws.com.
+_VHOST_S3 = re.compile(r"^(?P<bucket>[^/]+?)\.(?P<endpoint>s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com)$")
+
+
+def route_hint(href: str) -> dict | None:
+    """Derive per-request routing for an https href on a host outside the registry.
+
+    Assumes path-style S3 (https://HOST/BUCKET/KEY → s3://BUCKET/KEY @ HOST),
+    plus the documented virtual-hosted AWS form. Returns
+    {"path", "endpoint", "scope"} — the s3:// path and the s3_endpoint/s3_scope
+    a caller passes to `query` — or None when the href isn't https or has no
+    bucket/key to split. A hint, not a rewrite: callers surface it alongside the
+    original href, they don't substitute silently.
+    """
+    m = re.match(r"^https://([^/]+)/(.+)$", href)
+    if not m:
+        return None
+    host, rest = m.groups()
+    vhost = _VHOST_S3.match(host)
+    if vhost:
+        bucket, key = vhost.group("bucket"), rest
+        endpoint = vhost.group("endpoint")
+    else:
+        bucket, _, key = rest.partition("/")
+        endpoint = host
+    if not bucket or not key:
+        return None
+    return {
+        "path": f"s3://{bucket}/{key}",
+        "endpoint": endpoint,
+        "scope": f"s3://{bucket}",
+    }
+
+
+def _secret_identifier(name: str) -> str:
+    """Sanitize a registry name into a DuckDB identifier for CREATE SECRET."""
+    ident = re.sub(r"[^A-Za-z0-9_]", "_", name)
+    return ident if not ident[:1].isdigit() else f"s_{ident}"
+
+
+def source_secret_sql() -> list[str]:
+    """CREATE SECRET statements for every registry source that declares one.
+
+    All values are quote-escaped; USE_SSL is inferred from the endpoint unless
+    the entry says otherwise. Run on every DuckDB connection (query and tiles)
+    so scoped routing is identical everywhere.
+    """
+    stmts = []
+    for src in get_sources():
+        sec = src.get("secret")
+        if not sec or not sec.get("endpoint"):
+            continue
+        use_ssl = str(sec.get("use_ssl", infer_use_ssl(sec["endpoint"]))).strip().lower()
+        parts = [
+            "TYPE S3",
+            f"KEY_ID '{sql_quote(sec.get('key_id', ''))}'",
+            f"SECRET '{sql_quote(sec.get('secret', ''))}'",
+            f"ENDPOINT '{sql_quote(sec['endpoint'])}'",
+            f"URL_STYLE '{sql_quote(sec.get('url_style', 'path'))}'",
+            f"USE_SSL '{sql_quote(use_ssl)}'",
+        ]
+        if sec.get("region"):
+            parts.append(f"REGION '{sql_quote(sec['region'])}'")
+        if sec.get("scope"):
+            parts.append(f"SCOPE '{sql_quote(sec['scope'])}'")
+        stmts.append(
+            f"CREATE OR REPLACE SECRET {_secret_identifier(src['name'])} ("
+            + ", ".join(parts)
+            + ")"
+        )
+    return stmts

--- a/server.py
+++ b/server.py
@@ -117,7 +117,12 @@ TOOL_INJECTED_CONTEXT = f"""
 # -------------------------------------------------------------------------
 # 4. ISOLATION ENGINE
 # -------------------------------------------------------------------------
-from s3config import default_s3_secret_sql, infer_use_ssl, sql_quote as _sql_quote
+from s3config import (
+    default_s3_secret_sql,
+    infer_use_ssl,
+    source_secret_sql,
+    sql_quote as _sql_quote,
+)
 
 
 @contextmanager
@@ -129,6 +134,15 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
                 conn.sql(stmt)
             except Exception as e:
                 print(f"⚠️ Setup statement skipped: {stmt!r}: {e}", file=sys.stderr)
+        # Prefix-scoped secrets for every registry source (#264) — e.g. the
+        # anonymous source.coop mirror. Scoped, so they coexist deterministically
+        # with both the default `s3` secret and any client_s3 below (longest-
+        # scope match wins); shared with the tile connection via s3config.
+        for stmt in source_secret_sql():
+            try:
+                conn.sql(stmt)
+            except Exception as e:
+                print(f"⚠️ Source secret skipped: {e}", file=sys.stderr)
         # Bring-your-own-bucket. Two symmetric cases, both routed through one
         # per-request `client_s3` secret:
         #   - credentialed: both s3_key and s3_secret given (private data).

--- a/stac.py
+++ b/stac.py
@@ -14,6 +14,8 @@ import requests
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from pystac.stac_io import DefaultStacIO
 
+import s3config
+
 
 STAC_CATALOG_URL = os.environ.get(
     "STAC_CATALOG_URL",
@@ -40,11 +42,6 @@ _STAC_CHILD_RETRY_TIMEOUT = int(os.environ.get("STAC_CHILD_RETRY_TIMEOUT", "8"))
 
 # Legacy alias retained so external callers (if any) that read the old name still work.
 _STAC_TIMEOUT = _STAC_CHILD_TIMEOUT
-
-_S3_PUBLIC = "https://s3-west.nrp-nautilus.io/"
-_S3_INTERNAL = (
-    os.environ.get("S3_ENDPOINT_URL", "http://rook-ceph-rgw-nautiluss3.rook").rstrip("/") + "/"
-)
 
 # Navigational STAC link rel types excluded from _collection_to_dict output.
 _NAV_RELS = {"root", "parent", "self", "child", "item"}
@@ -104,8 +101,9 @@ class _TimeoutStacIO(DefaultStacIO):
         self._timeout = timeout if timeout is not None else _STAC_CHILD_TIMEOUT
 
     def read_text_from_href(self, href: str) -> str:
-        if href.startswith(_S3_PUBLIC):
-            href = _S3_INTERNAL + href[len(_S3_PUBLIC):]
+        # Registry-driven reroute (s3config): e.g. NRP external SSL hrefs are
+        # fetched via the in-cluster endpoint for speed.
+        href = s3config.metadata_href(href)
         if href.startswith("http"):
             headers = {"Authorization": f"Bearer {self._token}"} if self._token else {}
             resp = requests.get(href, timeout=self._timeout, headers=headers)
@@ -120,18 +118,14 @@ pystac.StacIO.set_default(_TimeoutStacIO)
 def _href_to_s3(href: str) -> str:
     """Convert an HTTPS S3 URL to an s3:// path for DuckDB read_parquet().
 
-    Handles both the primary NRP Ceph endpoint and the source.coop mirror. The
-    source.coop STAC entries publish assets under the `data.source.coop` HTTPS
-    gateway, which cannot list/glob; rewriting to the `us-west-2.opendata.source.coop`
-    S3 bucket form lets DuckDB expand `h0=*` globs against the mirror (see #260).
+    Registry-driven (s3config, #264): built-ins cover the primary NRP Ceph
+    endpoint and the source.coop mirror (whose `data.source.coop` HTTPS gateway
+    cannot list/glob — the AWS-bucket form can, see #260); deployments add
+    sources via S3_SOURCES. Hrefs on unknown hosts pass through unchanged —
+    the renderers surface a per-request routing hint for those instead
+    (s3config.route_hint) rather than guessing a rewrite.
     """
-    if href.startswith("https://s3-west.nrp-nautilus.io/"):
-        return href.replace("https://s3-west.nrp-nautilus.io/", "s3://")
-    if href.startswith("https://data.source.coop/"):
-        return href.replace(
-            "https://data.source.coop/", "s3://us-west-2.opendata.source.coop/"
-        )
-    return href
+    return s3config.rewrite_href(href)
 
 
 def _format_columns(table_cols: list) -> list[str]:
@@ -153,6 +147,18 @@ def _format_columns(table_cols: list) -> list[str]:
     return lines
 
 
+def _is_queryable_asset(href: str, atype: str) -> bool:
+    """True for assets the `query` tool reads via read_parquet()."""
+    if "pmtiles" in atype or href.endswith(".pmtiles"):
+        return False
+    if "tif" in atype or href.endswith(".tif") or href.endswith(".tiff"):
+        return False
+    return (
+        "parquet" in atype or href.endswith(".parquet")
+        or href.endswith("/") or "/hex/" in href
+    )
+
+
 def _extract_parquet_assets(col) -> list[str]:
     """Extract parquet/hex asset lines (with inline column schemas) from a collection's assets."""
     assets = []
@@ -161,18 +167,25 @@ def _extract_parquet_assets(col) -> list[str]:
         atype = asset.media_type or ""
         title = asset.title or asset_id
 
-        if "parquet" in atype or href.endswith(".parquet") or href.endswith("/") or "/hex/" in href:
-            # Skip PMTiles and COGs that might match loosely
-            if "pmtiles" in atype or href.endswith(".pmtiles"):
-                continue
-            if "tif" in atype or href.endswith(".tif") or href.endswith(".tiff"):
-                continue
+        if _is_queryable_asset(href, atype):
             s3 = _href_to_s3(href)
+            # Unknown host (no registry rewrite): render the derived s3:// form —
+            # the only form that can glob — with the per-request routing params
+            # the caller must pass to `query` (see s3config.route_hint, #264).
+            hint = s3config.route_hint(s3) if s3.startswith("http") else None
+            if hint:
+                s3 = hint["path"]
             if s3.endswith("/"):
                 s3 = s3.rstrip("/") + "/**"
             size = asset.extra_fields.get("file:size")
             size_note = f" ({size/1024**3:.2f} GiB)" if size and size > 1024**2 else ""
             assets.append(f"  - {title}{size_note}: `read_parquet('{s3}')`")
+            if hint:
+                assets.append(
+                    f"    - ⚠️ non-default endpoint (derived from `{href}` assuming "
+                    f"path-style S3): call `query` with s3_endpoint='{hint['endpoint']}', "
+                    f"s3_scope='{hint['scope']}' (anonymous; add s3_key/s3_secret if private)"
+                )
             # Asset-level description — carries per-asset facts (e.g. "this file has
             # duplicate rows per feature; dedup by <id>") that the model needs at
             # column-choice time. Without this line they never reach the prompt.
@@ -325,6 +338,17 @@ def _collection_to_dict(col, sub_children=None) -> dict:
             "title": asset.title,
             "description": asset.description,
         }
+        # Queryable asset on a host outside the registry: keep the original href
+        # (still fetchable over HTTPS by map clients) and attach the derived
+        # per-request routing advisory — s3_href + the s3_endpoint/s3_scope to
+        # pass to `query` (s3config.route_hint, #264). Additive only, so inline
+        # round-trips and non-DuckDB consumers are unaffected.
+        if a["href"].startswith("http") and _is_queryable_asset(asset.href, asset.media_type or ""):
+            hint = s3config.route_hint(a["href"])
+            if hint:
+                a["s3_href"] = hint["path"]
+                a["s3_endpoint"] = hint["endpoint"]
+                a["s3_scope"] = hint["scope"]
         # Merge extra_fields (table:columns, raster:bands, vector:layers, file:size, …)
         a.update(asset.extra_fields)
         assets[asset_id] = {k: v for k, v in a.items() if v is not None}

--- a/tests/test_s3config.py
+++ b/tests/test_s3config.py
@@ -1,0 +1,167 @@
+"""Tests for the s3config source registry (#264): data-driven href rewriting,
+metadata rerouting, per-source secrets, and route hints for unknown hosts."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import s3config
+
+
+class TestGetSources:
+    def test_builtins_present(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        names = [s["name"] for s in s3config.get_sources()]
+        assert "nrp_ceph" in names
+        assert "source_coop" in names
+
+    def test_env_appends_new_source(self, monkeypatch):
+        monkeypatch.setenv(
+            "S3_SOURCES",
+            '[{"name": "campus_minio", "https_prefix": "https://minio.example.edu/",'
+            ' "s3_prefix": "s3://", "secret": {"endpoint": "minio.example.edu",'
+            ' "scope": "s3://mirror-"}}]',
+        )
+        sources = {s["name"]: s for s in s3config.get_sources()}
+        assert "campus_minio" in sources
+        assert "source_coop" in sources  # built-ins retained
+
+    def test_env_merges_over_builtin_by_name(self, monkeypatch):
+        monkeypatch.setenv(
+            "S3_SOURCES",
+            '[{"name": "source_coop", "s3_prefix": "s3://other-mirror/"}]',
+        )
+        src = {s["name"]: s for s in s3config.get_sources()}["source_coop"]
+        assert src["s3_prefix"] == "s3://other-mirror/"
+        # Untouched keys survive the merge.
+        assert src["https_prefix"] == "https://data.source.coop/"
+
+    def test_env_disabled_removes_builtin(self, monkeypatch):
+        monkeypatch.setenv("S3_SOURCES", '[{"name": "source_coop", "disabled": true}]')
+        names = [s["name"] for s in s3config.get_sources()]
+        assert "source_coop" not in names
+
+    def test_malformed_env_ignored_with_warning(self, monkeypatch, capsys):
+        monkeypatch.setenv("S3_SOURCES", "not json")
+        names = [s["name"] for s in s3config.get_sources()]
+        assert "nrp_ceph" in names  # built-ins still served
+        assert "S3_SOURCES" in capsys.readouterr().err
+
+
+class TestRewriteHref:
+    def test_ceph_strip(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        assert (
+            s3config.rewrite_href("https://s3-west.nrp-nautilus.io/public-carbon/x.parquet")
+            == "s3://public-carbon/x.parquet"
+        )
+
+    def test_source_coop_gateway(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        assert (
+            s3config.rewrite_href("https://data.source.coop/cboettig/carbon/h0=*/d.parquet")
+            == "s3://us-west-2.opendata.source.coop/cboettig/carbon/h0=*/d.parquet"
+        )
+
+    def test_unknown_host_passthrough(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        href = "https://example.com/other.parquet"
+        assert s3config.rewrite_href(href) == href
+
+    def test_env_source_rewrites(self, monkeypatch):
+        monkeypatch.setenv(
+            "S3_SOURCES",
+            '[{"name": "campus_minio", "https_prefix": "https://minio.example.edu/",'
+            ' "s3_prefix": "s3://"}]',
+        )
+        assert (
+            s3config.rewrite_href("https://minio.example.edu/mirror-x/y.parquet")
+            == "s3://mirror-x/y.parquet"
+        )
+
+
+class TestMetadataHref:
+    def test_nrp_reroutes_to_internal(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        monkeypatch.delenv("S3_ENDPOINT_URL", raising=False)
+        assert (
+            s3config.metadata_href("https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json")
+            == "http://rook-ceph-rgw-nautiluss3.rook/public-data/stac/catalog.json"
+        )
+
+    def test_s3_endpoint_url_env_honored(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        monkeypatch.setenv("S3_ENDPOINT_URL", "https://s3-west.nrp-nautilus.io")
+        assert s3config.metadata_href(
+            "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
+        ) == "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
+
+    def test_source_coop_metadata_not_rerouted(self, monkeypatch):
+        """data.source.coop serves STAC JSON fine over HTTPS — only the DATA
+        path needs the bucket-form rewrite, so metadata_href must not touch it."""
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        href = "https://data.source.coop/cboettig/carbon/collection.json"
+        assert s3config.metadata_href(href) == href
+
+
+class TestSourceSecretSql:
+    def test_source_coop_secret_generated(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        stmts = s3config.source_secret_sql()
+        coop = [s for s in stmts if "SECRET source_coop" in s]
+        assert len(coop) == 1
+        assert "SCOPE 's3://us-west-2.opendata.source.coop'" in coop[0]
+        assert "REGION 'us-west-2'" in coop[0]
+        assert "ENDPOINT 's3.us-west-2.amazonaws.com'" in coop[0]
+
+    def test_nrp_has_no_secret(self, monkeypatch):
+        """NRP paths route via the deployment default `s3` secret — the registry
+        entry must not create a competing one."""
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        assert not any("nrp" in s for s in s3config.source_secret_sql())
+
+    def test_env_source_secret_with_ssl_inference(self, monkeypatch):
+        monkeypatch.setenv(
+            "S3_SOURCES",
+            '[{"name": "my-mirror!", "secret": {"endpoint": "minio.example.edu",'
+            ' "scope": "s3://mirror-"}}]',
+        )
+        stmt = [s for s in s3config.source_secret_sql() if "minio.example.edu" in s][0]
+        assert "SECRET my_mirror_ " in stmt  # name sanitized to an identifier
+        assert "USE_SSL 'true'" in stmt  # inferred: non-rook = https
+
+    def test_values_are_quote_escaped(self, monkeypatch):
+        monkeypatch.setenv(
+            "S3_SOURCES",
+            '[{"name": "q", "secret": {"endpoint": "e.example", "scope": "s3://a\'b"}}]',
+        )
+        stmt = [s for s in s3config.source_secret_sql() if "e.example" in s][0]
+        assert "s3://a''b" in stmt
+
+
+class TestRouteHint:
+    def test_path_style(self):
+        hint = s3config.route_hint("https://minio.other.edu/public-x/hex/h0=*/d.parquet")
+        assert hint == {
+            "path": "s3://public-x/hex/h0=*/d.parquet",
+            "endpoint": "minio.other.edu",
+            "scope": "s3://public-x",
+        }
+
+    def test_vhost_aws(self):
+        hint = s3config.route_hint("https://mybucket.s3.us-west-2.amazonaws.com/data/x.parquet")
+        assert hint["path"] == "s3://mybucket/data/x.parquet"
+        assert hint["endpoint"] == "s3.us-west-2.amazonaws.com"
+        assert hint["scope"] == "s3://mybucket"
+
+    def test_no_key_returns_none(self):
+        """A bare https file at host root has no bucket/key split to derive."""
+        assert s3config.route_hint("https://example.com/other.parquet") is None
+
+    def test_non_https_returns_none(self):
+        assert s3config.route_hint("s3://already/fine.parquet") is None
+        assert s3config.route_hint("/local/path.parquet") is None
+
+    def test_directory_key_preserves_trailing_slash(self):
+        hint = s3config.route_hint("https://minio.other.edu/mirror-x/data/")
+        assert hint["path"] == "s3://mirror-x/data/"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -352,8 +352,8 @@ class TestUnscopedClientRouting:
             assert "s3" in self._names(conn)
 
     def test_scoped_source_coop_survives_unscoped_client(self):
-        """The prefix-scoped source_coop secret (SETUP_SQL) still wins its own
-        paths over an unscoped client_s3 — longest-scope match beats unscoped."""
+        """The prefix-scoped source_coop secret (source registry) still wins its
+        own paths over an unscoped client_s3 — longest-scope match beats unscoped."""
         with get_isolated_db(s3_key="K", s3_secret="S") as conn:
             assert (
                 self._which(conn, "s3://us-west-2.opendata.source.coop/a.parquet")
@@ -369,6 +369,38 @@ class TestUnscopedClientRouting:
     def test_quote_in_scope_does_not_break_secret_sql(self):
         with get_isolated_db(s3_endpoint="minio.example.org", s3_scope="s3://pub'lic-") as conn:
             assert "client_s3" in self._names(conn)
+
+
+class TestSourceRegistrySecrets:
+    """Registry sources (s3config, #264) get prefix-scoped secrets on every
+    query connection — built-ins and S3_SOURCES env additions alike."""
+
+    def _names(self, conn):
+        return [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+
+    def test_source_coop_secret_present(self, monkeypatch):
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        with get_isolated_db() as conn:
+            assert "source_coop" in self._names(conn)
+
+    def test_env_source_secret_created_and_scoped(self, monkeypatch):
+        monkeypatch.setenv(
+            "S3_SOURCES",
+            '[{"name": "campus_minio", "https_prefix": "https://minio.example.edu/",'
+            ' "s3_prefix": "s3://", "secret": {"endpoint": "minio.example.edu",'
+            ' "scope": "s3://mirror-"}}]',
+        )
+        with get_isolated_db() as conn:
+            assert "campus_minio" in self._names(conn)
+            row = conn.sql(
+                "SELECT name FROM which_secret('s3://mirror-data/x.parquet', 's3')"
+            ).fetchone()
+            assert row[0] == "campus_minio"
+            # Paths outside the scope keep the deployment default.
+            row = conn.sql(
+                "SELECT name FROM which_secret('s3://public-data/x.parquet', 's3')"
+            ).fetchone()
+            assert row[0] == "s3"
 
 
 class TestDefaultEndpoint:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -375,6 +375,16 @@ class TestSourceCoopFallback:
         assert _href_to_s3("https://example.com/other.parquet") == \
             "https://example.com/other.parquet"
 
+    def test_env_registered_source_rewrites(self, monkeypatch):
+        """S3_SOURCES entries extend the rewrite table without code changes (#264)."""
+        monkeypatch.setenv(
+            "S3_SOURCES",
+            '[{"name": "campus_minio", "https_prefix": "https://minio.example.edu/",'
+            ' "s3_prefix": "s3://"}]',
+        )
+        assert _href_to_s3("https://minio.example.edu/mirror-x/y.parquet") == \
+            "s3://mirror-x/y.parquet"
+
     def test_source_coop_asset_rewritten_in_collection(self):
         col = MagicMock()
         col.id, col.title, col.description = "carbon", "Carbon", "d"
@@ -414,6 +424,78 @@ class TestSourceCoopFallback:
         col.links = [lnk]
         result = _collection_to_dict(col)  # must not raise
         assert result["links"][0]["href"] == "https://doi.org/10.5281/zenodo.4091029"
+
+
+class TestUnknownHostRouteHints:
+    """Assets on hosts outside the source registry get per-request routing
+    advisories (#264/#271): the derived s3:// form plus the s3_endpoint/s3_scope
+    to pass to `query` — instead of a broken https glob or a silent wrong-endpoint
+    rewrite. 'Carry the links' for endpoints nobody pre-configured."""
+
+    def _make_col(self, href, media_type="application/x-parquet"):
+        col = MagicMock()
+        col.id, col.title, col.description = "foreign", "Foreign", "d"
+        col.license, col.keywords, col.providers = "CC-BY", [], []
+        col.links, col.summaries, col.extra_fields = [], None, {}
+        spatial = MagicMock(); spatial.bboxes = [[-180, -90, 180, 90]]
+        temporal = MagicMock(); temporal.intervals = []
+        col.extent = MagicMock(spatial=spatial, temporal=temporal)
+        asset = MagicMock()
+        asset.href = href
+        asset.media_type = media_type
+        asset.title, asset.description, asset.extra_fields = "hex", None, {}
+        col.assets = {"hex": asset}
+        return col
+
+    def test_markdown_renders_s3_form_with_params(self):
+        col = self._make_col("https://minio.other.edu/public-x/hex/h0=*/data_0.parquet")
+        md = _format_collection(col, sub_children=[])
+        assert "read_parquet('s3://public-x/hex/h0=*/data_0.parquet')" in md
+        assert "s3_endpoint='minio.other.edu'" in md
+        assert "s3_scope='s3://public-x'" in md
+
+    def test_markdown_directory_asset_gets_glob_and_params(self):
+        col = self._make_col("https://minio.other.edu/public-x/hex/")
+        md = _format_collection(col, sub_children=[])
+        assert "read_parquet('s3://public-x/hex/**')" in md
+        assert "s3_endpoint='minio.other.edu'" in md
+
+    def test_dict_keeps_https_href_and_adds_advisory_fields(self):
+        """The structured form must stay additive: original href untouched (still
+        fetchable over HTTPS), advisory fields alongside."""
+        href = "https://minio.other.edu/public-x/hex/h0=*/data_0.parquet"
+        result = _collection_to_dict(self._make_col(href))
+        a = result["assets"]["hex"]
+        assert a["href"] == href
+        assert a["s3_href"] == "s3://public-x/hex/h0=*/data_0.parquet"
+        assert a["s3_endpoint"] == "minio.other.edu"
+        assert a["s3_scope"] == "s3://public-x"
+
+    def test_dict_non_queryable_asset_gets_no_advisory(self):
+        """PMTiles/COGs are fetched over HTTPS by map clients — no s3 advisory."""
+        result = _collection_to_dict(self._make_col(
+            "https://minio.other.edu/public-x/map.pmtiles",
+            media_type="application/vnd.pmtiles",
+        ))
+        a = result["assets"]["hex"]
+        assert "s3_endpoint" not in a
+        assert a["href"].startswith("https://")
+
+    def test_registry_host_gets_no_advisory(self):
+        """Registry-rewritten paths route via server-side secrets — no params needed."""
+        result = _collection_to_dict(self._make_col(
+            "https://data.source.coop/cboettig/carbon/hex/h0=*/data_0.parquet"
+        ))
+        a = result["assets"]["hex"]
+        assert a["href"].startswith("s3://us-west-2.opendata.source.coop/")
+        assert "s3_endpoint" not in a
+
+    def test_underivable_href_passes_through_unchanged(self):
+        """No bucket/key split → no hint; the https href renders as before."""
+        col = self._make_col("https://example.com/other.parquet")
+        md = _format_collection(col, sub_children=[])
+        assert "read_parquet('https://example.com/other.parquet')" in md
+        assert "s3_endpoint=" not in md
 
 
 class TestGetCollection:

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -574,6 +574,17 @@ class TestBuildTileConnection:
         finally:
             con.close()
 
+    def test_registry_source_secrets_present(self, monkeypatch):
+        """The tile connection gets the same scoped registry secrets as the query
+        tool (#264), so hex-tile builds over e.g. mirror paths route correctly."""
+        monkeypatch.delenv("S3_SOURCES", raising=False)
+        con = build_tile_connection()
+        try:
+            names = [r[0] for r in con.sql("SELECT name FROM duckdb_secrets()").fetchall()]
+            assert "source_coop" in names
+        finally:
+            con.close()
+
     def test_honors_s3_default_endpoint_env(self, monkeypatch):
         """The tile connection uses the same deployment default as the query
         tool (#268/#271) — previously hardcoded to rook, so a deployment

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -8,7 +8,7 @@ import os
 
 import duckdb
 
-from s3config import default_s3_secret_sql
+from s3config import default_s3_secret_sql, source_secret_sql
 
 
 def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnection:
@@ -60,4 +60,9 @@ def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnecti
     # cluster-internal Ceph endpoint, which broke hex tiles (source reads AND
     # s3://public-output writes) on any deployment repointed via env.
     con.sql(default_s3_secret_sql())
+    # Scoped registry-source secrets (#264), same set as the query tool — so a
+    # register_hex_tiles SQL over e.g. source.coop mirror paths routes correctly
+    # here too (previously only the query connections had the mirror secret).
+    for stmt in source_secret_sql():
+        con.sql(stmt)
     return con


### PR DESCRIPTION
Closes #264. Final PR of the #271 series (Findings 3–5), following #273 and #275. Replaces host-string special-casing with data-driven routing, per the north star in `docs/architecture/catalog-sourcing.md`.

## The registry

`s3config.py` gains a source registry. Each entry can carry `https_prefix → s3_prefix` (data-path rewrite), `metadata_url_prefix` (STAC-JSON fetch reroute), and `secret` (a prefix-scoped DuckDB secret created on every connection). Built-ins:

- **`nrp_ceph`** — the external→`s3://` strip rewrite plus the in-cluster metadata fast path (`S3_ENDPOINT_URL` still honored). No secret of its own: its paths route via the deployment-default `s3` secret, exactly as today. The "necessary NRP hardwiring" is now one data entry instead of code in two files.
- **`source_coop`** — the `data.source.coop` gateway→bucket rewrite plus the anonymous scoped secret (parameter-identical to the SETUP_SQL line it replaces, verified by generated-SQL comparison).

Deployments extend/override via `S3_SOURCES` env JSON (merge by name; `"disabled": true` removes). Adding a MinIO mirror is now config, not a code change:

```json
[{"name": "campus_minio", "https_prefix": "https://minio.example.edu/", "s3_prefix": "s3://",
  "secret": {"endpoint": "minio.example.edu", "scope": "s3://mirror-"}}]
```

## What it drives (the four formerly hand-synced sites from #271)

1. `stac._href_to_s3` — now a thin wrapper over `s3config.rewrite_href`. Existing rewrites byte-identical; unknown hosts still pass through (pinned by tests).
2. `stac._TimeoutStacIO` — metadata reroute comes from the registry (`_S3_PUBLIC`/`_S3_INTERNAL` removed).
3. `server.get_isolated_db` — per-source scoped secrets created alongside the default; the `source_coop` CREATE SECRET is removed from `query-setup.md` SQL.
4. `tiles/db.py` — the tile connection now gets the same source secrets, fixing a latent inconsistency: a `register_hex_tiles` SQL over mirror paths previously had no `source_coop` secret on the build connection and would fail.

## Route hints for unregistered hosts ("carry the links" without pre-configuration)

For queryable (parquet/dir) assets on hosts outside the registry, the STAC tools now surface derived per-request routing instead of a broken https glob or a silent wrong-endpoint rewrite (`s3config.route_hint`: path-style S3 plus the documented virtual-hosted AWS form):

- **Markdown** (`get_stac_details`): renders the s3:// form — the only globbable form — with an explicit note: *call `query` with `s3_endpoint='HOST'`, `s3_scope='s3://BUCKET'` (anonymous; add s3_key/s3_secret if private)*. This pairs with #273's deterministic scoping: the hint always includes the scope.
- **Structured** (`get_collection`): strictly additive — original https `href` untouched (still fetchable by map clients; PMTiles/COGs get no advisory), with `s3_href` / `s3_endpoint` / `s3_scope` fields alongside.
- Underivable hrefs (no bucket/key split) render exactly as before.

## Not in this PR (follow-ups)

- A structured `s3_sources` list parameter on `query` for multi-endpoint bring-your-own requests in one call — client-visible tool-schema change, deferred as discussed in #271.
- Catalog-of-catalogs composition (#263).
- STAC storage-extension-driven routing (the registry is the server-side stand-in until then).

## Tests

31 new: `tests/test_s3config.py` (registry merge/disable/malformed-env, rewrites, metadata reroute incl. the source.coop-not-rerouted case, secret SQL generation with name sanitization + quote escaping, route-hint derivation incl. vhost AWS and degenerate hrefs); `TestUnknownHostRouteHints` in test_stac (markdown + dict rendering, non-queryable and registry-host exclusions); registry-secret creation and scoped `which_secret` routing in both connection factories. All existing behavior stays pinned (rewrites, passthrough, #273 routing semantics). Full suite: 340 passed.
