### PR TITLE
fix(#321): unify SQL arg name — accept sql/sql_query on both tools

### DIFF
--- a/server.py
+++ b/server.py
@@ -356,15 +356,21 @@ _QUERY_LIMITER = anyio.CapacityLimiter(int(os.environ.get("MCP_QUERY_CONCURRENCY
 
 
 async def _query_tool(
-    sql_query: str,
+    sql_query: str = None,
     s3_key: str = None,
     s3_secret: str = None,
     s3_endpoint: str = None,
     s3_scope: str = None,
     s3_region: str = None,
     s3_url_style: str = None,
+    sql: str = None,
 ) -> str:
-    # Mirrors query()'s signature so FastMCP derives the identical tool schema.
+    # Accept `sql` as an alias for `sql_query`. register_hex_tiles's required param
+    # is `sql`, so in a hex workflow models reuse that name here and eat an
+    # avoidable rejection+retry (#321). Whichever name arrives, run the query.
+    sql_query = sql_query or sql
+    if not sql_query:
+        return "SQL Error: no query provided — pass the SQL as `sql_query` (the alias `sql` is also accepted)."
     return await anyio.to_thread.run_sync(
         query, sql_query, s3_key, s3_secret, s3_endpoint, s3_scope,
         s3_region, s3_url_style,
@@ -686,18 +692,29 @@ def register_hex_tiles(
 
 
 async def _register_hex_tiles_tool(
-    sql: str,
+    sql: str = None,
     agg: str = "COUNT",
     finest_res: int | None = None,
     min_res: int = 2,
     zoom_offset: int = 2,
     color_scale: str = "linear",
     layer_style: str = "fill",
+    sql_query: str = None,
 ) -> dict:
     # Served MCP tool. register_hex_tiles is sync (and the directly-tested core);
     # FastMCP would run a sync tool inline on the uvicorn event loop, where its
     # S3 marker I/O + bounded inline build-wait block /healthz and every other
     # request (#176). Offload it to a worker thread so the loop stays free.
+    #
+    # Accept `sql_query` as an alias for `sql` — the mirror of the alias `query`
+    # accepts (#321) — so the two SQL tools agree on either name and models don't
+    # eat a retry when they carry one name over from the other tool.
+    sql = sql or sql_query
+    if not sql:
+        return {
+            "status": "failed",
+            "error": "no query provided — pass the SQL as `sql` (the alias `sql_query` is also accepted).",
+        }
     return await anyio.to_thread.run_sync(
         register_hex_tiles, sql, agg, finest_res, min_res, zoom_offset, color_scale, layer_style
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -541,7 +541,7 @@ class TestTileRouteMounted:
         assert tools["query"].description == query.__doc__
         assert sorted(tools["query"].inputSchema["properties"]) == [
             "s3_endpoint", "s3_key", "s3_region", "s3_scope", "s3_secret",
-            "s3_url_style", "sql_query",
+            "s3_url_style", "sql", "sql_query",
         ]
 
     def test_query_tool_matches_sync_core(self):
@@ -551,6 +551,51 @@ class TestTileRouteMounted:
         sync_result = server.query(sql)
         async_result = anyio.run(server._query_tool, sql)
         assert async_result == sync_result
+
+    def test_query_tool_accepts_sql_alias(self):
+        """query accepts `sql` as an alias for `sql_query` — register_hex_tiles's
+        param name — so models don't eat a retry when they carry it over (#321)."""
+        import anyio, server
+        via_alias = anyio.run(
+            lambda: server._query_tool(sql="SELECT 1 AS one")
+        )
+        via_canonical = anyio.run(
+            lambda: server._query_tool(sql_query="SELECT 1 AS one")
+        )
+        assert via_alias == via_canonical
+        assert "SQL Error" not in via_alias
+
+    def test_query_tool_missing_sql_errors_clearly(self):
+        """Neither name supplied → a clear error, not an unhandled TypeError."""
+        import anyio, server
+        result = anyio.run(lambda: server._query_tool())
+        assert "SQL Error" in result and "sql_query" in result
+
+    def test_register_hex_tiles_accepts_sql_query_alias(self):
+        """register_hex_tiles accepts `sql_query` as an alias for `sql` — the
+        mirror of query's alias — so the two SQL tools agree on either name (#321)."""
+        import anyio, server
+        called = {}
+
+        def fake_register(sql, *a, **k):
+            called["sql"] = sql
+            return {"status": "done"}
+
+        orig = server.register_hex_tiles
+        server.register_hex_tiles = fake_register
+        try:
+            anyio.run(
+                lambda: server._register_hex_tiles_tool(sql_query="SELECT h8 FROM t")
+            )
+        finally:
+            server.register_hex_tiles = orig
+        assert called["sql"] == "SELECT h8 FROM t"
+
+    def test_register_hex_tiles_missing_sql_errors_clearly(self):
+        """Neither name supplied → a failed status with a clear message."""
+        import anyio, server
+        result = anyio.run(lambda: server._register_hex_tiles_tool())
+        assert result["status"] == "failed" and "sql" in result["error"]
 
     def test_query_tool_keeps_event_loop_responsive(self):
         """While the wrapped (blocking) query runs in a worker thread, the event


### PR DESCRIPTION
Fixes #321.

## Problem
The two SQL tools required **different** names for the same argument:
- `register_hex_tiles` → required param **`sql`**
- `query` → required param **`sql_query`**

In a hex workflow, models call `register_hex_tiles({sql: …})` then reuse `sql` on `query`, which rejected it and forced a retry with `sql_query`. Per the issue's open-llm-proxy evidence this is version-independent (a schema-naming problem, not a client regression) and the single most common avoidable retry in the hex flow; weaker models sometimes never recover in-budget.

## Fix
Make the two tools agree on the argument name — server-side, since every MCP consumer hits this:
- `query` now accepts **`sql`** as an alias for `sql_query`.
- `register_hex_tiles` now accepts **`sql_query`** as an alias for `sql`.

Either name works on either tool. When neither name is supplied, each tool returns a clear error message instead of a schema-validation failure.

## Tests
- `query`'s tool input schema now exposes both `sql` and `sql_query`.
- New tests: alias round-trips to the same result on `query`; `sql_query` alias reaches the core on `register_hex_tiles`; missing-SQL yields a clear error on each.
- Full suite: 99 passed.
