### PR TITLE
fix(#331): surface rollup_note on the get_hex_tile_status poll path

### DIFF
--- a/server.py
+++ b/server.py
@@ -402,6 +402,7 @@ from tiles.pyramid import (
     build_hex_tiles,
     cached_result_dict,
     render_recipe,
+    _rollup_note,
     lock_is_stale,
     read_existing_metadata,
     read_failed,
@@ -778,7 +779,7 @@ def _done_response(base: dict, meta: dict) -> dict:
     a build_hex_tiles return value — both have the same shape. Includes the
     paste-ready render recipe (source + layer) so the agent renders
     the result without further branching."""
-    return {
+    result = {
         **base,
         "status": "done",
         "bounds": meta["bounds"],
@@ -791,6 +792,14 @@ def _done_response(base: dict, meta: dict) -> dict:
         "feature_count_finest": meta["feature_count_finest"],
         **render_recipe(meta, base["tile_url_template"]),
     }
+    # Surface the rollup caveat for non-composable aggs (COUNT_DISTINCT). This
+    # is the async-poll path — the common one for big builds like global GBIF
+    # richness — so the note MUST appear here too, not just in the fast/cache
+    # paths of register_hex_tiles (#331).
+    note = _rollup_note(meta.get("agg", ""))
+    if note:
+        result["rollup_note"] = note
+    return result
 
 
 def _status_check_once(hash: str, con=None):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1015,6 +1015,36 @@ class TestGetHexTileStatus:
         assert "bounds" in status
         assert "value_stats" in status
 
+    def test_count_distinct_status_carries_rollup_note(self, isolated_jobs, monkeypatch):
+        # #331: the rollup caveat must reach the async-poll path too — big
+        # COUNT_DISTINCT builds (e.g. global GBIF richness) return "running"
+        # and the model only ever sees the done result via get_hex_tile_status.
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        sub = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 42 AS specieskey",
+            agg="COUNT_DISTINCT",
+        )
+        assert sub["status"] == "done"
+        assert "rollup_note" in sub and "lower bound" in sub["rollup_note"]
+        # The poll path (_done_response) must include it as well.
+        status = server.get_hex_tile_status(hash=sub["hash"])
+        assert status["status"] == "done"
+        assert "rollup_note" in status and "lower bound" in status["rollup_note"]
+
+    def test_non_count_distinct_status_has_no_rollup_note(self, isolated_jobs, monkeypatch):
+        # Exact aggs (AVG here) must NOT carry the caveat — it's specific to
+        # the non-composable COUNT_DISTINCT rollup.
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        sub = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        status = server.get_hex_tile_status(hash=sub["hash"])
+        assert status["status"] == "done"
+        assert "rollup_note" not in status
+
     def test_long_poll_returns_done_when_build_finishes_during_wait(self, isolated_jobs, monkeypatch):
         """wait_seconds blocks server-side until the build completes,
         avoiding the rapid-poll antipattern."""


### PR DESCRIPTION
Follow-up to #332, found during post-deploy verification of v0.8.8 on prod.

**Gap:** `_done_response` — the builder for `get_hex_tile_status`'s `done` payload — didn't include `rollup_note`. Only the fast-build and cache-hit paths of `register_hex_tiles` (via `cached_result_dict` / `build_hex_tiles`) carried it. But any COUNT_DISTINCT build large enough to go async returns `status:"running"`, and the model then only ever sees the result through `get_hex_tile_status`. Global GBIF richness is always that case — so in practice the coarse-zoom lower-bound caveat never reached the model, defeating the issue's "rollup behavior documented in the tool response" acceptance item.

**Fix:** add `rollup_note` in `_done_response`, keyed on the stored `agg`, identical to the other two paths.

**Tests:** `get_hex_tile_status` carries `rollup_note` for COUNT_DISTINCT and omits it for AVG (poll path).

The core feature itself is correct and live on prod v0.8.8 — tiles build and serve fine; this only restores the advisory note on the async path.