### PR TITLE
k8s(prod): promote v0.8.5 by digest (#309/#310 fractional-coverage guidance)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.4@sha256:3ee750ea370e4e6aef4be6c63041016b92caaa84c6f27ddb1287e393a45ea4ee
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.5@sha256:9369c5ae90d6dcc35999e02f5dfef8f0fda8a0f7e54bd3fc13ea0865d2c62692
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod `duckdb-mcp` v0.8.4 → **v0.8.5**, digest `sha256:9369c5ae…`. Ships the `h3-guide.md` fractional-coverage + partial-coverage overlay guidance (#309, #310). Only h3-guide.md changed since v0.8.4.

**Dev validation (curated ca-30x30 catalog, per AGENTS.md):**
| | Q1–Q3 baseline | Q4 breakdown | Q5 single-class |
|---|---|---|---|
| qwen | ✅ clean | ✅ 48.3% Desert Shrub (gold 48.2%) | ✅ 13.95% (gold 13.6%) |
| qwen3 | ✅ clean | ✅ gold-match | ✅ 13.6% |
| glm-5 | ✅ clean | ⚠️ provider timeout | ⚠️ provider timeout |

Targeted trap (binary-overlap over-count, Q4 was ~33%, Q5 25.3%) fixed for both working models; no baseline regression; glm-5 failures are endpoint timeouts, not guidance. Overlay SQL independently verified to reproduce the gold CWHR13 table exactly.