### PR TITLE
docs: fix VitePress dead link breaking Pages deploy

### DIFF
--- a/docs/guide/datasets.md
+++ b/docs/guide/datasets.md
@@ -51,7 +51,7 @@ materializing every distinct cell would defeat the fast approximate path — fal
 back to multiplying an approximate count by the nominal constant
 (`APPROX_COUNT_DISTINCT(h8) * 0.737327598`, accurate to ~1–2% globally).
 
-See [h3-guide.md](../../h3-guide.md) for the full area guidance.
+See [`h3-guide.md`](https://github.com/boettiger-lab/mcp-data-server/blob/main/h3-guide.md) for the full area guidance.
 
 ### Cross-dataset joins
 


### PR DESCRIPTION
The h3-guide link added in #295 used a relative path (`../../h3-guide.md`) that points outside the VitePress `docs/` srcDir, failing the dead-link check and the Pages deploy on main. Switch to the GitHub blob URL, matching the convention in `deployment.md`.