### PR TITLE
fix(#341): pin dev by digest so pods converge; symmetric convergence check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,14 +74,24 @@ release tags. The image is the unit of release.
 - `:<git-sha>` — immutable; one per commit.
 - `:vX.Y.Z` — immutable; built on release tags. **prod** pins this (by digest, below).
 
-**Merge to `main` → redeploy dev:**
-```
-kubectl apply -f k8s/dev-deployment.yaml
-kubectl rollout restart deployment/dev-duckdb-mcp -n biodiversity
-```
-dev pins `:main` with `imagePullPolicy: Always`, so the restart pulls the freshest build.
-**Wait for the `docker.yml` run on your merge to go green first** — rolling before the
-image is pushed gives `ImagePullBackOff`.
+**Merge to `main` → redeploy dev (promote by digest — same discipline as prod):**
+Dev pins an immutable `:main@sha256:…` (tag for humans, digest enforced), **not** the
+bare moving `:main` tag. `:main` + `imagePullPolicy: Always` is *non-convergent*: `Always`
+re-resolves the mutable `:main` → digest independently per pod at each (re)start, and
+`:main` moves on every push to `main` plus the weekly cron. So pods brought up seconds
+apart, or any single later liveness/eviction/crash/cron restart, silently drift onto
+different builds — the exact cross-pod skew dev's ≥2 replicas exist to catch (issue #341).
+Pinning a digest makes every dev pod run one reproducible build.
+
+1. **Wait for the `docker.yml` run on your merge to go green first** — rolling before the
+   image is pushed gives `ImagePullBackOff`.
+2. Read the freshly-built `:main` digest from the build run's job summary, or:
+   `docker buildx imagetools inspect ghcr.io/boettiger-lab/mcp-data-server:main --format '{{.Manifest.Digest}}'`
+3. Set `image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:<digest>` in
+   `k8s/dev-deployment.yaml` (keep `imagePullPolicy: IfNotPresent`).
+4. `kubectl apply -f k8s/dev-deployment.yaml`
+5. `kubectl rollout restart deployment/dev-duckdb-mcp -n biodiversity`
+6. Verify convergence (below) — this is dev's canary job; do not skip it.
 
 **Tag a release → redeploy prod (promote by digest):**
 1. `git tag vX.Y.Z && git push origin vX.Y.Z`, then wait for `docker.yml` to build `:vX.Y.Z`.
@@ -97,11 +107,17 @@ disagree, the digest wins). **Never apply prod while the manifest points at an i
 hasn't built yet** — the rollout stalls on `ImagePullBackOff`. `kubectl apply` must precede
 `rollout restart`; a git push alone does not update the cluster.
 
-Verify all prod replicas converge on a single digest after rollout:
+**Verify all replicas converge on a single digest after rollout** (both dev and prod —
+dev is the multi-replica canary, so its convergence matters as much as prod's). Swap the
+label for the deployment you rolled (`duckdb-mcp` for prod, `dev-duckdb-mcp` for dev):
 ```
 kubectl -n biodiversity get pods -l app=duckdb-mcp \
   -o custom-columns='NAME:.metadata.name,IMAGE:.status.containerStatuses[0].imageID'
 ```
+Every live (non-`Terminating`) pod must report the **same** `imageID` digest, and it must
+match the digest pinned in the manifest. Stuck `Terminating` zombie pods on unreachable
+NRP nodes are out of the Service's endpoints, so ignore them here — **never** force-delete
+them (NRP ops policy).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,22 @@ disagree, the digest wins). **Never apply prod while the manifest points at an i
 hasn't built yet** — the rollout stalls on `ImagePullBackOff`. `kubectl apply` must precede
 `rollout restart`; a git push alone does not update the cluster.
 
