### PR TITLE
k8s(prod): promote v0.8.4 by digest (#305 compact parent index)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.3@sha256:b510755a1a4f41afe789f53f15a7756a1e9ad1000903f996519fd3d3f8463e68
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.4@sha256:3ee750ea370e4e6aef4be6c63041016b92caaa84c6f27ddb1287e393a45ea4ee
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod `duckdb-mcp` v0.8.3 → **v0.8.4**, pinned by digest `sha256:3ee750ea…`.

**Ships:** #305 (PR #306) — parent-collection `get_stac_details` is now a compact chooser; child column schemas deferred to per-child calls. Only `stac.py` changed since v0.8.3.

**Verified on dev:**
- Parent payloads: us-census 21.8k→3.5k, pad-us-4.1 49.9k→4.7k, ca30x30 38.7k→13.1k — all under the 16k cap, each child carrying a `get_stac_details(<id>)` pointer.
- Leaf schemas unchanged; ca-30x30 gold set regression-clean under qwen (Q1–Q3 ~exact, Q5/Q6 improved vs prior run).
- Parent-routing probes (districts-per-state, PAD-US-by-GAP) went straight to child collections — deferring child columns is a no-op for the query path (matches logs: parents = 1% of schema calls, browse/chooser only).

**Rollout:** digest-pinned, `IfNotPresent` — apply + rollout after merge.