### PR TITLE
ci(gh-pages): bump Node to 22 and Pages actions off deprecated Node 20

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -37,10 +37,10 @@ jobs:
         run: npm run docs:build
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/.vitepress/dist
 
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
The docs deploy logged a deprecation warning: `actions/configure-pages` and a nested `actions/upload-artifact@v4` target the now-deprecated Node 20 runtime (being force-run on Node 24).

Bumps, all SHA-pinned to match repo convention:
- `actions/configure-pages` v5 → **v6.0.0** (Node 24)
- `actions/upload-pages-artifact` v3.0.1 → **v5.0.0** (pulls in the newer nested upload-artifact)
- `actions/deploy-pages` v4.0.5 → **v5.0.0**
- docs-build `node-version` 20 → **22** (LTS)

Interfaces are unchanged (`path` input, `deploy-pages` usage). The gh-pages workflow only runs on push to `main`, so it can't run on this PR — the real check is the deploy after merge, which I'll watch to confirm it's green and the Node 20 warning is gone.