### PR TITLE
feat(#331): register_hex_tiles agg=COUNT_DISTINCT (species richness)

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -423,3 +423,19 @@ Example SQL shape for the `sql` parameter:
 The tool handles pyramiding (coarser hexes at lower zooms) and partitioned
 parquet storage automatically. Repeat calls with identical inputs return the
 same URL — natural caching.
+
+**Species richness (distinct count per hex):** for a richness map — distinct
+species per cell, e.g. from GBIF — use `agg="COUNT_DISTINCT"`, NOT `COUNT`.
+Plain `COUNT` measures sampling effort (occurrence density), not richness.
+The SQL returns the H3 index then the key to count distinctly:
+
+    SELECT h5, specieskey
+    FROM read_parquet('s3://public-gbif/.../hex/h0=*/data_0.parquet', hive_partitioning = true)
+    WHERE <coordinate-quality filters>   -- see the gbif STAC data-quality note
+    GROUP BY h5, specieskey
+
+Call `register_hex_tiles(sql=..., agg="COUNT_DISTINCT")`. Distinct-count is not
+pyramid-composable (siblings share species, so a parent's richness can't be
+summed from its children), so it is **exact at the finest resolution** and rolls
+up coarser levels with `MAX` — a lower bound that under-counts at low zoom but
+never over-counts. The result carries a `rollup_note` spelling this out.

--- a/server.py
+++ b/server.py
@@ -579,6 +579,13 @@ def register_hex_tiles(
         - "AVG" / "SUM" / "MIN" / "MAX": SQL must return at least one
           numeric value column after the H3 index; each is aggregated by
           `agg` at every coarser level.
+        - "COUNT_DISTINCT": SQL must return a KEY column after the H3 index
+          (the thing counted distinctly, e.g. specieskey for species
+          richness). Output property is that column, holding the distinct
+          count per hex. Exact at the finest resolution; coarser pyramid
+          levels roll up with MAX, a lower bound (see `rollup_note` in the
+          result). Use this for richness maps — NOT plain COUNT, which
+          measures sampling effort, not distinct species.
     - `color_scale`: "linear" (default) or "log". Controls how the viridis
       ramp is spread across the data domain in the returned recipe; the tiles
       themselves are identical either way. Use "log" for right-skewed data
@@ -634,6 +641,17 @@ def register_hex_tiles(
 
        Call agg="AVG" (or the matching op). The SEMI JOIN must sit on the
        raw read_parquet(), upstream of GROUP BY — see h3-guide.md Problem 2.
+
+    3. Distinct-count per hex (e.g. species richness — distinct species
+       per cell, NOT occurrence count):
+
+       SELECT h<H>, specieskey                 -- H3 index, then the key to count
+       FROM read_parquet('<hex_path>', hive_partitioning = true)
+       WHERE <coordinate-quality filters>      -- see the gbif STAC data-quality note
+       GROUP BY h<H>, specieskey               -- pre-dedup optional; the agg does the distinct
+
+       Call agg="COUNT_DISTINCT". Exact at the finest resolution; coarser
+       levels are a MAX-based lower bound (result carries `rollup_note`).
 
     Always pass hive_partitioning = true so the planner can prune h0=* files.
     """

--- a/tests/test_tile_pyramid.py
+++ b/tests/test_tile_pyramid.py
@@ -171,6 +171,33 @@ class TestBuildPyramidStatements:
         assert 'SUM("v2" * __pyramid_weight) / SUM(__pyramid_weight) AS "v2"' in stmts[1]
         assert "SUM(__pyramid_weight) AS __pyramid_weight" in stmts[1]
 
+    def test_count_distinct_mode_finest_exact_parents_max(self):
+        # #331: COUNT_DISTINCT is exact at the finest level and rolls up with
+        # MAX (a lower bound) because distinct-count is not pyramid-composable.
+        stmts = build_pyramid_statements(
+            user_sql="SELECT h5, specieskey FROM src",
+            finest_res=5, min_res=2, agg="COUNT_DISTINCT",
+            value_columns=["specieskey"], h3_column="h5",
+            output_uri="s3://public-output/hex/abc/",
+        )
+        # Phase 1: exact distinct count of the key, aliased back to the key name.
+        assert 'COUNT(DISTINCT "specieskey") AS "specieskey"' in stmts[0]
+        # Parents: MAX rollup (never SUM — that would double-count shared keys).
+        for s in stmts[1:]:
+            assert 'MAX("specieskey") AS "specieskey"' in s
+            assert "SUM(" not in s
+
+    def test_count_distinct_requires_value_columns(self):
+        # Like the other value aggs, COUNT_DISTINCT needs a key column — the
+        # thing to count distinctly. Empty value_columns must raise.
+        with pytest.raises(ValueError, match="value column"):
+            build_pyramid_statements(
+                user_sql="SELECT h5 FROM src",
+                finest_res=5, min_res=2, agg="COUNT_DISTINCT",
+                value_columns=[], h3_column="h5",
+                output_uri="s3://public-output/hex/abc/",
+            )
+
     def test_invalid_agg_raises(self):
         import pytest
         with pytest.raises(ValueError, match="agg must be one of"):
@@ -404,6 +431,46 @@ class TestRegisterHexTiles:
         for key in ("hash", "bounds", "finest_res", "min_res", "value_columns",
                     "value_stats", "layer_name", "feature_count_finest"):
             assert second[key] == first[key], f"{key} differs across cache hit"
+
+    def test_count_distinct_exact_at_finest_lower_bound_at_parent(self, local_bucket, h3_conn):
+        # #331: species-richness case. Two res-6 sibling cells sharing a res-5
+        # parent, sharing one species. Finest richness must be EXACT; the parent
+        # must NOT double-count the shared species (SUM would give 4) — MAX
+        # rollup yields a lower bound of 2.
+        kids = h3_conn.sql(
+            "SELECT UNNEST(h3_cell_to_children(h3_latlng_to_cell(37.8, -122.3, 5), 6)) AS h6"
+        ).fetchall()
+        a, b = kids[0][0], kids[1][0]
+        # Cell A species {1,2}; Cell B species {2,3}. True parent distinct = 3.
+        user_sql = f"""
+            SELECT h6, specieskey FROM (VALUES
+              ({a}::UBIGINT, 1), ({a}::UBIGINT, 2),
+              ({b}::UBIGINT, 2), ({b}::UBIGINT, 3)
+            ) t(h6, specieskey)
+        """
+        result = register_hex_tiles(
+            con=h3_conn, sql=user_sql, finest_res=6, min_res=5,
+            agg="COUNT_DISTINCT", zoom_offset=-1,
+        )
+        # The key column is the value column, and the rollup caveat is surfaced.
+        assert result["value_columns"] == ["specieskey"]
+        assert "rollup_note" in result and "lower bound" in result["rollup_note"]
+
+        base = local_bucket / "hex" / result["hash"]
+        finest = dict(h3_conn.sql(
+            f"SELECT h, specieskey FROM "
+            f"read_parquet('{base}/res=6/**/*.parquet', hive_partitioning=true)"
+        ).fetchall())
+        # Exact distinct count per finest cell: 2 species each.
+        assert finest[a] == 2 and finest[b] == 2
+        # Parent (res=5): MAX(2, 2) = 2 — a lower bound, and crucially NOT the
+        # SUM-of-children 4 that would double-count the shared species.
+        parent = h3_conn.sql(
+            f"SELECT specieskey FROM "
+            f"read_parquet('{base}/res=5/**/*.parquet', hive_partitioning=true)"
+        ).fetchall()
+        assert len(parent) == 1
+        assert parent[0][0] == 2
 
     def test_auto_detect_raises_on_empty_sql(self, local_bucket, h3_conn):
         # SQL filters to zero rows — auto-detect can't sample a cell.

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -64,7 +64,7 @@ def build_pyramid_statements(
     so parent rollups produce correctly weighted averages instead of an
     unweighted mean-of-means.
     """
-    _VALID_AGG = {"AVG", "SUM", "MIN", "MAX", "COUNT"}
+    _VALID_AGG = {"AVG", "SUM", "MIN", "MAX", "COUNT", "COUNT_DISTINCT"}
     agg_upper = agg.upper()
     if agg_upper not in _VALID_AGG:
         raise ValueError(f"agg must be one of {_VALID_AGG}, got {agg!r}")
@@ -89,6 +89,20 @@ def build_pyramid_statements(
         phase2_values = ", ".join(f'MIN("{c}") AS "{c}"' for c in value_columns)
     elif agg_upper == "MAX":
         phase1_values = ", ".join(f'MAX("{c}") AS "{c}"' for c in value_columns)
+        phase2_values = ", ".join(f'MAX("{c}") AS "{c}"' for c in value_columns)
+    elif agg_upper == "COUNT_DISTINCT":
+        # Distinct-count per hex (e.g. species richness). NOT re-aggregatable:
+        # a parent's distinct count can't be derived from its children's counts
+        # because sibling children share keys (#331). So this is exact only at
+        # the finest level; parents use MAX as a defensible lower bound.
+        # Phase 1: exact distinct count of each key column, grouped by (h, h0).
+        phase1_values = ", ".join(
+            f'COUNT(DISTINCT "{c}") AS "{c}"' for c in value_columns
+        )
+        # Phase 2: MAX up the pyramid. A parent's true richness is >= its
+        # largest child, so MAX never overstates (unlike SUM, which would
+        # double-count keys shared across siblings) — a lower bound at coarse
+        # zoom. See render_recipe / value_stats note and h3-guide.md.
         phase2_values = ", ".join(f'MAX("{c}") AS "{c}"' for c in value_columns)
     else:  # AVG
         # Phase 1: average raw source rows + carry COUNT for weighted parents.
@@ -262,6 +276,25 @@ def render_recipe(
     return {"source": source, "layer": layer}
 
 
+# COUNT_DISTINCT is exact only at the finest resolution; coarser levels roll up
+# with MAX, a lower bound (see build_pyramid_statements, #331). Surface this in
+# the result so a caller styling coarse zooms knows the values under-count.
+_COUNT_DISTINCT_ROLLUP_NOTE = (
+    "COUNT_DISTINCT is exact at the finest resolution (finest_res); coarser "
+    "pyramid levels roll up with MAX, a lower bound on the true distinct count "
+    "(a parent's richness is at least its largest child, but siblings may share "
+    "keys). Values are accurate at high zoom and under-count at low zoom."
+)
+
+
+def _rollup_note(agg: str) -> str | None:
+    """Human-facing caveat about rollup fidelity for aggs whose coarse levels
+    are not exact. None when the agg is exact at every level."""
+    if agg.upper() == "COUNT_DISTINCT":
+        return _COUNT_DISTINCT_ROLLUP_NOTE
+    return None
+
+
 def _json_dumps_escaped(obj) -> str:
     # DuckDB's COPY ... (FORMAT CSV, QUOTE '') writes the raw string. We must
     # escape any single quotes in the JSON so they don't break the SQL literal.
@@ -415,6 +448,9 @@ def cached_result_dict(plan: dict, cached: dict) -> dict:
         "feature_count_finest": cached["feature_count_finest"],
         "cache_hit": True,
     }
+    note = _rollup_note(cached.get("agg", ""))
+    if note:
+        result["rollup_note"] = note
     result.update(render_recipe(cached, plan["tile_url_template"]))
     return result
 
@@ -443,7 +479,9 @@ def prepare_hex_tiles(
       Any extra columns in the user SQL are ignored.
     - Other aggs: user SQL must return at least one value column after the H3
       index. Each is aggregated via `agg` at every resolution including the finest
-      (one row per (h, h0) cell at every level).
+      (one row per (h, h0) cell at every level). For agg="COUNT_DISTINCT" the
+      value column is the KEY to count distinctly (e.g. specieskey); the result
+      is exact at finest_res and a MAX-based lower bound at coarser levels (#331).
 
     Returns a "plan" dict with everything build_hex_tiles needs, plus a
     `cached` field that is the persisted metadata if the tileset already
@@ -637,6 +675,9 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
         "layer_name": MVT_LAYER_NAME,
         "feature_count_finest": feature_count,
     }
+    note = _rollup_note(agg)
+    if note:
+        result["rollup_note"] = note
     result.update(render_recipe(metadata, plan["tile_url_template"]))
     return result
 
@@ -670,6 +711,9 @@ def register_hex_tiles(
       through raw at the finest level. Carried H3 index/partition columns
       (names matching `h<res>`, e.g. h0, h3) are dropped from value_columns —
       they're join/partition keys, not values (#319).
+    - agg="COUNT_DISTINCT": the value column is the key counted distinctly per
+      hex (species richness = distinct specieskey per cell). Exact at finest_res;
+      coarser levels roll up with MAX (a lower bound — see `rollup_note`, #331).
     """
     plan = prepare_hex_tiles(
         con=con, sql=sql, finest_res=finest_res,


### PR DESCRIPTION
Closes #331.

## What

Adds `agg="COUNT_DISTINCT"` to `register_hex_tiles`, so distinct-count-per-hex — canonically **species richness from GBIF** (distinct `specieskey` per H3 cell) — is expressible. Before this, the enum was `{COUNT,SUM,AVG,MIN,MAX}`, so a model wanting richness had to fall back to occurrence `COUNT` (measures sampling effort, not richness) or punt to a precomputed dataset. We hit exactly this in production (`padus`, qwen, "render global gbif richness hex map").

## Approach — Option A (from the issue)

Distinct-count is **not pyramid-composable**: a parent cell's distinct count can't be derived from its children's counts because siblings share species (`SUM` over-counts, `MAX` under-counts). So:

- **Phase 1** (finest): `COUNT(DISTINCT "<key>") AS "<key>"` grouped by `(h, h0)` — **exact richness at `finest_res`**, which is what the user sees at high zoom (the common case).
- **Phase 2** (parents): `MAX("<key>")` — a parent's true richness is ≥ its largest child, so `MAX` is a defensible **lower bound** at coarse zoom (never overstates as `SUM` would).

The result carries a `rollup_note` (both the fresh-build and cache-hit paths) documenting the finest-exact / coarse-lower-bound behavior, so it's not silently wrong. No serve-path change — the distinct count is stored as an ordinary named value column, styled like any other metric.

Option B (exact-at-every-level via key-set propagation) is deferred as a correctness follow-up if coarse-zoom under-count proves to be a real problem.

## Docs

- `server.py` tool docstring: `COUNT_DISTINCT` in the `agg` list + SQL pattern #3, steering away from plain `COUNT` for richness.
- `pyramid.py` value-column contracts updated.
- `h3-guide.md`: richness pattern with the same lower-bound caveat.

## Tests

- Unit: finest `COUNT(DISTINCT key)` / parent `MAX` (no `SUM`) / empty-value-column guard.
- End-to-end: two res-6 sibling cells share a species — finest counts are exact (2 and 2), and the res-5 parent is `MAX = 2` (a lower bound), **not** the double-counting `SUM = 4`. `rollup_note` present.

Full `tests/test_tile_pyramid.py`, `test_server.py`, `test_tile_endpoint.py` pass locally.

## Rollout note

Acceptance item "renders end-to-end on dev, then the padus richness prompt produces a richness layer" is a post-merge dev-deploy check, not covered by this PR's automated tests.