### PR TITLE
Accept s3_region and s3_url_style on query for BYO AWS buckets

### DIFF
--- a/server.py
+++ b/server.py
@@ -134,7 +134,7 @@ if _MEMORY_LIMIT:
 
 
 @contextmanager
-def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None):
+def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None, s3_region: str = None, s3_url_style: str = None):
     # An S3 key without its secret (or vice versa) can't authenticate. Rather
     # than silently downgrade to anonymous — which yields a confusing 403 on a
     # private bucket, or ignores the key entirely with no endpoint — fail fast
@@ -187,13 +187,20 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
             key = s3_key if credentialed else ""
             secret = s3_secret if credentialed else ""
             use_ssl = infer_use_ssl(endpoint)
+            # URL_STYLE defaults to 'path' (correct for Ceph/MinIO); REGION is
+            # omitted unless given. A bring-your-own AWS-hosted bucket needs both
+            # knobs — the built-in source_coop registry entry needed exactly
+            # REGION + url_style to work (#286).
+            url_style = s3_url_style or "path"
+            region_clause = f", REGION '{_sql_quote(s3_region)}'" if s3_region else ""
             scope_clause = f", SCOPE '{_sql_quote(s3_scope)}'" if s3_scope else ""
             # Credentials (if any) injected here; intentionally not logged.
             conn.sql(
                 f"CREATE OR REPLACE SECRET client_s3 ("
                 f"TYPE S3, KEY_ID '{_sql_quote(key)}', SECRET '{_sql_quote(secret)}', "
-                f"ENDPOINT '{_sql_quote(endpoint)}', URL_STYLE 'path', USE_SSL '{use_ssl}'"
-                f"{scope_clause})"
+                f"ENDPOINT '{_sql_quote(endpoint)}', URL_STYLE '{_sql_quote(url_style)}', "
+                f"USE_SSL '{use_ssl}'"
+                f"{region_clause}{scope_clause})"
             )
         # Default S3 endpoint — server-owned and per-deployment configurable (#268),
         # built by s3config (shared with the tile subsystem). Lets you deploy this
@@ -289,11 +296,11 @@ def analyst_persona() -> str:
 # -------------------------------------------------------------------------
 # 8. TOOL DEFINITION — SQL Query
 # -------------------------------------------------------------------------
-def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None) -> str:
+def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint: str = None, s3_scope: str = None, s3_region: str = None, s3_url_style: str = None) -> str:
     """Placeholder (overwritten below)."""
     print(f"🔍 Executing: {sql_query}", file=sys.stderr)
     try:
-        with get_isolated_db(s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope) as db:
+        with get_isolated_db(s3_key=s3_key, s3_secret=s3_secret, s3_endpoint=s3_endpoint, s3_scope=s3_scope, s3_region=s3_region, s3_url_style=s3_url_style) as db:
             result = db.sql(sql_query)
             if result is None: return "Command executed successfully."
 
@@ -331,6 +338,7 @@ BEFORE writing any SQL:
 For private data, pass s3_key, s3_secret, and optionally s3_endpoint and s3_scope alongside the SQL query.
 For an anonymous public source (e.g. a read-only mirror), pass s3_endpoint alone (no key/secret) with s3_scope — useful to read a mirror like s3://public-* from a backup endpoint when the primary is unavailable.
 Use s3_scope (e.g. 's3://private-wyoming' or 's3://public-') so DuckDB routes those paths to your endpoint rather than the server default; supply it whenever a query mixes sources.
+For a bring-your-own AWS-hosted bucket, also pass s3_region (e.g. 'us-west-2') and, if the bucket needs it, s3_url_style ('path' by default, or 'vhost'); the defaults suit Ceph/MinIO.
 WITHOUT s3_scope, your endpoint/credentials apply to EVERY s3:// path in the query and the server-default endpoint is disabled for this request — fine for a query touching only your bucket, wrong for a query mixing your bucket with catalog data. When mixing, always pass s3_scope.
 Credentials, when given, are scoped to this request only and never persisted.
 
@@ -353,10 +361,13 @@ async def _query_tool(
     s3_secret: str = None,
     s3_endpoint: str = None,
     s3_scope: str = None,
+    s3_region: str = None,
+    s3_url_style: str = None,
 ) -> str:
     # Mirrors query()'s signature so FastMCP derives the identical tool schema.
     return await anyio.to_thread.run_sync(
         query, sql_query, s3_key, s3_secret, s3_endpoint, s3_scope,
+        s3_region, s3_url_style,
         limiter=_QUERY_LIMITER,
     )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -373,6 +373,49 @@ class TestUnscopedClientRouting:
             assert "client_s3" in self._names(conn)
 
 
