### PR TITLE
guidance(h3): fractional overlay applies to single-class questions too

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -274,6 +274,8 @@ GROUP BY f.whr13num
 ORDER BY pct_conserved;
 ```
 
+Asking about **one** class ("what percent of hardwood woodland is conserved") is the same query with `WHERE f.whr13num = <code>` — keep the `frac × weight` product. Joining to the *distinct conserved cells* instead (a `SEMI JOIN` on `(h10, h0)`) counts every partly-conserved cell as fully conserved and overstates the percentage.
+
 **If you plan to mask this result against another hex dataset:** put the
 `SEMI JOIN` on the raw `read_parquet(...)` *before* `GROUP BY`, not in a
 CTE after it. Aggregation blocks DuckDB's dynamic partition pruning, so a


### PR DESCRIPTION
Follow-up to #309, from its dev validation.

**What validation showed:** qwen + qwen3 both produced the gold CWHR13 %-conserved **breakdown** (Q4) via the new fractional overlay — the primary trap is fixed. But qwen, on the **single-class** phrasing ('what % of hardwood woodland is conserved', Q5), dropped the overlay and used a binary `SEMI JOIN` on distinct conserved cells → 25.3% vs gold 13.6% (over-counts every partly-conserved cell).

**Fix:** one clause in the overlay note making explicit that the single-class case is the same `frac × weight` product with a `WHERE` filter, and that a `SEMI JOIN` to distinct conserved cells overstates it. (+2 lines, no new SQL block.)

Re-validated on dev before prod.