### PR TITLE
fix(#303): dedup per-column descriptions across assets in get_stac_details

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -159,9 +159,54 @@ def _is_queryable_asset(href: str, atype: str) -> bool:
     )
 
 
+def _asset_column_summary(table_cols: list) -> str:
+    """One-line `` `name` (type) `` list of an asset's columns (geometry included).
+
+    The per-asset delta view (#303): it makes each queryable asset's column set
+    unambiguous — which asset carries the hex's `h0/h8/h10`, which one keeps
+    `geometry` — without repeating every column's prose. The full descriptions
+    and categorical `values` live once in the shared block appended by
+    `_extract_parquet_assets`.
+    """
+    parts = []
+    for c in table_cols:
+        name = c.get("name")
+        if not name:
+            continue
+        t = c.get("type")
+        parts.append(f"`{name}` ({t})" if t else f"`{name}`")
+    return ", ".join(parts)
+
+
+def _any_queryable_asset_has_columns(col) -> bool:
+    """True if any queryable asset carries its own `table:columns`.
+
+    Gates the collection-level `Key columns` trailer (#303): when assets are
+    self-describing, the shared per-asset block already covers every column, so
+    the trailer would be a redundant copy. It stays only as the sole source for
+    collections that describe columns solely at the collection level (e.g.
+    census sub-datasets whose hex assets carry no `table:columns`).
+    """
+    for asset in (col.assets or {}).values():
+        if not _is_queryable_asset(asset.href, asset.media_type or ""):
+            continue
+        if asset.extra_fields.get("table:columns"):
+            return True
+    return False
+
+
 def _extract_parquet_assets(col) -> list[str]:
-    """Extract parquet/hex asset lines (with inline column schemas) from a collection's assets."""
+    """Extract parquet/hex asset lines from a collection's assets.
+
+    Column *descriptions* are deduplicated (#303): rather than reprinting every
+    column's prose once per asset — 2-3× on the common flat-GeoParquet + hex
+    dataset, which pushed the largest schemas past geo-agent's 16k tool-result
+    cap and truncated them — each asset line lists only its own column
+    names/types, and every column's description + categorical `values` is
+    rendered exactly once in a shared block appended after the asset lines.
+    """
     assets = []
+    shared_cols: dict = {}  # name -> col dict, in first-seen order (union of all assets)
     for asset_id, asset in (col.assets or {}).items():
         href = asset.href
         atype = asset.media_type or ""
@@ -201,11 +246,30 @@ def _extract_parquet_assets(col) -> list[str]:
                 ext_val = asset.extra_fields.get(ext_key)
                 if ext_val is not None:
                     assets.append(f"    - {ext_key}: {ext_val}")
-            # Inline per-asset column schema if present
+            # Per-asset column *set* only (names/types); descriptions are shared below.
             asset_cols = asset.extra_fields.get("table:columns", [])
-            col_lines = _format_columns(asset_cols)
-            if col_lines:
-                assets.extend(col_lines)
+            summary = _asset_column_summary(asset_cols)
+            if summary:
+                assets.append(f"    - columns: {summary}")
+            # Accumulate the union for the single shared description block. First
+            # asset to define a name wins; later assets backfill any field it was
+            # missing (description/values/type) so the block is maximally complete.
+            for c in asset_cols:
+                name = c.get("name")
+                if not name:
+                    continue
+                if name not in shared_cols:
+                    shared_cols[name] = dict(c)
+                else:
+                    existing = shared_cols[name]
+                    for k in ("description", "values", "type"):
+                        if not existing.get(k) and c.get(k):
+                            existing[k] = c[k]
+
+    block = _format_columns(list(shared_cols.values()))
+    if block:
+        assets.append("\nColumn descriptions (shared across the assets above):")
+        assets.extend(block)
     return assets
 
 
@@ -242,8 +306,12 @@ def _format_collection(col, sub_children: list = None) -> str:
     # Collect parquet assets from this level
     parquet_assets = _extract_parquet_assets(col)
 
