### PR TITLE
chore: add .zenodo.json for DOI record metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,24 @@
+{
+  "title": "MCP Data Server",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "BSD-3-Clause",
+  "creators": [
+    {
+      "name": "Boettiger, Carl",
+      "orcid": "0000-0002-1642-628X",
+      "affiliation": "University of California, Berkeley"
+    }
+  ],
+  "keywords": [
+    "Model Context Protocol",
+    "MCP",
+    "STAC",
+    "DuckDB",
+    "cloud-native",
+    "geospatial",
+    "H3",
+    "AI agents"
+  ],
+  "description": "An open Model Context Protocol (MCP) server that connects AI agents to cloud-native data. It grounds agents in STAC metadata and confines them to validated cloud-native engines — SQL over Parquet on S3 via DuckDB with H3 spatial indexing — so they can query terabyte-scale data without downloading it, misreading it, or silently failing at scale. Runs locally for sensitive data or on autoscaling Kubernetes for scale."
+}


### PR DESCRIPTION
Adds `.zenodo.json` so Zenodo's GitHub integration records proper metadata (author, ORCID, title, abstract, keywords from CITATION.cff) on the DOI when we cut the next release tag.

Zenodo's GitHub integration reads `.zenodo.json`, not `CITATION.cff`, so without this the minted DOI record would fall back to bare repo metadata (owner only).

Prep for tagging v0.8.11 to mint a DOI.