+class TestClientS3RegionUrlStyle:
+    """A bring-your-own AWS-hosted bucket needs REGION and (optionally) a
+    virtual-hosted URL_STYLE on the per-request client_s3 secret — the defaults
+    ('path', no region) suit Ceph/MinIO but break on AWS (#286)."""
+
+    def _secret_string(self, conn):
+        return conn.sql(
+            "SELECT secret_string FROM duckdb_secrets() WHERE name='client_s3'"
+        ).fetchone()[0]
+
+    def test_region_set_on_secret(self):
+        with get_isolated_db(
+            s3_endpoint="s3.us-west-2.amazonaws.com", s3_region="us-west-2"
+        ) as conn:
+            assert "region=us-west-2" in self._secret_string(conn)
+
+    def test_no_region_by_default(self):
+        """Backward-compat: without s3_region the secret carries no region."""
+        with get_isolated_db(s3_endpoint="minio.example.org") as conn:
+            assert "region=" not in self._secret_string(conn)
+
+    def test_url_style_defaults_to_path(self):
+        with get_isolated_db(s3_endpoint="minio.example.org") as conn:
+            assert "url_style=path" in self._secret_string(conn)
+
+    def test_url_style_vhost(self):
+        with get_isolated_db(
+            s3_endpoint="s3.us-west-2.amazonaws.com", s3_url_style="vhost"
+        ) as conn:
+            assert "url_style=vhost" in self._secret_string(conn)
+
+    def test_query_with_region_and_url_style_succeeds(self):
+        """query accepts the AWS knobs without error."""
+        result = query(
+            "SELECT 9 as n",
+            s3_endpoint="s3.us-west-2.amazonaws.com",
+            s3_scope="s3://mybucket",
+            s3_region="us-west-2",
+            s3_url_style="vhost",
+        )
+        assert "9" in result
+
+
 class TestSourceRegistrySecrets:
     """Registry sources (s3config, #264) get prefix-scoped secrets on every
     query connection — built-ins and S3_SOURCES env additions alike."""
@@ -497,7 +540,8 @@ class TestTileRouteMounted:
         assert "query" in tools
         assert tools["query"].description == query.__doc__
         assert sorted(tools["query"].inputSchema["properties"]) == [
-            "s3_endpoint", "s3_key", "s3_scope", "s3_secret", "sql_query",
+            "s3_endpoint", "s3_key", "s3_region", "s3_scope", "s3_secret",
+            "s3_url_style", "sql_query",
         ]
 
     def test_query_tool_matches_sync_core(self):


### PR DESCRIPTION
## Summary

Closes #286 (deferred smaller item split out of #271).

The per-request `client_s3` secret built in `get_isolated_db` hardcoded `URL_STYLE 'path'` and never set `REGION`. That's correct for Ceph/MinIO but wrong for a bring-your-own **AWS-hosted** bucket: the built-in `source_coop` registry entry needed exactly `REGION` + `url_style` to reach `s3.us-west-2.amazonaws.com`, and a per-request BYO AWS bucket had no way to supply either — the failure surfaced as a confusing DuckDB HTTP error.

This adds optional scalar `s3_region` and `s3_url_style` params to `query` (option (a) in the issue). The structured `s3_sources` alternative (option (b)) remains tracked in #284; these scalars stay as the one-source shorthand when it lands.

## Changes

- `get_isolated_db`: new `s3_region` / `s3_url_style` params. `URL_STYLE` now uses the supplied value (default `'path'`); `REGION` is appended only when given — mirroring the optional-REGION pattern already in `s3config.source_secret_sql`. Both apply to the credentialed and anonymous `client_s3` cases.
- `query` and `_query_tool`: thread the two params through (appended after `s3_scope`), so the FastMCP tool schema picks them up. Docstring gains one line for the AWS-bucket case.
- Tests: new `TestClientS3RegionUrlStyle` covering region set / defaulted-off, url_style vhost / default-path, and a smoke query; updated the tool-schema pin test for the two new properties.

Defaults reproduce today's behavior exactly, so the change is fully backward-compatible.

## Verification

`pytest tests/` — 373 passed. (No local-server path per AGENTS.md; end-to-end against dev is the branch-deploy step.)