-    # Column schema from this level
-    col_lines = _extract_columns(col)
+    # Collection-level "Key columns" trailer, kept ONLY as a fallback (#303):
+    # when queryable assets are self-describing, `_extract_parquet_assets` already
+    # renders every column once, so this would be a redundant 2nd/3rd copy. It
+    # survives solely for collections that describe columns at the collection
+    # level and nowhere else (e.g. census sub-datasets).
+    col_lines = [] if _any_queryable_asset_has_columns(col) else _extract_columns(col)
 
     # Check for sub-children — some collections (wyoming-wildlife-lands,
     # pad-us, census) group sub-datasets as child collections, each with

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1368,6 +1368,102 @@ class TestFormatColumnsFullRender:
             assert v in rendered, f"value {v!r} missing from rendered output"
 
 
+class TestFlatHexColumnDedup:
+    """Per-asset column descriptions are rendered once, not once-per-asset (#303).
+
+    The common flat-GeoParquet + hex dataset shares most attribute descriptions
+    across both assets; reprinting them per asset inflated the largest schemas
+    past geo-agent's 16k tool-result cap and truncated them. Descriptions now
+    live in a single shared block; each asset line carries only its column set.
+    """
+
+    def _make_flat_plus_hex(self):
+        col = MagicMock()
+        col.id, col.title, col.description = "nci-frontiers", "NCI Frontiers", "d"
+        col.extra_fields = {}
+        col.get_self_href.return_value = None
+
+        shared = [
+            {"name": "id", "type": "varchar", "description": "Unique feature identifier"},
+            {"name": "area_km2", "type": "double", "description": "Feature area in square kilometres"},
+            {"name": "category", "type": "varchar", "description": "Conservation category",
+             "values": ["core", "buffer"]},
+        ]
+
+        flat = MagicMock()
+        flat.href = "https://s3-west.nrp-nautilus.io/public-nci/frontiers/data.parquet"
+        flat.media_type = "application/x-parquet"
+        flat.title, flat.description = "GeoParquet", None
+        flat.extra_fields = {"table:columns": shared + [
+            {"name": "geometry", "type": "geometry", "description": "Feature geometry"},
+        ]}
+
+        hex_a = MagicMock()
+        hex_a.href = "https://s3-west.nrp-nautilus.io/public-nci/frontiers/hex/"
+        hex_a.media_type = "application/x-parquet"
+        hex_a.title = "hex"
+        hex_a.description = "One row per (feature, hex cell); dedup by `id` before aggregating."
+        hex_a.extra_fields = {
+            "h3:native_resolution": 10,
+            "table:columns": shared + [
+                {"name": "h0", "type": "ubigint", "description": "H3 parent cell at resolution 0 (partition key)"},
+                {"name": "h8", "type": "ubigint", "description": "H3 cell at resolution 8"},
+                {"name": "h10", "type": "ubigint", "description": "H3 cell at native resolution 10"},
+            ],
+        }
+        col.assets = {"data": flat, "hex": hex_a}
+        return col
+
+    def test_shared_description_rendered_once(self):
+        col = self._make_flat_plus_hex()
+        md = _format_collection(col, sub_children=[])
+        assert md.count("Feature area in square kilometres") == 1
+        assert md.count("Conservation category") == 1
+
+    def test_per_asset_column_set_is_unambiguous(self):
+        """Each asset line lists its own columns; the hex's h0/h8/h10 delta and the
+        flat asset's geometry are both visible without repeating descriptions."""
+        col = self._make_flat_plus_hex()
+        md = _format_collection(col, sub_children=[])
+        assert "read_parquet('s3://public-nci/frontiers/data.parquet')" in md
+        assert "read_parquet('s3://public-nci/frontiers/hex/**')" in md
+        # The hex partition keys appear on the hex asset's column line
+        for h in ("`h0`", "`h8`", "`h10`"):
+            assert h in md
+        assert "`geometry`" in md  # flat asset keeps geometry in its column set
+        # The hex's per-feature dedup note still reaches the prompt
+        assert "dedup by `id`" in md
+
+    def test_h3_partition_key_description_present_once(self):
+        col = self._make_flat_plus_hex()
+        md = _format_collection(col, sub_children=[])
+        assert md.count("H3 parent cell at resolution 0 (partition key)") == 1
+
+    def test_no_key_columns_trailer_when_assets_self_describe(self):
+        """Collection-level `Key columns` trailer is dropped once per-asset columns
+        cover everything — it was the redundant 3rd copy."""
+        col = self._make_flat_plus_hex()
+        # Even if the collection also carries table:columns, the trailer is suppressed.
+        col.extra_fields = {"table:columns": [
+            {"name": "id", "type": "varchar", "description": "Unique feature identifier"},
+        ]}
+        md = _format_collection(col, sub_children=[])
+        assert "Key columns:" not in md
+
+    def test_collection_level_columns_kept_when_assets_have_none(self):
+        """Fallback: a collection whose queryable asset carries no table:columns
+        (e.g. census sub-datasets) still surfaces its collection-level schema."""
+        col = self._make_flat_plus_hex()
+        col.assets["data"].extra_fields = {}
+        col.assets["hex"].extra_fields = {"h3:native_resolution": 10}
+        col.extra_fields = {"table:columns": [
+            {"name": "SLDUST", "type": "varchar", "description": "Senate district ID"},
+        ]}
+        md = _format_collection(col, sub_children=[])
+        assert "Key columns:" in md
+        assert "SLDUST" in md
+
+
 class TestInlineCollectionContent:
     """Inline `collection=` / `catalog=` parameters bypass the HTTP fetch — caller
     hands the already-loaded JSON over instead of letting the server re-fetch via


### PR DESCRIPTION
Closes #303.

## Problem

`_format_collection` (the renderer behind `get_stac_details`, `get_schema`'s inline forward, and `get_dataset`) reprinted **every column's description once per queryable asset**. On the common **flat GeoParquet + hex** dataset each shared attribute description landed 2–3× — once under the flat `read_parquet(...)`, once under the hex, and a third time via the collection-level `Key columns` trailer (`_extract_columns`).

`get_schema` (~4.4k calls / 3 months, vs 540 `get_stac_details`, 63 `get_collection`) is the dominant metadata channel, so this is where the model gets its schema. The duplication was not just tokens: three schemas (`nci-frontiers`, `ace-terrestrial-biodiversity-summary`, `ca30x30-conserved-areas-terrestrial-2025`) sat at exactly **16,016 chars = geo-agent's `TOOL_RESULT_CAP = 16000` + truncation marker** — cut off, so the model never saw the tail columns and fabricated / broke SQL.

## Fix (render-time only)

- **Per-asset lines** now list only that asset's column **names/types**, keeping the set unambiguous — which asset carries the hex's `h0/h8/h10`, which keeps `geometry`, plus the per-feature dedup note.
- **One shared "Column descriptions" block** renders each column's prose + categorical `values` exactly once (union across assets; first-seen wins, later assets backfill missing fields).
- The collection-level **`Key columns` trailer is dropped** when any queryable asset carries its own `table:columns`, and **kept only as the sole fallback** for collections that describe columns at the collection level alone (e.g. census sub-datasets).
- Per-asset `table:columns` on disk is **unchanged** — assets stay self-describing; publishers / `verify-stac` unaffected.

`_collection_to_dict` (get_collection, structured JSON) is intentionally left as-is: its per-asset columns are meant to round-trip through the inline `collection=` parameter, and it isn't the truncating channel.

## Verification

- A ~55-column flat+hex schema that previously truncated now renders in **8,922 chars** (< 16k), each description **once**, with `h0/h8/h10` and the dedup note intact.
- New `TestFlatHexColumnDedup` covers: shared description once, per-asset set unambiguous, no trailer when assets self-describe, trailer kept as fallback.
- Full suite: **364 passed**.

## Cross-refs

geo-agent companion (repoint `extractColumns` to per-asset; the 16k cap) and publisher-side backfill (data-workflows #404 / #369 / #356) tracked separately.