+**No `docker` CLI (e.g. a JupyterLab session)?** `imagetools inspect` needs it, and the
+GHCR packages API needs a `read:packages` token most of our `gh` logins don't carry. An
+anonymous pull token against the registry v2 API works anywhere `curl` does — substitute
+`main` or `vX.Y.Z` for `<tag>`:
+```
+repo=boettiger-lab/mcp-data-server
+tok=$(curl -s "https://ghcr.io/token?scope=repository:$repo:pull" \
+      | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
+curl -sI -H "Authorization: Bearer $tok" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+  "https://ghcr.io/v2/$repo/manifests/<tag>" | grep -i '^docker-content-digest:'
+```
+Sanity-check the method before trusting it: run it on the tag prod already pins and
+confirm the digest matches `k8s/deployment.yaml`.
+
 **Verify all replicas converge on a single digest after rollout** (both dev and prod —
 dev is the multi-replica canary, so its convergence matters as much as prod's). Swap the
 label for the deployment you rolled (`duckdb-mcp` for prod, `dev-duckdb-mcp` for dev):

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         # dev's ≥2 replicas exist to catch. Bump this digest on redeploy (see
         # AGENTS.md → Rollout workflow). The tag prefix is for humans; the digest
         # is enforced. See issue #341.
-        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:1b0f133f4c7684b4a3271f627bb0fd4a494da3e056f1b6adf0cff68f85371f4f
+        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:f9be5daeb9af3d96dc77a10d78c557e911c687d5091b1e513eb8b6068b048144
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -23,8 +23,17 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:main
-        imagePullPolicy: Always
+        # Pinned by digest (not the moving :main tag) so every dev pod converges
+        # on one reproducible build. :main + imagePullPolicy: Always is
+        # non-convergent: Always re-resolves the mutable :main → digest
+        # independently per pod at each (re)start, so pods brought up seconds
+        # apart — or a single later liveness/eviction/cron restart — silently
+        # drift onto different builds with no signal, exactly the cross-pod skew
+        # dev's ≥2 replicas exist to catch. Bump this digest on redeploy (see
+        # AGENTS.md → Rollout workflow). The tag prefix is for humans; the digest
+        # is enforced. See issue #341.
+        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:1b0f133f4c7684b4a3271f627bb0fd4a494da3e056f1b6adf0cff68f85371f4f
+        imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL
           value: "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"


### PR DESCRIPTION
Closes #341.

## Problem
`dev-duckdb-mcp` was serving traffic from **multiple mismatched builds at once**. The live ReplicaSet ran two different digests on its two pods, so a request hit the metadata.json tile feature (≥ v0.8.6) or not, at random — which is what broke `add_hex_tile_layer` on the padus app.

Root cause is the deploy design, not a code bug: dev pinned the moving `:main` tag with `imagePullPolicy: Always`. `Always` re-resolves the mutable `:main` → digest **independently per pod at each (re)start**, and `:main` moves on every push to `main` plus the weekly cron. So pods started seconds apart, or any single later liveness/eviction/crash/cron restart, silently drift onto different builds — the exact cross-pod skew dev's ≥2 replicas exist to surface. AGENTS.md documented convergence verification for **prod only**, so the skew was invisible in dev's own workflow.

## Fix (issue's Option A — pin dev by digest, same discipline as prod)
- **`k8s/dev-deployment.yaml`**: pin `main@sha256:1b0f133f…` (current `:main`) with `imagePullPolicy: IfNotPresent`. All dev pods now run one reproducible build; restarts/evictions/cron can't silently drift a pod. Redeploy is one extra `imagetools inspect` line — identical to the prod promote flow.
- **`AGENTS.md`**: dev redeploy is now a promote-by-digest flow (read digest → pin → apply → restart → verify). The convergence check is stated once for **both dev and prod**, with the Terminating-zombie caveat (out of Service endpoints; never force-delete per NRP policy).

Trade-off: dev no longer auto-tracks `main`/the cron. Accepted — dev tests a specific merge, so reproducibility beats auto-freshness, and the cron silently bumping dev to random builds was itself the footgun.

## Cluster remediation (already applied)
Applied the digest-pinned manifest to dev and rolled out — this both converges the live pods and implements the pin. Verified all live pods report the single pinned `imageID`. The two stuck `Terminating` zombie pods (07-05 / 07-09) on unreachable nodes are left alone per NRP ops policy.