### PR TITLE
k8s: CPU (DuckDB) deployment for the self-hosted cirrus cluster

### DIFF
--- a/k8s/cirrus-deployment.yaml
+++ b/k8s/cirrus-deployment.yaml
@@ -1,0 +1,82 @@
+# CPU (DuckDB) MCP data server on the local k3s cluster (cirrus).
+#
+# Derived from the NRP dev recipe (dev-deployment.yaml) but retargeted at the
+# self-hosted cluster: it runs in the `mcp` namespace alongside gpu-mcp, is
+# pinned to the cirrus node, and reads from the in-cluster MinIO mirror instead
+# of NRP Ceph so all data traffic stays on-node. Ingress/TLS/DNS are handled by
+# Traefik + cert-manager + external-dns (see cirrus-ingress.yaml).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: duckdb-mcp
+  namespace: mcp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: duckdb-mcp
+  template:
+    metadata:
+      labels:
+        app: duckdb-mcp
+    spec:
+      # Pin to cirrus: MinIO and Traefik both live on cirrus, so co-locating the
+      # server keeps S3 reads on-node rather than crossing the 1Gb VXLAN wire.
+      nodeSelector:
+        kubernetes.io/hostname: cirrus
+      containers:
+      - name: server
+        image: ghcr.io/boettiger-lab/mcp-data-server:main
+        imagePullPolicy: Always
+        env:
+        # In-cluster MinIO mirror (matches gpu-mcp). STAC metadata + S3 data both
+        # resolve to the on-node MinIO S3 endpoint (plain http, path-style).
+        - name: STAC_CATALOG_URL
+          value: "http://minio-svc.minio.svc.cluster.local:9000/public-data/stac/catalog.json"
+        # Reroute nrp_ceph STAC metadata fetches to in-cluster MinIO.
+        - name: S3_ENDPOINT_URL
+          value: "http://minio-svc.minio.svc.cluster.local:9000"
+        # DuckDB default `s3` secret: bare host, http, path-style for MinIO.
+        - name: S3_DEFAULT_ENDPOINT
+          value: "minio-svc.minio.svc.cluster.local:9000"
+        - name: S3_DEFAULT_USE_SSL
+          value: "false"
+        - name: MCP_PUBLIC_BASE_URL
+          value: "https://duckdb-mcp.carlboettiger.info"
+        # Boot even if the STAC catalog is briefly unreachable at startup, so a
+        # MinIO blip doesn't wedge the whole deployment. Discovery fills in once
+        # MinIO answers; known/inline datasets still work meanwhile (#260).
+        - name: STAC_ALLOW_DEGRADED_START
+          value: "true"
+        resources:
+          # Small requests so the pod schedules easily on the shared cirrus node;
+          # limits stay generous so large DuckDB queries can still burst. cirrus
+          # has 128 CPU / ~251Gi, shared with gpu-mcp and JupyterHub — hence the
+          # 96Gi ceiling (vs 160Gi on the much larger NRP nodes).
+          requests:
+            memory: 2Gi
+            cpu: 250m
+          limits:
+            memory: 96Gi
+            cpu: 64
+        ports:
+        - containerPort: 8000
+        # HTTP probes (GET /healthz), not a bare TCP accept: a pod whose event
+        # loop is starved by a runaway query still accepts TCP but can't answer
+        # HTTP, so a TCP-only probe would keep routing to a wedged backend (#157).
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6

--- a/k8s/cirrus-ingress.yaml
+++ b/k8s/cirrus-ingress.yaml
@@ -1,0 +1,33 @@
+# NOTE: assumes cert-manager (letsencrypt-production ClusterIssuer) and
+# external-dns (Cloudflare, carlboettiger.info zone) are configured on cirrus.
+# external-dns provisions the A record from spec.rules.host; cert-manager mints
+# the TLS cert into mcp-server-duckdb-tls. See ../../k8s (traefik/, cert-manager/,
+# external-dns/) in the boettiger-lab/k8s repo.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-server-duckdb-ingress
+  namespace: mcp
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+    # <namespace>-<name>@kubernetescrd — see cirrus-middleware.yaml.
+    traefik.ingress.kubernetes.io/router.middlewares: mcp-mcp-cors@kubernetescrd
+    traefik.ingress.kubernetes.io/service.servertransport: mcp-mcp-long-timeout@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: duckdb-mcp.carlboettiger.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-server-duckdb
+                port:
+                  number: 8000
+  tls:
+    - hosts:
+        - duckdb-mcp.carlboettiger.info
+      secretName: mcp-server-duckdb-tls

