### PR TITLE
feat(#270): set DuckDB memory_limit from the pod limit (spill instead of OOM)

### DIFF
--- a/dbconfig.py
+++ b/dbconfig.py
@@ -1,0 +1,86 @@
+"""DuckDB session configuration derived from deployment env.
+
+Companion to s3config.py (which owns the S3 secrets): this owns the non-S3
+`SET` statements whose value depends on the deployment/pod rather than the
+query. Env is read at call time, not import time, so per-connection setup picks
+up changes without a restart and tests can monkeypatch — the same contract as
+s3config.default_s3_secret_sql().
+"""
+import os
+import re
+import sys
+
+from s3config import sql_quote
+
+# Fraction of the pod's memory *limit* DuckDB may use before it spills to
+# temp_directory. The headroom absorbs allocations DuckDB doesn't count against
+# memory_limit (the Python process, httpfs buffers, uvicorn) so the cgroup never
+# OOM-kills the pod — an OOM takes out every co-tenant query on the replica, not
+# just the offender, whereas spilling only makes the one oversized query slower
+# (#270).
+_MEMORY_LIMIT_FRACTION = 0.8
+
+# SI (10^3) and binary (2^10) byte units, plus the k8s "Ki/Mi/Gi/Ti" quantities.
+_BYTE_UNITS = {
+    "": 1, "b": 1,
+    "k": 10**3, "kb": 10**3, "ki": 2**10, "kib": 2**10,
+    "m": 10**6, "mb": 10**6, "mi": 2**20, "mib": 2**20,
+    "g": 10**9, "gb": 10**9, "gi": 2**30, "gib": 2**30,
+    "t": 10**12, "tb": 10**12, "ti": 2**40, "tib": 2**40,
+}
+
+
+def _parse_bytes(text: str) -> int:
+    """Parse a byte count: a plain integer (the Downward API emits bytes) or a
+    k8s/SI quantity like '96Gi', '2Gi', '500Mi', '10G'. Raises ValueError otherwise.
+    """
+    m = re.fullmatch(r"\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]*)\s*", text or "")
+    if not m:
+        raise ValueError(f"unparseable byte quantity: {text!r}")
+    num, unit = m.group(1), m.group(2).lower()
+    if unit not in _BYTE_UNITS:
+        raise ValueError(f"unknown byte unit {unit!r} in {text!r}")
+    return int(float(num) * _BYTE_UNITS[unit])
+
+
+def duckdb_memory_limit() -> str | None:
+    """The DuckDB `memory_limit` value for this pod, or None to leave DuckDB's
+    own default in place.
+
+    Resolution order:
+    - DUCKDB_MEMORY_LIMIT (explicit override) wins, passed through verbatim so an
+      operator can set '120GB', '160GiB', '-1' (unlimited), etc. (DuckDB units:
+      KB/MB/GB/TB or KiB/MiB/GiB/TiB, or -1; no '%' form.)
+    - else POD_MEMORY_LIMIT (wire the pod's cgroup limit in via the Downward API —
+      resourceFieldRef limits.memory): return ~80% of it.
+    - else None. In a plain local run DuckDB sizes itself from detected RAM, which
+      is only unsafe under a container cgroup — where detection can read the node's
+      RAM, not the pod's, and DuckDB allocates past the limit and gets OOM-killed
+      before it ever spills (#270).
+    """
+    explicit = os.environ.get("DUCKDB_MEMORY_LIMIT", "").strip()
+    if explicit:
+        return explicit
+    raw = os.environ.get("POD_MEMORY_LIMIT", "").strip()
+    if not raw:
+        return None
+    try:
+        total = _parse_bytes(raw)
+    except ValueError as e:
+        print(f"⚠️ POD_MEMORY_LIMIT ignored ({e}); using DuckDB's default memory_limit",
+              file=sys.stderr)
+        return None
+    budget_mib = int(total * _MEMORY_LIMIT_FRACTION) // (1024 * 1024)
+    if budget_mib <= 0:
+        return None
+    return f"{budget_mib}MiB"
+
+
+def memory_limit_sql() -> str:
+    """`SET memory_limit=...` for this pod, or '' when unconfigured (caller skips).
+
+    Run on every DuckDB connection (query and tiles) so the spill-not-OOM
+    protection is identical on both paths.
+    """
+    value = duckdb_memory_limit()
+    return f"SET memory_limit='{sql_quote(value)}'" if value else ""

--- a/k8s/cirrus-deployment.yaml
+++ b/k8s/cirrus-deployment.yaml
@@ -48,6 +48,14 @@ spec:
         # MinIO answers; known/inline datasets still work meanwhile (#260).
         - name: STAC_ALLOW_DEGRADED_START
           value: "true"
+        # Pod's cgroup memory limit → DuckDB memory_limit (~80%), so an oversized
+        # query spills to /tmp instead of OOM-killing the replica and every
+        # co-tenant query on it (#270).
+        - name: POD_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: server
+              resource: limits.memory
         resources:
           # Small requests so the pod schedules easily on the shared cirrus node;
           # limits stay generous so large DuckDB queries can still burst. cirrus

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -30,6 +30,14 @@ spec:
           value: "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
         - name: MCP_PUBLIC_BASE_URL
           value: "https://duckdb-mcp.nrp-nautilus.io"
+        # Pod's cgroup memory limit → DuckDB memory_limit (~80%), so an oversized
+        # query spills to /tmp instead of OOM-killing the replica and every
+        # co-tenant query on it (#270).
+        - name: POD_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: server
+              resource: limits.memory
         resources:
           # Requests intentionally kept small (≤2 GiB memory, ≤1 CPU) to land in
           # NRP's "Ignored" bucket for utilization violations. Limits stay high so

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -36,6 +36,14 @@ spec:
         # Dev-only for now; prod keeps the default fail-fast until proven out.
         - name: STAC_ALLOW_DEGRADED_START
           value: "true"
+        # Pod's cgroup memory limit → DuckDB memory_limit (~80%), so an oversized
+        # query spills to /tmp instead of OOM-killing the replica and every
+        # co-tenant query on it (#270).
+        - name: POD_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: server
+              resource: limits.memory
         resources:
           # Requests intentionally kept small (≤2 GiB memory, ≤1 CPU) to land in
           # NRP's "Ignored" bucket for utilization violations. Limits stay high so

--- a/query-setup.md
+++ b/query-setup.md
@@ -35,6 +35,14 @@ fallback for the public source.coop mirror: DuckDB routes
 tools as `s3://us-west-2.opendata.source.coop/cboettig/<dataset>/...`) when the
 primary Ceph endpoint is unavailable.
 
