### PR TITLE
fix(#285): error on partial S3 credentials instead of silent anonymous downgrade

### DIFF
--- a/server.py
+++ b/server.py
@@ -127,6 +127,18 @@ from s3config import (
 
 @contextmanager
 def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None):
+    # An S3 key without its secret (or vice versa) can't authenticate. Rather
+    # than silently downgrade to anonymous — which yields a confusing 403 on a
+    # private bucket, or ignores the key entirely with no endpoint — fail fast
+    # with the actual cause (#285). Both present = credentialed; neither present
+    # = anonymous (optionally with s3_endpoint for a public mirror).
+    if bool(s3_key) != bool(s3_secret):
+        missing = "s3_secret" if s3_key else "s3_key"
+        raise ValueError(
+            f"{missing} is required: pass both s3_key and s3_secret together for "
+            f"a private bucket, or neither (optionally with s3_endpoint) for an "
+            f"anonymous source."
+        )
     conn = duckdb.connect(database=":memory:")
     try:
         for stmt in (s.strip() for s in SETUP_SQL.split(";") if s.strip()):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -232,14 +232,15 @@ class TestS3Credentials:
             names = [r[0] for r in secrets]
             assert "client_s3" not in names
 
-    def test_partial_credentials_no_secret(self):
-        """Supplying only key or only secret does not create a secret (both required)."""
-        with get_isolated_db(s3_key="AKID") as conn:
-            names = [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
-            assert "client_s3" not in names
-        with get_isolated_db(s3_secret="SECRET") as conn:
-            names = [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
-            assert "client_s3" not in names
+    def test_partial_credentials_raise(self):
+        """Supplying only key or only secret is a clear error, not a silent
+        anonymous downgrade (#285) — both are required together."""
+        with pytest.raises(ValueError, match="s3_secret is required"):
+            with get_isolated_db(s3_key="AKID"):
+                pass
+        with pytest.raises(ValueError, match="s3_key is required"):
+            with get_isolated_db(s3_secret="SECRET"):
+                pass
 
     def test_ssl_disabled_for_rook_endpoint(self):
         """Rook/Ceph internal endpoints get USE_SSL false."""
@@ -296,12 +297,13 @@ class TestAnonymousBYOBucket:
         result = query("SELECT 7 as n", s3_endpoint="minio.example.org", s3_scope="s3://public-")
         assert "7" in result
 
-    def test_endpoint_with_partial_creds_is_anonymous(self):
-        """s3_endpoint + only a key (no secret) still creates a secret (treated anonymous),
-        rather than injecting a half-credential or erroring."""
-        with get_isolated_db(s3_endpoint="minio.example.org", s3_key="ONLY_KEY") as conn:
-            names = [r[0] for r in conn.sql("SELECT name FROM duckdb_secrets()").fetchall()]
-            assert "client_s3" in names
+    def test_endpoint_with_partial_creds_raises(self):
+        """s3_endpoint + only a key (no secret) is an error, not a silent
+        anonymous downgrade (#285). A half-credential can't authenticate, so a
+        private read would otherwise fail with a confusing 403 instead."""
+        with pytest.raises(ValueError, match="s3_secret is required"):
+            with get_isolated_db(s3_endpoint="minio.example.org", s3_key="ONLY_KEY"):
+                pass
 
     def test_no_endpoint_no_creds_still_no_secret(self):
         """The anonymous path must not fire without an endpoint (no accidental secret)."""


### PR DESCRIPTION
Closes #285.

## Problem
In `get_isolated_db`, `credentialed = bool(s3_key and s3_secret)` required **both** creds. Passing exactly one of `{s3_key, s3_secret}` (typo, truncated config, half-populated env) silently dropped the caller's intent to authenticate:

- **with `s3_endpoint`** → built an *anonymous* `client_s3` (`key=""`, `secret=""`), so a private-bucket read was attempted anonymously and returned a confusing **403** with no hint the real cause was a missing secret.
- **without `s3_endpoint`** → the key was ignored entirely and the request fell through to the deployment default secret.

## Fix
A small guard at the top of `get_isolated_db`: if exactly one of `{s3_key, s3_secret}` is present (XOR), raise a clear `ValueError` naming the missing field. Both-present stays credentialed; neither-present stays anonymous (optionally with `s3_endpoint` for a public mirror). Placed before the DuckDB connection opens, so no connection is created for an invalid request.

## Behavior change is confined to a currently-broken path
- **The `query` tool schema is unchanged** — same params/types/defaults. Every MCP client (geo-agent, Claude Code, scripts) sees an identical tool definition, so **no client bump** is needed.
- Both *valid* shapes are untouched: both-present (private) and neither-present (anonymous). Only the XOR case — which **cannot succeed today** (403 or silent wrong-identity) — flips from a confusing downstream failure to an immediate, actionable error. No working client can depend on half-credentials, because they don't work.

## Tests
Flips the two tests that pinned the old silent behavior (added in #267) to assert the error instead:
- `test_partial_credentials_no_secret` → `test_partial_credentials_raise`
- `test_endpoint_with_partial_creds_is_anonymous` → `test_endpoint_with_partial_creds_raises`

Not run locally (project rule: don't import/run `server.py` on the shared pod); `py_compile` passes on both files, CI runs the suite.