### PR TITLE
docs(#279): verified hex-tile output fallback on the minio mirror

### DIFF
--- a/docs/guide/mirror-failover.md
+++ b/docs/guide/mirror-failover.md
@@ -66,11 +66,15 @@ mirror, anonymously, with no per-query changes.
 
 > **Two caveats on a mirror-configured head:**
 > - **Hex-tile builds write.** `register_hex_tiles` writes its pyramid output to
->   `s3://public-output` on the default backend. NRP Ceph accepts those writes
->   anonymously; the mirror bucket likely requires credentials, so expect builds
->   to fail at write time until the scoped write secret in
->   [#279](https://github.com/boettiger-lab/mcp-data-server/issues/279) is in
->   place. `query` reads are unaffected.
+>   `s3://public-output` on the default backend, anonymously. Both NRP Ceph and
+>   the minio mirror accept these writes (verified end-to-end in
+>   [#279](https://github.com/boettiger-lab/mcp-data-server/issues/279): build on
+>   a mirror head → pyramid on minio → tiles served) — the requirement is that
+>   the mirror's bucket policy is open for anonymous Get/Put/List
+>   (`mc anonymous set public <alias>/public-output`). No credentials are
+>   involved. To redirect *only* tile output at the mirror while the default
+>   backend stays on Ceph, add a scoped registry entry instead:
+>   `{"name": "minio_output", "secret": {"endpoint": "minio.carlboettiger.info", "scope": "s3://public-output"}}`.
 > - **Booting mid-outage.** With `STAC_CATALOG_URL` swapped to the mirror as
 >   above, the head starts normally. If you keep the Ceph catalog URL (or the
 >   mirror lacks a root catalog), also set `STAC_ALLOW_DEGRADED_START=true`


### PR DESCRIPTION
Closes #279. The caveat added in #272 assumed the mirror bucket would need write credentials; testing proved otherwise once the bucket policy was opened. Verified end-to-end today on the mirror-configured dev head:

- anonymous DuckDB `COPY` + glob read-back against `minio.carlboettiger.info/public-output` ✅
- live `register_hex_tiles` (wdpa, one h0, COUNT) → status `done` in 3.3s ✅
- pyramid physically on minio (9 files) and **not** on Ceph (0 files — routing proof) ✅
- tile GET from the dev endpoint serving the minio-backed pyramid: 200, 211KB pbf ✅

Guide caveat updated to the verified statement (open anonymous Get/Put/List policy, no credentials), including the scoped `S3_SOURCES` recipe for redirecting only tile output while the default backend stays on Ceph.