### PR TITLE
k8s(prod): promote v0.8.10 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.9@sha256:7a52645cc98fb5a0eaaddf6c59a086942cc9ab6f72a14313f9bbdecce74686fa
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.10@sha256:df2ddd2734f9dce60d29bf0aeb7b4c6c9bc03328eff41db3ebdff41f9549eda8
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod `duckdb-mcp` to **v0.8.10**, shipping the per-pod periodic STAC catalog refresh (#337, PR #338).

- Image: `ghcr.io/boettiger-lab/mcp-data-server:v0.8.10@sha256:df2ddd2734f9dce60d29bf0aeb7b4c6c9bc03328eff41db3ebdff41f9549eda8`
- Digest fetched from GHCR and method-validated (v0.8.9 lookup matches the currently-pinned prod digest).
- Dev (`dev-duckdb-mcp`, `:main`) already rolled out on this commit.

After merge: `kubectl apply -f k8s/deployment.yaml -n biodiversity` + `kubectl rollout status`.