### PR TITLE
fix(#326): stop MCP schema titles from leaking internal wrapper names

### DIFF
--- a/server.py
+++ b/server.py
@@ -380,6 +380,12 @@ async def _query_tool(
 
 # Register the async wrapper under the tool name, reusing the sync function's
 # docstring as the LLM-facing description (mirroring the hex-tool pattern, #185).
+# Name the wrapper after the PUBLIC tool so FastMCP derives a clean input-schema
+# title ("queryArguments"), not "_query_toolArguments": func_metadata builds the
+# args model as f"{func.__name__}Arguments", and weak models (qwen) read that
+# leaked internal name off inputSchema.title and call it as if it were the tool,
+# getting "Unknown tool" (#326).
+_query_tool.__name__ = "query"
 mcp.tool(name="query", description=query.__doc__)(_query_tool)
 
 # -------------------------------------------------------------------------
@@ -722,6 +728,9 @@ async def _register_hex_tiles_tool(
 
 # Register the async wrapper under the tool name, reusing the sync function's
 # docstring as the LLM-facing description (the wrapper mirrors its signature).
+# See the query registration above: rename the wrapper so the schema title is
+# "register_hex_tilesArguments", not the leaked "_register_hex_tiles_toolArguments" (#326).
+_register_hex_tiles_tool.__name__ = "register_hex_tiles"
 mcp.tool(name="register_hex_tiles", description=register_hex_tiles.__doc__)(
     _register_hex_tiles_tool
 )
@@ -875,6 +884,8 @@ async def _get_hex_tile_status_tool(
         await anyio.sleep(min(2.0, max(0.1, deadline - time.time())))
 
 
+# Clean schema title ("get_hex_tile_statusArguments") — see query registration (#326).
+_get_hex_tile_status_tool.__name__ = "get_hex_tile_status"
 mcp.tool(name="get_hex_tile_status", description=get_hex_tile_status.__doc__)(
     _get_hex_tile_status_tool
 )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -544,6 +544,22 @@ class TestTileRouteMounted:
             "s3_url_style", "sql", "sql_query",
         ]
 
+    def test_served_tool_schema_titles_dont_leak_wrapper_name(self):
+        """The async wrappers (_query_tool, _register_hex_tiles_tool, ...) must not
+        leak their internal names into inputSchema.title. FastMCP derives the title
+        as f'{func.__name__}Arguments', so a wrapper named `_query_tool` yields
+        `_query_toolArguments` — which weak models read as if it were the tool name
+        and try to call (getting 'Unknown tool'). Titles must derive from the
+        public tool name instead (#326)."""
+        from server import mcp
+        import anyio
+        tools = {t.name: t for t in anyio.run(mcp.list_tools)}
+        for name in ("query", "register_hex_tiles", "get_hex_tile_status"):
+            title = tools[name].inputSchema.get("title", "")
+            assert not title.startswith("_"), f"{name} title leaks wrapper name: {title!r}"
+            assert "_tool" not in title, f"{name} title leaks wrapper name: {title!r}"
+            assert title == f"{name}Arguments", f"{name} title is {title!r}"
+
     def test_query_tool_matches_sync_core(self):
         """The async wrapper returns the same payload as the sync query()."""
         import anyio, server


### PR DESCRIPTION
Fixes #326.

## Problem
The three tools offloaded to async wrappers in #176/#185 leaked their internal wrapper names into the MCP `inputSchema.title`:

| tool | leaked title |
|---|---|
| `query` | `_query_toolArguments` |
| `register_hex_tiles` | `_register_hex_tiles_toolArguments` |
| `get_hex_tile_status` | `_get_hex_tile_status_toolArguments` |

FastMCP builds the arguments model as `f"{func.__name__}Arguments"` (`mcp/server/fastmcp/utilities/func_metadata.py:259`). The tool *name* is set explicitly via `name=`, but the schema *title* still derived from the wrapper's `__name__`.

Weak models read that leaked title and call it **as if it were the tool name**. Observed live on dev (dse-nimbus `qwen`, `show california carbon as hex`): the model twice emitted a call to `_register_hex_tiles_toolArguments` → `Unknown tool`, burning turns. Distinct from the arg-name issue in #321.

## Fix
Set each wrapper's `__name__` to its public tool name before `mcp.tool(name=…)(wrapper)`, so titles derive cleanly: `queryArguments` / `register_hex_tilesArguments` / `get_hex_tile_statusArguments`.

Added `test_served_tool_schema_titles_dont_leak_wrapper_name` asserting no served-tool title starts with `_` or contains `_tool`. Full suite: 100 passed.

## Note on the question that prompted this
The `register_hex_tiles` parameter surface itself is *not* over-complex — only `sql`, `agg`, `color_scale`, `layer_style` are documented to the model (`finest_res`/`min_res`/`zoom_offset` are deliberately hidden). The confusion was the leaked schema title, not the args.
