### PR TITLE
k8s(prod): promote v0.8.6 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.5@sha256:9369c5ae90d6dcc35999e02f5dfef8f0fda8a0f7e54bd3fc13ea0865d2c62692
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.6@sha256:db04aef3d3d4165ab839d75247eef379382ea2bc47f5f09c43a6a401f7c86145
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes production (`k8s/deployment.yaml`) to **v0.8.6**, pinned by digest.

- Image: `ghcr.io/boettiger-lab/mcp-data-server:v0.8.6@sha256:db04aef3d3d4165ab839d75247eef379382ea2bc47f5f09c43a6a401f7c86145`
- Digest verified against GHCR; docker build smoke-test (httpfs/spatial/h3) passed.

### Shipped since v0.8.5
- #317 — re-instate hex tileset `metadata.json` tile-host route (un-revert #287), fixes #316
- #313 — accept `s3_region` / `s3_url_style` on `query` for BYO AWS buckets
- #314 — CITATION.cff, code of conduct, contributing guide

Already deployed and verified on dev (`git_sha 0eee054`).