--- a/k8s/cirrus-middleware.yaml
+++ b/k8s/cirrus-middleware.yaml
@@ -1,0 +1,51 @@
+# Traefik CRDs backing the cirrus ingress.
+#
+# On NRP the CORS policy and long timeouts are HAProxy ingress annotations;
+# Traefik expresses the same behaviour as first-class CRDs referenced from the
+# ingress via `router.middlewares` / `service.servertransport`.
+---
+# CORS — mirrors the HAProxy cors-* annotations from ingress.yaml so browser MCP
+# clients (and the mcp-session-id header) keep working through Traefik.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mcp-cors
+  namespace: mcp
+spec:
+  headers:
+    accessControlAllowMethods:
+      - GET
+      - POST
+      - OPTIONS
+    accessControlAllowHeaders:
+      - DNT
+      - X-CustomHeader
+      - Keep-Alive
+      - User-Agent
+      - X-Requested-With
+      - If-Modified-Since
+      - Cache-Control
+      - Content-Type
+      - Authorization
+      - mcp-session-id
+    accessControlAllowOriginList:
+      - "*"
+    accessControlAllowCredentials: true
+    accessControlMaxAge: 86400
+    addVaryHeader: true
+---
+# Long backend timeouts for slow DuckDB queries and long-lived SSE streams — the
+# Traefik equivalent of the timeout-server/timeout-tunnel annotations. This is
+# the same ServersTransport gpu-mcp already uses in this namespace; declared here
+# so the recipe is self-contained and re-applies idempotently.
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: mcp-long-timeout
+  namespace: mcp
+spec:
+  forwardingTimeouts:
+    dialTimeout: 30s
+    idleConnTimeout: 600s
+    readIdleTimeout: 600s
+    responseHeaderTimeout: 600s

--- a/k8s/cirrus-service.yaml
+++ b/k8s/cirrus-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-server-duckdb
+  namespace: mcp
+spec:
+  selector:
+    app: duckdb-mcp
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000


### PR DESCRIPTION
Adds the manifests for a second deploy target — the self-hosted k3s cluster (**cirrus**) — as a sibling to the existing NRP manifests. The deployment is already applied and serving at **duckdb-mcp.carlboettiger.info**; this commits it so it's reproducible from the repo rather than only living as cluster state.

## What
- `k8s/cirrus-deployment.yaml` — `duckdb-mcp`, 2 replicas, pinned to cirrus, reading the on-node MinIO mirror (`minio-svc.minio.svc.cluster.local:9000`, http/path-style), 96Gi memory ceiling for the shared node.
- `k8s/cirrus-service.yaml` — `mcp-server-duckdb` (:8000).
- `k8s/cirrus-ingress.yaml` — Traefik ingress → `duckdb-mcp.carlboettiger.info`.
- `k8s/cirrus-middleware.yaml` — `mcp-cors` Middleware + `mcp-long-timeout` ServersTransport.

## How it differs from NRP
NRP uses HAProxy; cirrus uses **Traefik + cert-manager (letsencrypt-production) + external-dns (Cloudflare)**. The HAProxy CORS annotations become a Traefik `mcp-cors` Middleware, and the long query/SSE timeouts become the shared `mcp-long-timeout` ServersTransport. Backed by in-cluster MinIO instead of NRP Ceph.

## Why
A local self-hosted CPU endpoint independent of NRP, and the **CPU baseline for the DuckDB-vs-GPU benchmark (#42)** — same node, same MinIO backend as the GPU work, for a fair head-to-head.

Verified live: pods ready, TLS issued, DNS resolves, `/healthz` + `/version` OK, STAC catalog loads from MinIO, MCP `query` executes.