### PR TITLE
k8s(prod): promote v0.8.8 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.7@sha256:0001e40966a360032181538c52c4a7d321759ceecd839008ec2ec934670bb4e2
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.8@sha256:473eb984a6915458aff0378f02c684d60c678e7be562723fcfe5b6ebf94a7bb1
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod (`duckdb-mcp`, 6 replicas, `biodiversity`) from v0.8.7 → **v0.8.8**.

Ships `register_hex_tiles agg="COUNT_DISTINCT"` (species richness from GBIF, #331), merged in #332.

- Image: \`ghcr.io/boettiger-lab/mcp-data-server:v0.8.8@sha256:473eb984a6915458aff0378f02c684d60c678e7be562723fcfe5b6ebf94a7bb1\`
- Digest fetched via the GHCR registry manifest API; the same method reproduced v0.8.7's currently-pinned digest exactly, so it's the right pin.
- Versioned build (`docker.yml` on tag `v0.8.8`) passed, including the httpfs/spatial/h3 smoke test.

**Verified on dev before promotion:** headless run (qwen/DSE-nimbus → dev MCP) plus interactive check. qwen chose `agg="COUNT_DISTINCT"` unprompted, the server built the global GBIF richness pyramid (902,835 finest cells), tiles serve (HTTP 200 MVT), and the answer is framed as richness not occurrence density — the exact production failure from #331 is resolved. Change is purely additive; COUNT/SUM/AVG/MIN/MAX paths are byte-for-byte unchanged and the full suite is green.

Rollout: merge, then `kubectl apply -f k8s/deployment.yaml -n biodiversity` + `kubectl rollout status`.