### PR TITLE
fix(#337): per-pod periodic STAC catalog refresh

### DIFF
--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.session import BaseSession
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-from stac import STAC_DATASETS, STAC_LOAD_ERRORS, STAC_CATALOG_URL, list_datasets as _stac_list, get_dataset as _stac_get, get_collection as _stac_get_collection
+from stac import STAC_DATASETS, STAC_LOAD_ERRORS, STAC_CATALOG_URL, list_datasets as _stac_list, get_dataset as _stac_get, get_collection as _stac_get_collection, start_periodic_refresh as _stac_start_periodic_refresh
 
 # Workaround for https://github.com/boettiger-lab/mcp-data-server/issues/5
 # send_notification crashes with ClosedResourceError when the client disconnects
@@ -1021,6 +1021,10 @@ if __name__ == "__main__":
     print("🚀 Starting DuckDB MCP Server...", file=sys.stderr)
     print(f"📂 STAC catalog: {STAC_CATALOG_URL}", file=sys.stderr)
     print(f"📊 Datasets loaded: {len(STAC_DATASETS)}", file=sys.stderr)
+    # Keep every replica's STAC snapshot fresh without a rollout — a publish to S3
+    # (new dataset OR new asset on an existing collection) becomes visible within
+    # one refresh interval instead of the pod's lifetime (#337).
+    _stac_start_periodic_refresh()
     uvicorn.run(
         app,
         host="0.0.0.0",

--- a/stac.py
+++ b/stac.py
@@ -9,6 +9,7 @@ high-speed internal reads via the Ceph S3 endpoint.
 
 import os
 import sys
+import threading
 import pystac
 import requests
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
@@ -42,6 +43,22 @@ _STAC_CHILD_RETRY_TIMEOUT = int(os.environ.get("STAC_CHILD_RETRY_TIMEOUT", "8"))
 
 # Legacy alias retained so external callers (if any) that read the old name still work.
 _STAC_TIMEOUT = _STAC_CHILD_TIMEOUT
+
+# Seconds between background re-walks of the default catalog (see #337). The
+# startup snapshot goes stale the moment a new asset/dataset is published to S3;
+# the on-miss re-fetch (#11) only rescues *new* dataset ids, never an updated
+# asset on an already-cached collection (a cache HIT). A per-pod timer keeps
+# every replica converged without an external trigger or a rollout. `0` (or
+# negative) disables the thread — used by tests and one-shot tooling.
+_STAC_REFRESH_INTERVAL = int(os.environ.get("STAC_REFRESH_INTERVAL", "900"))
+
+# Guards the atomic swap of the shared module caches (STAC_DATASETS / _STAC_RAW /
+# STAC_LOAD_ERRORS) against concurrent readers. The clear()+update() swap has a
+# transient-empty window a concurrent request could otherwise observe as a
+# spurious "not found"; the background refresh (#337) makes that race routine.
+# Only the fast in-memory swap and the shared-dict reads take the lock — the slow
+# HTTP walk in fetch_stac_catalog runs lock-free.
+_STAC_LOCK = threading.RLock()
 
 # Navigational STAC link rel types excluded from _collection_to_dict output.
 _NAV_RELS = {"root", "parent", "self", "child", "item"}
@@ -697,13 +714,16 @@ def fetch_stac_catalog(catalog_url: str = None, catalog_token: str = None) -> di
         # load produced something. If every child failed, keep the previous snapshot
         # rather than wiping a working cache. Errors are always refreshed so operators
         # and the list_datasets footer see the current failure state.
-        if datasets:
-            STAC_DATASETS.clear()
-            STAC_DATASETS.update(datasets)
-            _STAC_RAW.clear()
-            _STAC_RAW.update(raw)
-        STAC_LOAD_ERRORS.clear()
-        STAC_LOAD_ERRORS.update(errors)
+        # Held under _STAC_LOCK so a concurrent reader never sees a half-swapped
+        # (transiently empty) cache — see #337.
+        with _STAC_LOCK:
+            if datasets:
+                STAC_DATASETS.clear()
+                STAC_DATASETS.update(datasets)
+                _STAC_RAW.clear()
+                _STAC_RAW.update(raw)
+            STAC_LOAD_ERRORS.clear()
+            STAC_LOAD_ERRORS.update(errors)
 
     return datasets
 
@@ -715,6 +735,68 @@ STAC_DATASETS: dict[str, str] = {}
 # Kick off the initial load at import. Populates STAC_DATASETS, _STAC_RAW,
 # STAC_LOAD_ERRORS in place.
 fetch_stac_catalog()
+
+# Set once start_periodic_refresh() spawns the daemon, so repeat calls are no-ops.
+_refresh_thread: threading.Thread | None = None
+
+
+def _refresh_loop(interval: int, stop_event: threading.Event) -> None:
+    """Re-walk the default catalog every *interval* seconds until *stop_event*.
+
+    A publish to S3 (new dataset OR a new asset on an existing collection) is
+    invisible to get_stac_details/get_collection/list_datasets until the in-process
+    snapshot is rebuilt — the on-miss re-fetch (#11) can't help the updated-asset
+    case because it's a cache HIT. This per-pod timer rebuilds the snapshot so every
+    replica converges without an external trigger or a rollout (#337).
+
+    Failures are swallowed: fetch_stac_catalog already keeps the previous snapshot
+    when a walk yields nothing, so a transient S3 blip just means a stale-but-working
+    cache until the next tick — never a crashed thread or a wiped catalog.
+    """
+    while not stop_event.wait(interval):
+        try:
+            fetch_stac_catalog()
+        except Exception as e:  # never let the daemon die on a transient error
+            print(
+                f"⚠️ STAC periodic refresh failed (keeping previous snapshot): "
+                f"{type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+
+
+def start_periodic_refresh(interval: int = None) -> threading.Thread | None:
+    """Spawn the background refresh daemon (idempotent). Returns the thread, or
+    None when disabled (interval <= 0).
+
+    Started explicitly from server.py's __main__ rather than at import, so tests
+    and one-shot tooling that import `stac` don't spawn a background thread.
+    """
+    global _refresh_thread
+    if interval is None:
+        interval = _STAC_REFRESH_INTERVAL
+    if interval <= 0:
+        print(
+            "⏸️ STAC periodic refresh disabled (STAC_REFRESH_INTERVAL <= 0)",
+            file=sys.stderr,
+        )
+        return None
+    if _refresh_thread is not None and _refresh_thread.is_alive():
+        return _refresh_thread
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_refresh_loop,
+        args=(interval, stop_event),
+        name="stac-refresh",
+        daemon=True,
+    )
+    thread._stop_event = stop_event  # handle for tests / future shutdown
+    thread.start()
+    _refresh_thread = thread
+    print(
+        f"🔄 STAC periodic refresh started (every {interval}s)",
+        file=sys.stderr,
+    )
+    return thread
 
 
 def _render_inline_catalog(catalog: dict) -> dict[str, str]:
@@ -766,9 +848,12 @@ def list_datasets(
         # can detect failure via returned dict being empty or partial.
         footer_errors: dict = {}
     else:
-        datasets = STAC_DATASETS
+        # Snapshot the shared caches under the lock so a concurrent background
+        # refresh (#337) can't mutate them mid-iteration below.
+        with _STAC_LOCK:
+            datasets = dict(STAC_DATASETS)
+            footer_errors = dict(STAC_LOAD_ERRORS)
         url = STAC_CATALOG_URL
-        footer_errors = STAC_LOAD_ERRORS
     if not datasets and not footer_errors:
         return f"No datasets loaded. STAC catalog: {url}"
     lines = [f"# Available Datasets ({len(datasets)} collections)\n"]
@@ -805,18 +890,21 @@ def get_dataset(
         return _format_collection(col, sub_children=sub_children)
 
     if catalog_url:
+        # Local (unshared) dict — no lock needed.
         datasets = fetch_stac_catalog(catalog_url, catalog_token=catalog_token)
+        result = _fuzzy_lookup(datasets, dataset_id)
     else:
-        datasets = STAC_DATASETS
-
-    result = _fuzzy_lookup(datasets, dataset_id)
+        # Shared cache — read under the lock (guards against a concurrent refresh #337).
+        with _STAC_LOCK:
+            result = _fuzzy_lookup(STAC_DATASETS, dataset_id)
     if result is not None:
         return result
 
     # Cache miss (default catalog only): re-fetch in case datasets were added since startup
     if not catalog_url:
         fetch_stac_catalog()  # populates STAC_DATASETS in place if successful
-        result = _fuzzy_lookup(STAC_DATASETS, dataset_id)
+        with _STAC_LOCK:
+            result = _fuzzy_lookup(STAC_DATASETS, dataset_id)
         if result is not None:
             return result
     return f"Dataset '{dataset_id}' not found. Use list_datasets to see available datasets."
@@ -916,15 +1004,18 @@ def get_collection(
             return {"error": f"Failed to fetch catalog: {e}"}
         return {"error": f"Collection '{collection_id}' not found. Use browse_stac_catalog to list available collections."}
 
-    # Default catalog: look up from pre-populated cache.
-    result = _fuzzy_lookup(_STAC_RAW, collection_id)
+    # Default catalog: look up from pre-populated cache (read under the lock so a
+    # concurrent background refresh #337 can't mutate _STAC_RAW mid-lookup).
+    with _STAC_LOCK:
+        result = _fuzzy_lookup(_STAC_RAW, collection_id)
     if result is not None:
         return result
 
     # Cache miss: re-fetch.
     # fetch_stac_catalog() updates _STAC_RAW when catalog_url is None.
     fetch_stac_catalog()
-    result = _fuzzy_lookup(_STAC_RAW, collection_id)
+    with _STAC_LOCK:
+        result = _fuzzy_lookup(_STAC_RAW, collection_id)
     if result is not None:
         return result
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -7,6 +7,7 @@ import os
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+import stac
 from stac import list_datasets, get_dataset, fetch_stac_catalog, get_collection, _collection_to_dict, _fuzzy_lookup, _format_collection, _href_to_s3
 
 
@@ -1793,4 +1794,57 @@ class TestExtractParquetAssetsExtensions:
         rendered = "\n".join(_extract_parquet_assets(col))
         assert "h3:native_resolution" not in rendered
         assert "h3:parent_resolutions" not in rendered
+
+
+class TestPeriodicRefresh:
+    """Background per-pod catalog refresh (#337): a publish to S3 becomes visible
+    within one interval instead of only on pod restart."""
+
+    def teardown_method(self):
+        # Never leak a live daemon between tests.
+        t = stac._refresh_thread
+        if t is not None:
+            ev = getattr(t, "_stop_event", None)
+            if ev is not None:
+                ev.set()
+            t.join(timeout=2)
+        stac._refresh_thread = None
+
+    def test_disabled_returns_none(self):
+        """interval <= 0 disables the thread entirely (tests / one-shot tooling)."""
+        assert stac.start_periodic_refresh(0) is None
+        assert stac.start_periodic_refresh(-5) is None
+        assert stac._refresh_thread is None
+
+    def test_loop_refetches_each_tick_until_stopped(self):
+        """_refresh_loop re-walks once per non-stopped tick, then exits on stop."""
+        stop = MagicMock()
+        # wait() -> False twice (proceed), then True (stop): expect 2 refetches.
+        stop.wait.side_effect = [False, False, True]
+        with patch("stac.fetch_stac_catalog") as mock_fetch:
+            stac._refresh_loop(interval=1, stop_event=stop)
+        assert mock_fetch.call_count == 2
+
+    def test_loop_swallows_fetch_errors(self):
+        """A transient S3 failure must not kill the daemon (keeps prev snapshot)."""
+        stop = MagicMock()
+        stop.wait.side_effect = [False, True]
+        with patch("stac.fetch_stac_catalog", side_effect=RuntimeError("boom")):
+            # Must not raise.
+            stac._refresh_loop(interval=1, stop_event=stop)
+
+    def test_start_is_idempotent(self):
+        """Repeat calls return the same live daemon, not a second thread."""
+        stac._refresh_thread = None
+        with patch("stac.fetch_stac_catalog"):
+            # Long interval so the thread blocks in wait() rather than refetching.
+            t1 = stac.start_periodic_refresh(3600)
+            assert t1 is not None and t1.is_alive()
+            t2 = stac.start_periodic_refresh(3600)
+            assert t2 is t1
+
+    def test_default_interval_from_env(self):
+        """start_periodic_refresh() with no arg uses the module default knob."""
+        with patch.object(stac, "_STAC_REFRESH_INTERVAL", 0):
+            assert stac.start_periodic_refresh() is None
 


### PR DESCRIPTION
## Problem

The in-process STAC snapshot (`STAC_DATASETS` / `_STAC_RAW` / `STAC_LOAD_ERRORS`) is built once at startup by `fetch_stac_catalog()` and only re-fetched on a cache **MISS** — an unknown dataset id (#11's on-miss rescue). A **new asset published to an already-cached collection is a cache HIT**, so `get_stac_details` / `get_collection` / `list_datasets` serve the startup-pinned copy for the pod's lifetime, while the same server's `query` tool reads live S3. The discovery path is stale while the data path is fresh — a confidently-wrong "these are the assets" answer.

Fixes #337.

**Observed:** the `gbif-dataset-publishers-2026-06` / `publishing_country` sidecar was published to `s3://public-gbif/stac-collection.json`; hours later prod `get_stac_details(gbif-derived)` still returned the pre-sidecar schema. In a global-30x30 demo the model concluded the field didn't exist and gave up, though it was live and queryable the whole time.

## Fix

A **per-pod background daemon** re-walks the default catalog every `STAC_REFRESH_INTERVAL` seconds (default **900** = 15 min; `0`/negative disables). Every replica converges within one interval — no external trigger, no rollout, no version bump.

Why periodic rather than the alternatives (see the [proposal on #337](https://github.com/boettiger-lab/mcp-data-server/issues/337#issuecomment-5009867922)):
- **On-miss re-fetch already exists** and by definition can't fix a cache *hit* (the updated-asset case never misses).
- **A refresh endpoint** only refreshes the one pod the request lands on; prod runs 6 replicas → inconsistent answers.
- **A root-`catalog.json` ETag check is insufficient** — updating a child `stac-collection.json` in place doesn't change the root's ETag, which is exactly the sidecar case. So the loop always does the (bounded, cheap, in-cluster) full walk.

### Details
- `_refresh_loop` swallows exceptions; `fetch_stac_catalog` already keeps the previous snapshot on an empty walk, so a transient S3 blip means stale-but-working until the next tick, never a crashed thread or a wiped catalog.
- The cache swap (`clear()`+`update()`) and the shared-dict reads now take `_STAC_LOCK`, so a concurrent reader never observes a half-swapped, transiently-empty cache (spurious "not found"). The slow HTTP walk stays lock-free.
- The daemon is started from `server.py` `__main__`, **not at import**, so tests and one-shot tooling that `import stac` don't spawn a thread.

## Config
`STAC_REFRESH_INTERVAL` (seconds, default 900). No manifest change required; prod picks up the default. Immediate unstick for currently-stale pods remains `kubectl -n biodiversity rollout restart deployment/duckdb-mcp`.

## Tests
New `TestPeriodicRefresh`: disabled-when-<=0, refetch-per-tick, error-swallowing, idempotent start, env-default. Full suite: **400 passed**. Also verified a real-timer daemon fires ~3× over 750ms at a 200ms interval and stops cleanly.

## Sibling issues
#11 (registry on-miss) stays closed — superseded by this. #65's short-TTL cache never actually landed (only its timeout + parallelism did); this is the first TTL-style refresh across the detail paths.