### PR TITLE
guidance(h3): fractional-coverage assets + partial-coverage overlay (CWHR13 Q4 fix)

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -230,20 +230,49 @@ Raster datasets are converted to hex by assigning each **pixel** its H3 cell —
 
 **DISTINCT does not help here** — you genuinely need to aggregate the values.
 
-**✅ CORRECT: Always GROUP BY and aggregate raster datasets**
+**Always GROUP BY and aggregate raster datasets.**
 ```sql
--- Continuous values (carbon, biomass, etc.) → SUM or AVG
-SELECT h8, h0, SUM(value) as total
-FROM read_parquet('<STAC_HEX_PATH>')
+-- Continuous values (carbon, biomass, elevation) → SUM or AVG
+SELECT h8, h0, SUM(value) AS total
+FROM read_parquet('<hex>')
 GROUP BY h8, h0
 
--- Categorical values (land cover, etc.) → use MODE (most frequent class)
-SELECT h8, h0, MODE(class) as dominant_class
-FROM read_parquet('<STAC_HEX_PATH>')
+-- Categorical, dominant class per cell (map styling, "what's here") → MODE
+SELECT h8, h0, MODE(class) AS dominant_class
+FROM read_parquet('<mode hex>')
 GROUP BY h8, h0
 ```
 
-Check the dataset's STAC description — it will note when aggregation is required and which method (SUM, AVG, or MODE) to use.
+Check the dataset's STAC description — it notes when aggregation is required and which method (SUM, AVG, or MODE) to use.
+
+For categorical **area or composition** ("how much of class X", "percent of the region that is X"), MODE is the wrong tool: a cell holds several classes and MODE keeps only the winner, biasing per-class areas in both directions. Categorical layers increasingly ship a companion **`*-hex-fractions`** asset — a long schema with one `(class, frac)` row per class present in a cell, where `frac` is that class's fractional coverage of the cell, in (0,1]. When it exists (check `get_schema`), use it and weight area by `frac`:
+
+```sql
+SELECT class, SUM(frac * h3_cell_area(h10, 'km^2')) AS area_km2
+FROM read_parquet('<hex-fractions>')
+WHERE class <> <nodata>          -- exclude the no-data class; get its code from get_schema
+GROUP BY class;
+```
+
+`get_schema` names the fractions asset and the no-data code. Per cell `SUM(frac) <= 1`; the shortfall is outside-raster/quantization, so do not treat the layer as covering 100% of a cell.
+
+**Overlaying two partial-coverage layers — multiply the coverage fractions; never count a cell as all-or-nothing.** *(Skip unless you are intersecting a fractional-coverage layer with another layer that only partly covers its cells — e.g. "what percent of each habitat class is conserved".)* Treating a cell as fully inside the other layer whenever it matches over-counts every partly-covered cell. Weight by the coverage fraction on **both** sides. The other layer's per-cell weight is either its own `frac`, or — for a vector layer tiled from features — a per-feature coverage share its STAC documents (e.g. ca30x30 conserved-areas: a unit's GAP 1+2 share is `Acres / Total_Acre`). Reduce to one weight per cell (`MAX` over the features on it), then multiply:
+
+```sql
+WITH cell_w AS (   -- per cell: covering unit's GAP 1+2 coverage share (STAC-documented overlay weight)
+  SELECT h10, h0, MAX(Acres / NULLIF(Total_Acre, 0)) AS w
+  FROM (SELECT DISTINCT h10, h0, _cng_fid, Acres, Total_Acre
+        FROM read_parquet('<conserved-areas hex>'))
+  GROUP BY h10, h0
+)
+SELECT f.whr13num,
+       100 * SUM(f.frac * COALESCE(c.w, 0)) / SUM(f.frac) AS pct_conserved
+FROM read_parquet('<cwhr13 hex-fractions>') f
+LEFT JOIN cell_w c ON f.h10 = c.h10 AND f.h0 = c.h0
+WHERE f.whr13num <> 0
+GROUP BY f.whr13num
+ORDER BY pct_conserved;
+```
 
 **If you plan to mask this result against another hex dataset:** put the
 `SEMI JOIN` on the raw `read_parquet(...)` *before* `GROUP BY`, not in a


### PR DESCRIPTION
Fixes the CWHR13 "% conserved" answer family (Q4/Q5), which ran systematically high because `h3-guide.md` Problem 3 was stale after data-workflows #394 made fractional-coverage hex assets standard for the ca-30x30 categorical layers.

## What was wrong
- Problem 3 taught **categorical → MODE** as *the* method. MODE per-class area is biased; and nothing covered the fractional-coverage (`*-hex-fractions`/`frac`) companions #394 shipped.
- No general pattern for **overlaying two partial-coverage layers** → models treated conserved-cell membership as all-or-nothing (binary), over-counting every partially-conserved cell. CWHR13 %-conserved came out ~5–12 pts high.

## Change (h3-guide.md Problem 3 only)
1. **MODE scoped to dominant-class / styling.** For categorical **area/composition**, use the `*-hex-fractions` asset and weight area by `frac` (check `get_schema`; exclude the no-data class).
2. **New gated overlay pattern:** multiply the coverage fraction on **both** sides; the other layer's per-cell weight is its own `frac` or a per-feature coverage share its STAC documents (ca30x30 conserved-areas: `Acres/Total_Acre`). Reduce to one weight per cell (MAX), then multiply.

## Correctness
The overlay SQL in the guidance **reproduces the gold CWHR13 %-conserved table exactly** (Hardwood Woodland 13.6%, Desert Woodland 56.7%, Desert Shrub 48.2%, … all 13 match), verified against live data.

## Layering (AGENTS.md)
General hex pattern → `h3-guide.md`. The cwhr13 STAC already documents `frac` well (unchanged); no stale STAC guidance found working against this. No ❌ blocks; positive framing; overlay gated with a Skip header.

## Validation
Per AGENTS.md, this prompt-artifact change will be validated on the **dev open-model suite** (CWHR13 trap + standing baseline, multi-model) before any prod promotion. Prod stays pinned at v0.8.4 until validation is clean.