### PR TITLE
docs: add mirror-failover guide to the site sidebar

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -38,6 +38,7 @@ export default {
         items: [
           { text: 'Deployment', link: '/guide/deployment' },
           { text: 'Architecture', link: '/guide/architecture' },
+          { text: 'Mirror failover (S3 outage)', link: '/guide/mirror-failover' },
         ],
       },
     ],


### PR DESCRIPTION
Follow-up to #272: the guide published (200 at /guide/mirror-failover.html) but was missing from the VitePress sidebar, so it was invisible in navigation. One-line config addition under Operations.