### PR TITLE
k8s(prod): promote v0.8.9 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.8@sha256:473eb984a6915458aff0378f02c684d60c678e7be562723fcfe5b6ebf94a7bb1
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.9@sha256:7a52645cc98fb5a0eaaddf6c59a086942cc9ab6f72a14313f9bbdecce74686fa
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod (`duckdb-mcp`, `biodiversity`) v0.8.8 → **v0.8.9**.

Ships the poll-path `rollup_note` fix (#334) so COUNT_DISTINCT builds that go async (global GBIF richness) deliver the coarse-zoom lower-bound caveat to the model — completing the #331 acceptance.

- Image: \`ghcr.io/boettiger-lab/mcp-data-server:v0.8.9@sha256:7a52645cc98fb5a0eaaddf6c59a086942cc9ab6f72a14313f9bbdecce74686fa\`
- Digest verified via GHCR registry manifest API.
- Versioned build passed (incl. httpfs/spatial/h3 smoke test).