### PR TITLE
k8s(prod): promote v0.8.2 by digest (#270 memory_limit)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.1@sha256:c7f7c7bce143e633c9d9040984f7e03d99247d04b0761218f5eca8a1fe627651
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.2@sha256:2fa1baa1822f7d99f7b921c00363cb58f73d0799a1d31a6eb268405d762e6cb7
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod to **v0.8.2** — DuckDB `memory_limit` from the pod limit so an oversized query spills instead of OOM-killing the replica (#270).

- Image: `ghcr.io/boettiger-lab/mcp-data-server:v0.8.2@sha256:2fa1baa1822f7d99f7b921c00363cb58f73d0799a1d31a6eb268405d762e6cb7`
- Digest confirmed against GHCR's registry `docker-content-digest` for tag `v0.8.2` (matches the build run's reported digest).
- `k8s/deployment.yaml` also already carries the new `POD_MEMORY_LIMIT` Downward-API env (merged in #298); this apply brings the digest + env together. Prod is 160Gi → DuckDB `memory_limit` resolves to 128 GiB (verified on dev, which is also 160Gi: `DuckDB memory_limit = 131072MiB`).

Validated on dev: rolled out `:main` (git_sha a73a3194), `/healthz` 200, `/version` OK, memory_limit applied at startup.

Rollout after merge: `kubectl apply -f k8s/deployment.yaml && kubectl rollout restart deployment/duckdb-mcp -n biodiversity`, then confirm all 6 replicas converge on the digest.