### PR TITLE
fix(#278): inline collection dicts no longer require links/description

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -739,8 +739,9 @@ def get_dataset(
 def _coerce_inline_collection(d: dict):
     """Parse an inline STAC collection dict into a pystac.Collection.
 
-    Tolerates dicts that omit STAC envelope fields (`type`, `stac_version`) so
-    that `_collection_to_dict` output can round-trip back through the inline
+    Tolerates dicts that omit STAC envelope fields (`type`, `stac_version`,
+    `links`, `description`) so that both `_collection_to_dict` output AND
+    hand-built/client-cached dicts (#105) can pass through the inline
     `collection=` parameter. The `children` key is consumed by the caller and
     must be stripped before pystac sees the dict.
     """
@@ -751,7 +752,16 @@ def _coerce_inline_collection(d: dict):
     # values — so a license-less collection round-tripped through this path
     # would crash pystac's parser. "various" is the STAC-recommended placeholder.
     payload.setdefault("license", "various")
-    return pystac.Collection.from_dict(payload)
+    # pystac raises a bare KeyError for these two (unlike `extent`, which it
+    # defaults with a warning) — a hand-built dict shouldn't need them (#278).
+    payload.setdefault("links", [])
+    payload.setdefault("description", "")
+    try:
+        return pystac.Collection.from_dict(payload)
+    except Exception as e:
+        # Surface remaining parse failures (e.g. a missing `id`) as a readable
+        # message instead of pystac's bare KeyError reaching the tool response.
+        raise ValueError(f"Invalid inline collection: {type(e).__name__}: {e}") from e
 
 
 def get_collection(

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1396,6 +1396,25 @@ class TestInlineCollectionContent:
             d["children"] = children
         return d
 
+    def test_inline_dict_without_links_or_description_works(self):
+        """Hand-built inline dicts (not round-tripped from _collection_to_dict)
+        commonly omit `links`/`description`; pystac raises a bare KeyError for
+        both, so the coercion must default them (#278)."""
+        d = self._minimal_collection_dict()
+        del d["links"]
+        del d["description"]
+        result = get_dataset("inline-col", collection=d)
+        assert "Inline" in result
+        assert "s3://bucket/data.parquet" in result
+
+    def test_inline_dict_missing_id_raises_readable_error(self):
+        """Remaining parse failures surface as 'Invalid inline collection: ...'
+        rather than a bare KeyError bubbling into the tool response (#278)."""
+        d = self._minimal_collection_dict()
+        del d["id"]
+        with pytest.raises(ValueError, match="Invalid inline collection"):
+            get_dataset("whatever", collection=d)
+
     def test_get_collection_inline_returns_dict_no_http(self):
         with patch("stac.requests.get") as mock_get, \
              patch("stac.pystac.Catalog.from_file") as mock_cat, \


### PR DESCRIPTION
Closes #278. Found live-testing #276 on dev during the Ceph outage — the exact scenario where inline collections are the only path to the STAC tools.

`_coerce_inline_collection` exists to tolerate missing STAC envelope fields, but only defaulted `type`/`stac_version`/`license`. pystac's `Collection.from_dict` also hard-requires `links` and `description` (verified: bare `KeyError` for both, while `extent` gets defaulted with a warning), so a hand-built inline dict failed with `Error executing tool get_stac_details: 'links'`. Round-tripped `_collection_to_dict` output always carries both fields, which is why the round-trip tests never caught it.

Two more `setdefault`s, plus remaining parse failures (e.g. missing `id`) now surface as `Invalid inline collection: <reason>` instead of a bare KeyError. Two new tests; full suite 342 passed. Verified the previously-failing dict shape from the dev test session now renders.