### PR TITLE
k8s(prod): promote v0.8.3 by digest (#303 get_stac_details dedup)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.2@sha256:2fa1baa1822f7d99f7b921c00363cb58f73d0799a1d31a6eb268405d762e6cb7
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.3@sha256:b510755a1a4f41afe789f53f15a7756a1e9ad1000903f996519fd3d3f8463e68
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod `duckdb-mcp` from v0.8.2 → **v0.8.3**, pinned by digest `sha256:b510755a…`.

**Ships:** #303 (PR #304) — `get_stac_details`/`get_schema` per-column dedup. Only `stac.py` changed since v0.8.2 (rest was docs/CI).

**Verified on dev before promoting:**
- 2 of 3 formerly-truncated flat+hex schemas now render full under the 16k cap (ace 11.5k, ca30x30 14.6k); 0 duplicated descriptions; no legacy `Key columns` trailer.
- Regression-tested under qwen (curated ca-30x30 catalog): Q1–Q3 exact gold matches, Q4 legend correct — as good or better than the pre-change baseline; all aggregation guidance preserved.

**Rollout:** digest-pinned, `imagePullPolicy: IfNotPresent` — apply + rollout after merge.

Follow-ups tracked separately: #305 (compact parent index, PR #306) and data-workflows #407 (bucket-of-datasets restructure).