### PR TITLE
Add well-formed .zenodo.json for DOI minting

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,24 @@
+{
+  "title": "MCP Data Server: an open Model Context Protocol server connecting AI agents to cloud-native scientific data",
+  "description": "An open Model Context Protocol (MCP) server that connects AI agents to cloud-native data. It grounds agents in STAC metadata and confines them to validated cloud-native engines — SQL over Parquet on S3 via DuckDB with H3 spatial indexing — so they can query terabyte-scale data without downloading it, misreading it, or silently failing at scale. Runs locally for sensitive data or on autoscaling Kubernetes for scale.",
+  "license": "bsd-3-clause",
+  "upload_type": "software",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Boettiger, Carl",
+      "affiliation": "University of California, Berkeley",
+      "orcid": "0000-0002-1642-628X"
+    }
+  ],
+  "keywords": [
+    "Model Context Protocol",
+    "MCP",
+    "STAC",
+    "DuckDB",
+    "cloud-native",
+    "geospatial",
+    "H3",
+    "AI agents"
+  ]
+}


### PR DESCRIPTION
Adds a `.zenodo.json` so a GitHub release mints a correct Zenodo DOI with proper metadata (title, description, author + ORCID, keywords).

Formed to avoid the two failure modes we hit elsewhere:
- **license** uses the lowercase SPDX id `"bsd-3-clause"` (Zenodo's InvenioRDM vocabulary rejects the capitalized `BSD-3-Clause` with HTTP 400);
- **no `grants` block** (an unresolvable funder award rejects the whole deposit).

Metadata mirrors the repo's existing `CITATION.cff`. Validated as JSON.