### PR TITLE
fix(#305): compact parent-collection index — defer child columns to per-child calls

### DIFF
--- a/stac.py
+++ b/stac.py
@@ -195,7 +195,7 @@ def _any_queryable_asset_has_columns(col) -> bool:
     return False
 
 
-def _extract_parquet_assets(col) -> list[str]:
+def _extract_parquet_assets(col, compact: bool = False) -> list[str]:
     """Extract parquet/hex asset lines from a collection's assets.
 
     Column *descriptions* are deduplicated (#303): rather than reprinting every
@@ -204,6 +204,14 @@ def _extract_parquet_assets(col) -> list[str]:
     cap and truncated them — each asset line lists only its own column
     names/types, and every column's description + categorical `values` is
     rendered exactly once in a shared block appended after the asset lines.
+
+    *compact* (#305): emit only each asset's ``read_parquet(...)`` path, routing
+    hint, description, and extension fields — NO per-asset column names and NO
+    shared description block. Used by the parent/sub-dataset index, where the
+    columns would re-dump every child's schema (20-50k parent payloads over the
+    16k cap) and duplicate what the per-child ``get_stac_details`` call returns.
+    The caller appends an explicit per-child "call get_stac_details(<id>)"
+    pointer instead.
     """
     assets = []
     shared_cols: dict = {}  # name -> col dict, in first-seen order (union of all assets)
@@ -246,6 +254,10 @@ def _extract_parquet_assets(col) -> list[str]:
                 ext_val = asset.extra_fields.get(ext_key)
                 if ext_val is not None:
                     assets.append(f"    - {ext_key}: {ext_val}")
+            # Per-asset columns are omitted in compact mode (parent index, #305):
+            # the caller adds a per-child get_stac_details pointer instead.
+            if compact:
+                continue
             # Per-asset column *set* only (names/types); descriptions are shared below.
             asset_cols = asset.extra_fields.get("table:columns", [])
             summary = _asset_column_summary(asset_cols)
@@ -266,10 +278,11 @@ def _extract_parquet_assets(col) -> list[str]:
                         if not existing.get(k) and c.get(k):
                             existing[k] = c[k]
 
-    block = _format_columns(list(shared_cols.values()))
-    if block:
-        assets.append("\nColumn descriptions (shared across the assets above):")
-        assets.extend(block)
+    if not compact:
+        block = _format_columns(list(shared_cols.values()))
+        if block:
+            assets.append("\nColumn descriptions (shared across the assets above):")
+            assets.extend(block)
     return assets
 
 
@@ -322,10 +335,15 @@ def _format_collection(col, sub_children: list = None) -> str:
         lines.append(f"\n**Sub-datasets ({len(sub_children)}):**\n")
         for sc in sub_children:
             sc_title = sc.title or sc.id
-            sc_parquet = _extract_parquet_assets(sc)
+            # Compact render (#305): paths + extensions only, no columns. The
+            # parent index is a chooser — inlining every child's schema re-dumped
+            # the whole bucket (20-50k payloads over the 16k cap) and duplicated
+            # what the per-child get_stac_details call returns anyway.
+            sc_parquet = _extract_parquet_assets(sc, compact=True)
             if sc_parquet:
                 lines.append(f"*{sc_title}* (`{sc.id}`):")
                 lines.extend(sc_parquet)
+                lines.append(f"  - columns: call get_stac_details('{sc.id}')")
         lines.append(f"\nCall get_stac_details with a sub-dataset ID (e.g. `{sub_children[0].id}`) for column schemas and details.")
     elif parquet_assets:
         lines.append("\nSQL data (use with `query` tool):")

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -230,6 +230,80 @@ class TestChildCollectionIndexing:
             assert "SLDUST" in result
 
 
+class TestCompactParentIndex:
+    """Parent-collection index is a compact chooser (#305): it lists each child's
+    path + a `get_stac_details(<id>)` pointer, and does NOT inline child column
+    schemas — which re-dumped the whole bucket (20-50k parent payloads over
+    geo-agent's 16k cap) and duplicated the per-child call.
+
+    Uses a realistic fixture where children carry *per-asset* `table:columns`
+    (production layout), unlike the census fixture whose columns sit at the
+    collection level — that fixture masked the pre-#305 behavior.
+    """
+
+    def _make_parent_with_column_bearing_children(self):
+        def _child(cid, title, col_desc):
+            c = MagicMock()
+            c.id, c.title, c.description = cid, title, "d"
+            c.extra_fields = {}
+            c.get_self_href.return_value = None
+            asset = MagicMock()
+            asset.href = f"https://s3-west.nrp-nautilus.io/public-x/{cid}/hex/"
+            asset.media_type = "application/x-parquet"
+            asset.title, asset.description = "hex", None
+            asset.extra_fields = {
+                "h3:native_resolution": 8,
+                "table:columns": [
+                    {"name": "VALUE", "type": "double", "description": col_desc},
+                    {"name": "h8", "type": "ubigint", "description": "H3 cell at resolution 8"},
+                    {"name": "h0", "type": "ubigint", "description": "H3 partition key"},
+                ],
+            }
+            c.assets = {"hex": asset}
+            return c
+        parent = MagicMock()
+        parent.id, parent.title, parent.description = "widgets", "Widgets", "grouping"
+        parent.assets, parent.extra_fields, parent.links = {}, {}, []
+        parent.get_self_href.return_value = None
+        c1 = _child("widget-blue", "Blue Widgets", "COUNT_OF_BLUE_WIDGETS_UNIQUE_STRING")
+        c2 = _child("widget-red", "Red Widgets", "COUNT_OF_RED_WIDGETS_UNIQUE_STRING")
+        return parent, [c1, c2]
+
+    def test_parent_omits_child_column_descriptions(self):
+        parent, subs = self._make_parent_with_column_bearing_children()
+        md = _format_collection(parent, sub_children=subs)
+        # child descriptions and the shared block must NOT appear in the parent
+        assert "COUNT_OF_BLUE_WIDGETS_UNIQUE_STRING" not in md
+        assert "COUNT_OF_RED_WIDGETS_UNIQUE_STRING" not in md
+        assert "Column descriptions (shared" not in md
+        # nor the per-asset `- columns:` names line
+        assert "- columns: `VALUE`" not in md
+
+    def test_parent_lists_children_with_paths_and_pointer(self):
+        parent, subs = self._make_parent_with_column_bearing_children()
+        md = _format_collection(parent, sub_children=subs)
+        assert "**Sub-datasets (2):**" in md
+        assert "`widget-blue`" in md and "`widget-red`" in md
+        # child read_parquet path present (chooser can still see where data lives)
+        assert "read_parquet('s3://public-x/widget-blue/hex/**')" in md
+        # explicit per-child pointer to fetch columns
+        assert "columns: call get_stac_details('widget-blue')" in md
+        assert "columns: call get_stac_details('widget-red')" in md
+
+    def test_child_rendered_alone_still_shows_full_columns(self):
+        """The per-child get_stac_details (leaf render) is unchanged — full schema."""
+        parent, subs = self._make_parent_with_column_bearing_children()
+        leaf = _format_collection(subs[0], sub_children=[])
+        assert "COUNT_OF_BLUE_WIDGETS_UNIQUE_STRING" in leaf
+        assert "Column descriptions (shared" in leaf
+
+    def test_parent_index_is_small(self):
+        parent, subs = self._make_parent_with_column_bearing_children()
+        md = _format_collection(parent, sub_children=subs)
+        # compact chooser stays tiny relative to the full inlined render
+        assert len(md) < 1500
+
+
 class TestCollectionToDict:
     """Unit tests for _collection_to_dict."""
 


### PR DESCRIPTION
Closes #305.

## Problem

`get_stac_details` on a **parent** collection inlined **every child's full column schema**, even though the same output ends with "Call `get_stac_details` with a sub-dataset ID … for column schemas." The parent index — a chooser — thus re-dumped the whole bucket, over the 16k `TOOL_RESULT_CAP`, duplicating what the per-child call returns:

| parent | before | after |
|---|--:|--:|
| pad-us-4.1 | 49.9k | **4.4k** |
| high-seas | 45.1k | **11.4k** |
| ca30x30 | 38.7k | **12.6k** |
| us-census | 21.8k | **3.1k** |

## Change

`_extract_parquet_assets(col, compact=True)` emits only each asset's `read_parquet(...)` path + routing hint + description + extension fields — no per-asset column names, no shared description block. The sub-children branch of `_format_collection` uses it and appends an explicit per-child `columns: call get_stac_details('<child-id>')` pointer. Leaf render (per-child `get_stac_details`) and `_collection_to_dict` are unchanged.

Example (3-child parent, ~1.1k):
```
**Sub-datasets (3):**

*2024 State Boundaries* (`census-2024-state`):
  - GeoParquet: `read_parquet('s3://public-census/census-2024/state.parquet')`
  - hex: `read_parquet('s3://public-census/census-2024/state/hex/**')`
    - h3:native_resolution: 8
  - columns: call get_stac_details('census-2024-state')
…
```

## Risk — log-checked before changing behavior

Two weeks of prod traffic (581 query-sessions, 3,107 schema calls):
- Parent ids are **1.0%** of schema calls (31/3107); apps address child/leaf IDs directly and use the parent only as a browse/chooser step (`browse → collection(parent) → schema(child)`).
- **0 of 581** query-sessions queried using only-parent schema — every real query had a leaf `get_stac_details` first. The lone borderline per-dataset case in 2 weeks (`pad-us-4.1 → combined.parquet` with well-known `Unit_Nm/GIS_Acres/GAP_Sts`) still works via a one-call leaf round-trip, which the explicit pointer now signposts.

So deferring child columns has negligible real-world impact, and the compact chooser still shows each child's `read_parquet(...)` path.

## Tests

`TestCompactParentIndex` (4 cases) with a **realistic per-asset-columns fixture** — the census fixture stored columns at the collection level, which masked this behavior. Asserts: parent omits child descriptions / shared block / per-asset `- columns:` line; lists each child's path + pointer; leaf render still shows full columns; parent stays small. Full suite: **368 passed**.

## Cross-refs

- #303 (leaf per-column dedup, shipped) — made the leaf lean; this makes the parent index lean.
- data-workflows #407 (bucket-of-datasets restructure) — depends on this: restructuring is moot while the parent re-dumps children.