### PR TITLE
docs(#259): document valid h3_cell_area units + acre conversion

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -53,7 +53,14 @@ GROUP BY state;
 
 When the scope is a name or feature id on a global `h0=*` dataset, restrict `h0` first — see *Scoping by name or feature id* in query-optimization.md.
 
-`h3_cell_area()` takes any resolution column (`h3_cell_area(h6, 'km^2')`) and unit (`'km^2'`, `'m^2'`).
+`h3_cell_area()` takes a resolution column (`h3_cell_area(h6, 'km^2')`) and exactly one of three units: `'km^2'`, `'m^2'`, `'rads^2'`. It has no acre unit; any other unit string returns `NaN`, not an error. For acres, compute in `km^2` and multiply by 247.105 (or `m^2` by 0.000247105):
+
+```sql
+SELECT SUM(h3_cell_area(h8, 'km^2')) * 247.105 AS area_acres
+FROM (SELECT DISTINCT h8, h0 FROM read_parquet('<hex>') WHERE <scope>);
+```
+
+The `acres/cell (rough)` column in the table below already includes this factor, so a count × constant path needs no conversion.
 
 For unscoped global aggregates over millions of cells, multiplying an approximate count by the rough per-cell constant is faster (within ~1–2%). Exact area would force materializing every distinct cell, defeating the approximate path:
 


### PR DESCRIPTION
Closes #259.

`h3_cell_area(h, 'acres')` returns `NaN` **silently** — the DuckDB `h3` extension only supports `'km^2'`, `'m^2'`, and `'rads^2'`. This corrupted area math in ca-30x30 agent runs and sent some models into retry loops.

## Change

Updates the cell-area section of `h3-guide.md` (injected into the `query` tool description as `{H3_RAW}`) to cover all three points from the issue:

1. **Valid units are `'km^2'`, `'m^2'`, `'rads^2'`** — any other unit, notably `'acres'`, returns `NaN` with no error.
2. **Acre conversion**: compute in `km^2` and multiply × 247.105 (or `m^2` × 0.000247105), with a worked SQL example.
3. The existing **per-resolution `acres/cell` constants table** already bakes in the conversion, so a count × constant path needs no function call.

## On the optional server-side guard

The issue floats surfacing a clear error on an unknown unit. Detecting it means SQL-string parsing for `h3_cell_area(…, '<bad unit>')`, which is fragile and false-positive-prone; the issue itself notes the guide note "prevents both," so this PR stays doc-only.