### PR TITLE
k8s(prod): promote v0.8.1 by digest (#259 h3 area guidance)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.0@sha256:661d3dd870db6f49b98fdcce036cbd07f01c01ee0f18378a821d5e772e7cdb57
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.1@sha256:c7f7c7bce143e633c9d9040984f7e03d99247d04b0761218f5eca8a1fe627651
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod from v0.8.0 → **v0.8.1**, shipping the #259 `h3_cell_area` units + acres-conversion guidance (validated on qwen3 + DSE-nimbus qwen against dev).

Pin: `v0.8.1@sha256:c7f7c7bce143e633c9d9040984f7e03d99247d04b0761218f5eca8a1fe627651` — image built by docker.yml on the v0.8.1 tag.

After merge: `kubectl apply -f k8s/deployment.yaml` + `kubectl rollout restart deployment/duckdb-mcp -n biodiversity`, then verify all replicas converge on the digest.