+**Server-applied memory limit.** Beyond the settings above, the server issues
+`SET memory_limit` per connection, sized to ~80% of the pod's memory limit
+(`POD_MEMORY_LIMIT`, wired from the container's cgroup limit via the k8s Downward
+API; override with `DUCKDB_MEMORY_LIMIT`, e.g. `120GB` / `160GiB` / `-1`). An
+oversized query then **spills to `temp_directory` instead of getting OOM-killed**,
+which would otherwise take out every co-tenant query on the replica. It is applied
+by the server, not written into query SQL — do not emit it yourself. (#270)
+
 **Note:** On the default NRP deployment, the server's `s3` secret points at the internal endpoint `rook-ceph-rgw-nautiluss3.rook` (only reachable from inside the k8s cluster; the public external endpoint is `s3-west.nrp-nautilus.io`, which needs `USE_SSL true` and `SET THREADS=2`). A deployment can repoint this default at another backend (e.g. a MinIO mirror) via `S3_DEFAULT_ENDPOINT` without any query changes.
 
 You must read parquet datasets with from S3 using read_parquet().  There are no local tables.

--- a/server.py
+++ b/server.py
@@ -123,6 +123,14 @@ from s3config import (
     source_secret_sql,
     sql_quote as _sql_quote,
 )
+from dbconfig import duckdb_memory_limit, memory_limit_sql
+
+# Cap DuckDB's memory at ~80% of the pod's limit so an oversized query spills
+# instead of OOM-killing the pod (#270); no-op unless POD_MEMORY_LIMIT /
+# DUCKDB_MEMORY_LIMIT is set. Logged once at boot for ops visibility.
+_MEMORY_LIMIT = duckdb_memory_limit()
+if _MEMORY_LIMIT:
+    print(f"DuckDB memory_limit = {_MEMORY_LIMIT} (spill before cgroup OOM)", file=sys.stderr)
 
 
 @contextmanager
@@ -146,6 +154,15 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
                 conn.sql(stmt)
             except Exception as e:
                 print(f"⚠️ Setup statement skipped: {stmt!r}: {e}", file=sys.stderr)
+        # Bound memory to the pod so a big aggregate spills instead of OOM-killing
+        # the replica (#270). Not part of SETUP_SQL: the value is deployment-derived
+        # (dbconfig reads POD_MEMORY_LIMIT/DUCKDB_MEMORY_LIMIT), not model guidance.
+        mem_sql = memory_limit_sql()
+        if mem_sql:
+            try:
+                conn.sql(mem_sql)
+            except Exception as e:
+                print(f"⚠️ memory_limit setup skipped: {mem_sql!r}: {e}", file=sys.stderr)
         # Prefix-scoped secrets for every registry source (#264) — e.g. the
         # anonymous source.coop mirror. Scoped, so they coexist deterministically
         # with both the default `s3` secret and any client_s3 below (longest-

--- a/tests/test_dbconfig.py
+++ b/tests/test_dbconfig.py
@@ -1,0 +1,74 @@
+"""Unit tests for dbconfig — the DuckDB memory_limit derivation (#270)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from dbconfig import _parse_bytes, duckdb_memory_limit, memory_limit_sql
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Each test starts with neither memory var set."""
+    monkeypatch.delenv("DUCKDB_MEMORY_LIMIT", raising=False)
+    monkeypatch.delenv("POD_MEMORY_LIMIT", raising=False)
+
+
+class TestParseBytes:
+    def test_plain_integer_is_bytes(self):
+        # The Downward API emits the limit in bytes as a plain integer.
+        assert _parse_bytes("104857600") == 100 * 2**20
+
+    @pytest.mark.parametrize("text,expected", [
+        ("96Gi", 96 * 2**30),
+        ("2Gi", 2 * 2**30),
+        ("500Mi", 500 * 2**20),
+        ("10G", 10 * 10**9),
+        ("1Ti", 2**40),
+    ])
+    def test_k8s_and_si_quantities(self, text, expected):
+        assert _parse_bytes(text) == expected
+
+    @pytest.mark.parametrize("bad", ["", "abc", "10Xi", "Gi"])
+    def test_unparseable_raises(self, bad):
+        with pytest.raises(ValueError):
+            _parse_bytes(bad)
+
+
+class TestDuckdbMemoryLimit:
+    def test_unset_returns_none(self):
+        assert duckdb_memory_limit() is None
+        assert memory_limit_sql() == ""
+
+    def test_explicit_override_passthrough(self, monkeypatch):
+        monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "120GB")
+        assert duckdb_memory_limit() == "120GB"
+        assert memory_limit_sql() == "SET memory_limit='120GB'"
+
+    def test_explicit_override_wins_over_pod_limit(self, monkeypatch):
+        monkeypatch.setenv("POD_MEMORY_LIMIT", str(96 * 2**30))
+        monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "100GB")
+        assert duckdb_memory_limit() == "100GB"
+
+    def test_pod_limit_bytes_is_80_percent_in_mib(self, monkeypatch):
+        # 100 MiB → 80% = 80 MiB.
+        monkeypatch.setenv("POD_MEMORY_LIMIT", str(100 * 2**20))
+        assert duckdb_memory_limit() == "80MiB"
+        assert memory_limit_sql() == "SET memory_limit='80MiB'"
+
+    def test_pod_limit_k8s_quantity(self, monkeypatch):
+        monkeypatch.setenv("POD_MEMORY_LIMIT", "96Gi")
+        # ~80% of 96 GiB, expressed in MiB.
+        expected_mib = int(96 * 2**30 * 0.8) // 2**20
+        assert duckdb_memory_limit() == f"{expected_mib}MiB"
+
+    def test_unparseable_pod_limit_falls_back_to_none(self, monkeypatch, capsys):
+        monkeypatch.setenv("POD_MEMORY_LIMIT", "not-a-size")
+        assert duckdb_memory_limit() is None
+        assert "POD_MEMORY_LIMIT ignored" in capsys.readouterr().err
+
+    def test_zero_pod_limit_returns_none(self, monkeypatch):
+        monkeypatch.setenv("POD_MEMORY_LIMIT", "0")
+        assert duckdb_memory_limit() is None

