### PR TITLE
k8s(prod): promote v0.8.7 by digest (#321 arg-alias, #322/#325 h0-guidance, #326 schema-title)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.6@sha256:db04aef3d3d4165ab839d75247eef379382ea2bc47f5f09c43a6a401f7c86145
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.7@sha256:0001e40966a360032181538c52c4a7d321759ceecd839008ec2ec934670bb4e2
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod `duckdb-mcp` from v0.8.6 to **v0.8.7**, pinned by digest `sha256:0001e409…` (verified against the GHCR `:v0.8.7` manifest; validation confirmed the method reproduces the currently-pinned v0.8.6 digest exactly).

## Included since v0.8.6
- **#321** — `query` and `register_hex_tiles` accept both `sql` and `sql_query` (eliminates the most common hex-workflow retry)
- **#322 / #325** — h3-guide: `h0` is a partition key, never a boundary; region-subset section leads with the paraphrase-robust `hN IN (SELECT hN FROM <mask> WHERE <attr>)` form
- **#326** — MCP `inputSchema.title` no longer leaks the async-wrapper name (weak models were calling `_register_hex_tiles_toolArguments` → 'Unknown tool')
- **#319** — strip H3 index/partition columns from `value_columns`

## Validation (dev, qwen, identical A/B)
| | before | after |
|---|---|---|
| CA carbon-as-hex | 15 calls, 259s, 5 errors, 2 tool-name leaks | 5 calls, 31s, 0 errors, 0 leaks |
| FL carbon-as-hex | 6 calls, 38s, 1 error | 5 calls, 39s, 0 errors |

Both clip to real state extents on the first `register_hex_tiles` call.

After merge: `kubectl apply -f k8s/deployment.yaml -n biodiversity` + rollout.