### PR TITLE
chore: gitignore .vscode/ noise (keep tracked mcp.json)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,7 @@ cython_debug/
 node_modules/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
+
+# Editor settings — ignore .vscode noise but keep the shared MCP config
+.vscode/*
+!.vscode/mcp.json


### PR DESCRIPTION
Adds `.vscode/*` to `.gitignore` with `!.vscode/mcp.json` so editor noise is ignored while the intentionally-committed `.vscode/mcp.json` stays tracked. (`.ipynb_checkpoints` already ignored here.)