--- a/tiles/db.py
+++ b/tiles/db.py
@@ -5,10 +5,12 @@ tile requests never take user credentials, so the connection can be long-lived
 and shared across requests via con.cursor() for per-request isolation.
 """
 import os
+import sys
 
 import duckdb
 
 from s3config import default_s3_secret_sql, source_secret_sql
+from dbconfig import memory_limit_sql
 
 
 def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnection:
@@ -39,6 +41,17 @@ def build_tile_connection(threads: int | None = None) -> duckdb.DuckDBPyConnecti
     con.sql("SET preserve_insertion_order=false")
     con.sql("SET enable_object_cache=true")
     con.sql("SET temp_directory='/tmp'")
+
+    # Bound memory to the pod so a heavy pyramid build spills instead of OOM-killing
+    # the replica (#270); no-op unless POD_MEMORY_LIMIT/DUCKDB_MEMORY_LIMIT is set.
+    # Guarded because the value can come from an operator override (DUCKDB_MEMORY_LIMIT)
+    # — a malformed one shouldn't take down tile serving, just fall back to the default.
+    mem_sql = memory_limit_sql()
+    if mem_sql:
+        try:
+            con.sql(mem_sql)
+        except Exception as e:
+            print(f"⚠️ tile memory_limit setup skipped: {mem_sql!r}: {e}", file=sys.stderr)
 
     # httpfs read tuning. NOTE: the "~126 files per h0 / ~923 files" figure behind
     # the original #190 characterization was a since-fixed GBIF over-sharding bug,


### PR DESCRIPTION
Closes #270.

## Problem
Query pods run with a big memory **limit** and a tiny **request** (overcommit, e.g. request 2Gi / limit 160Gi). With no explicit DuckDB `memory_limit`, DuckDB sizes itself from *detected* RAM — which in a container can read the **node's** RAM rather than the **pod's cgroup limit** — then allocates toward the node and gets **OOM-killed before it ever spills**. An OOM is incompressible: it takes out *every* in-flight query on that replica, not just the offender.

## Fix
New `dbconfig.py` (a non-S3 sibling to `s3config.py`) resolves a `memory_limit`:
- **`DUCKDB_MEMORY_LIMIT`** (explicit override) — passed through verbatim (`120GB`, `160GiB`, `-1`).
- else **`POD_MEMORY_LIMIT`** (the pod's cgroup limit, wired via the k8s Downward API `resourceFieldRef: limits.memory`) → **~80%** of it, leaving headroom for the Python process / httpfs buffers / uvicorn.
- else **`None`** — local dev keeps DuckDB's own default (the detection problem only exists under a cgroup).

`memory_limit_sql()` is applied on **both** connection paths — `query` (`get_isolated_db`) and tiles (`build_tile_connection`) — so an oversized query or pyramid build **spills to `temp_directory` (`/tmp`) and runs slower instead of dying**, protecting co-tenant queries on the replica.

Wired `POD_MEMORY_LIMIT` into the **prod (160Gi)**, **dev (160Gi)**, and **cirrus (96Gi)** deployments. Derived values verified against DuckDB 1.5.4: 160Gi→`128.0 GiB`, 96Gi→`76.7 GiB`.

## Scope / caveats (from the issue)
- **Primary win only:** a single oversized query spills instead of OOM-killing the replica. Node-level contention across pods is still bounded separately by the existing `MCP_QUERY_CONCURRENCY` limiter — out of scope here.
- **Spill target:** `temp_directory='/tmp'`. `/tmp` is the container's writable layer (node ephemeral storage / overlayfs), **not** a `medium: Memory` emptyDir, so spill lands on disk as intended. No manifest mounts tmpfs over `/tmp`.
- DuckDB `memory_limit` is a strong mitigation, not an absolute guarantee — some operators spill imperfectly.
- **DuckDB 1.5.4 rejects the `%` form** for `memory_limit` (only `KB/MB/GB/TB`, `KiB/MiB/GiB/TiB`, `-1`), so the derived value is emitted in `MiB` and the override docs avoid `%`. The tile-path `SET` is guarded so a malformed operator override can't crash tile serving.

## Behavior / compatibility
- **No-op** on any deployment that sets neither env var (existing tests, local runs).
- **No `query` tool schema change** — client-transparent.
- `query-setup.md` documents it in **prose only**; that prose is not injected into any model (only the fenced \`\`\`sql\`\`\` block becomes `SETUP_SQL`), and the SQL block is unchanged — so this does not touch an injected prompt artifact and doesn't require the headless guidance-validation gate.

## Tests
`tests/test_dbconfig.py` — unit tests for `_parse_bytes` (plain bytes + k8s/SI quantities + rejects), the resolution order (override > pod-limit > none), the 80%/MiB math, and unparseable/zero fallbacks. `py_compile` clean on all changed files; the server suite is left to CI (project rule: don't import/run `server.py` on the shared pod).