### PR TITLE
k8s(prod): promote v0.8.0 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.7.13@sha256:5da3f35c60c191ecbdbbb1fef5f57b6f97ac125a5b5c97c746a05133cf5bbb9f
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.0@sha256:661d3dd870db6f49b98fdcce036cbd07f01c01ee0f18378a821d5e772e7cdb57
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes production to v0.8.0 (`ffe7d4d`), the first prod release carrying this week's S3-abstraction series — deterministic secret routing (#273), single-source default endpoint config incl. tiles (#275), the data-driven source registry + route hints (#264/#276), inline-collection ergonomics (#278/#280), and the verified mirror-failover path for hex-tile output (#279/#282). All battle-tested on dev through the Ceph outage.

Digest from the v0.8.0 docker.yml run (28813746687). Prod keeps fail-fast startup (no `STAC_ALLOW_DEGRADED_START`), so the `kubectl apply` is deliberately held until NRP Ceph — currently flapping — shows sustained health; merging this PR does not deploy.