### PR TITLE
docs(outage): make mirror-failover the single runbook; tell agents the STAC tools work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@ server on this machine, stop. The workflow is: land the change on dev (dev track
 `:main` — see Rollout below), then validate on dev with the headless matrix
 (see *Validating guidance changes*).
 
+**When NRP Ceph (`s3-west.nrp-nautilus.io`) is down**, don't improvise a fallback:
+follow [docs/guide/mirror-failover.md](docs/guide/mirror-failover.md) — the single
+runbook for the MinIO mirror and the mirror-configured head at
+`duckdb-mcp.carlboettiger.info`. Its "For agents querying through MCP" section is
+the short version: the normal STAC tools work on a mirror head; use the paths the
+tools return verbatim. Older outage notes elsewhere describing a source.coop route
+are superseded.
+
 ## Contributing
 
 This repo uses **GitHub Flow**: all changes go through a branch + PR, never committed directly to `main`. `main` has branch protection enforced — direct pushes are rejected.

--- a/docs/guide/mirror-failover.md
+++ b/docs/guide/mirror-failover.md
@@ -9,6 +9,11 @@ The reference mirror is **`minio.carlboettiger.info`**: a drop-in copy of the NR
 anonymous reads, CORS + HTTP range enabled for browsers. A mirror-configured MCP
 head already reads from it at **`https://duckdb-mcp.carlboettiger.info/mcp`**.
 
+> **Pointed here mid-outage and just need to query?** Read
+> [For agents querying through MCP](#agents) — those five rules are the whole
+> instruction, and this page is the only place they live. Everything else here is
+> for whoever switches an app over.
+
 ## Runbook
 
 An app reads over **two independent surfaces, and both must be switched** — one
@@ -58,7 +63,7 @@ Flip both hosts back (`minio.carlboettiger.info` → `s3-west.nrp-nautilus.io`,
 obligation** for every app switched — see [Zero-touch alternative](#zero-touch-alternative)
 for how to stop owing it.
 
-## For agents querying through MCP during an outage
+## For agents querying through MCP during an outage {#agents}
 
 - **Use the normal tools.** On a mirror-configured head, `browse_stac_catalog`,
   `get_stac_details`, and `get_collection` all work — the head serves a complete

--- a/docs/guide/mirror-failover.md
+++ b/docs/guide/mirror-failover.md
@@ -1,58 +1,88 @@
 # Running an app on a mirror during an S3 outage
 
-When the primary NRP Ceph endpoint (`s3-west.nrp-nautilus.io`) is unavailable,
-an app can be pointed at a public **mirror** of the `public-*` buckets and keep
-working. This is app-driven — nothing needs to change on the primary server.
+When the primary NRP Ceph endpoint (`s3-west.nrp-nautilus.io`) is unavailable, an
+app can be pointed at a public **mirror** of the `public-*` buckets and keep
+working. This is app-driven — nothing changes on the primary server.
 
-The reference mirror is **`minio.carlboettiger.info`** (MinIO): a drop-in copy of
-the NRP `public-*` buckets — same bucket names, same catalog structure,
-self-consistent asset hrefs, public/anonymous reads, with CORS + HTTP range
-enabled for browser access. (A partial AWS mirror also exists on source.coop; see
-[architecture.md](architecture.md) and issue #260. MinIO is the more complete
-drop-in.)
+The reference mirror is **`minio.carlboettiger.info`**: a drop-in copy of the NRP
+`public-*` buckets — same bucket names, same paths, self-consistent asset hrefs,
+anonymous reads, CORS + HTTP range enabled for browsers. A mirror-configured MCP
+head already reads from it at **`https://duckdb-mcp.carlboettiger.info/mcp`**.
 
-## The two data surfaces
+## Runbook
 
-An app reads data over **two independent paths**, and both must be pointed at the
-mirror to fully ride out an outage:
+An app reads over **two independent surfaces, and both must be switched** — one
+alone leaves the app half-broken (layers load but queries 503, or the reverse):
 
-| Surface | Fetched by | Through the MCP server? |
+| Surface | Fetched by | Switch by |
 | --- | --- | --- |
-| Collection JSON, PMTiles, COGs (map layers) | the browser (and TiTiler) | **No** — client-side |
-| SQL analytics (`query` tool) | the LLM → MCP server → DuckDB | **Yes** |
+| Catalog + collection JSON, PMTiles, COGs | the browser | app config |
+| SQL analytics (`query`) | LLM → MCP server → DuckDB | `mcp_url` |
 
-Because these are independent, they are switched separately.
+In the app config (`layers-input.json`):
 
-## 1. Map layers (client-side)
+1. **`catalog` and every `collection_url`** — swap the host, keep the path:
+   `s3-west.nrp-nautilus.io` → `minio.carlboettiger.info`.
+   Bucket names are identical, so nothing else changes. The mirror's collection
+   JSONs are self-consistent (their PMTiles/COG/parquet hrefs already point at
+   the mirror), so assets cascade on their own.
+2. **`mcp_url`** → `https://duckdb-mcp.carlboettiger.info/mcp`.
+3. **`titiler_url`** → leave as `https://titiler.nrp-nautilus.io`. TiTiler reads
+   the mirror's COG URLs server-side (verified).
 
-The map layers are fetched directly from the URLs in your app config
-(`layers-input.json`) — they never touch the MCP server. Point them at the mirror:
+If the app's `mcp_url` comes from a deployment env var rather than the config
+file, that is a manifest change: `kubectl apply` it, not just a rollout restart.
 
-- `catalog`:
-  `https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json`
-  → `https://minio.carlboettiger.info/public-data/stac/catalog.json`
-- every `collection_url`: swap the host
-  `s3-west.nrp-nautilus.io` → `minio.carlboettiger.info`
-  (the path is unchanged — the bucket names are identical)
+### Verify before declaring it done
 
-That is the only layer change. The mirror's collection JSONs are self-consistent —
-their PMTiles / COG / parquet asset hrefs already point at the mirror — so
-everything cascades. Leave `titiler_url` as `https://titiler.nrp-nautilus.io`:
-TiTiler reads the mirror's COG URLs server-side (verified).
+```bash
+# 1. collection JSON on the mirror (expect 200 + JSON, not console HTML —
+#    minio.carlboettiger.info is the object host; data.carlboettiger.info is the console)
+curl -s https://minio.carlboettiger.info/public-padus/padus-4-1/fee/stac-collection.json | head -c 40
 
-## 2. Query / analytics (through the MCP server)
+# 2. browser-side prerequisites on a PMTiles object (expect 206 + access-control-allow-origin)
+curl -sD- -o /dev/null -H "Origin: https://<app-host>" -H "Range: bytes=0-99" \
+  https://minio.carlboettiger.info/public-padus/padus-4-1/fee.pmtiles | grep -iE "^HTTP|access-control-allow-origin"
 
-The server owns endpoint routing via a data-driven **source registry**
-(`s3config.py`, #264/#271): it rewrites known mirror hrefs to globbable `s3://`
-paths and creates the matching (anonymous, prefix-scoped) DuckDB secrets. The
-`query` paths themselves are the `s3://` form, and the STAC tools return them
-ready to use — you don't hand-edit query SQL. There are two ways to route
-queries to the mirror during an outage:
+# 3. query surface: the MCP head actually reads the mirror
+curl -s -X POST https://duckdb-mcp.carlboettiger.info/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"query","arguments":{
+       "sql_query":"SELECT COUNT(*) FROM read_parquet('"'"'s3://public-padus/padus-4-1/fee.parquet'"'"')"}}}'
+```
 
-**a. Point `mcp_url` at a mirror-configured MCP head (recommended).** Deploy the
-server with `S3_DEFAULT_ENDPOINT=<mirror host>` (and, so the mirror's own hrefs
-rewrite cleanly, register it via `S3_SOURCES` — see [deployment.md](deployment.md)
-and issues #268/#264):
+### Reverting
+
+Flip both hosts back (`minio.carlboettiger.info` → `s3-west.nrp-nautilus.io`,
+`mcp_url` → the default head) and redeploy. **This is a standing manual
+obligation** for every app switched — see [Zero-touch alternative](#zero-touch-alternative)
+for how to stop owing it.
+
+## For agents querying through MCP during an outage
+
+- **Use the normal tools.** On a mirror-configured head, `browse_stac_catalog`,
+  `get_stac_details`, and `get_collection` all work — the head serves a complete
+  mirrored catalog. Do **not** apply outage advice that says to avoid them and
+  use only `get_schema`; that applied to a partial source.coop fallback with no
+  root catalog, and following it on a mirror head needlessly blinds you.
+- **Use the paths the STAC tools return, verbatim.** The server owns endpoint
+  routing (`s3config.py`): it rewrites known mirror hrefs to globbable `s3://`
+  paths and creates the matching anonymous, prefix-scoped DuckDB secrets. Never
+  hand-edit an endpoint into query SQL.
+- **Internal vs public hosts.** A head's own read endpoint may be an in-cluster
+  address (e.g. `minio-svc.minio.svc.cluster.local`); the URLs it hands you for
+  client use are public. If `browse_stac_catalog` reports an in-cluster catalog
+  root, that's a display bug (#346) — the public equivalent is the mirror host
+  above; asset hrefs from `get_collection` are already public.
+- **When mixing sources, always pass `s3_scope`.** A per-request `s3_endpoint`
+  (or credentials) *without* a scope applies to every `s3://` path in that query
+  and disables the server default for the request (deterministic since #273) —
+  correct for a query hitting only your bucket, wrong for one mixing your bucket
+  with catalog data.
+
+## Deploying your own mirror-configured head
+
+Set these and point `mcp_url` at it (#268/#264; see [deployment.md](deployment.md)):
 
 ```
 S3_DEFAULT_ENDPOINT=minio.carlboettiger.info
@@ -60,52 +90,28 @@ S3_SOURCES='[{"name":"minio","https_prefix":"https://minio.carlboettiger.info/",
 STAC_CATALOG_URL=https://minio.carlboettiger.info/public-data/stac/catalog.json
 ```
 
-Point the app's `mcp_url` at this head. `s3://public-*` reads (and hex-tile
-*reads*, which now honor the same default endpoint — #275) resolve to the
-mirror, anonymously, with no per-query changes.
+`s3://public-*` reads — and hex-tile reads, which honor the same default
+endpoint (#275) — then resolve to the mirror anonymously, with no per-query
+changes. Two caveats:
 
-> **Two caveats on a mirror-configured head:**
-> - **Hex-tile builds write.** `register_hex_tiles` writes its pyramid output to
->   `s3://public-output` on the default backend, anonymously. Both NRP Ceph and
->   the minio mirror accept these writes (verified end-to-end in
->   [#279](https://github.com/boettiger-lab/mcp-data-server/issues/279): build on
->   a mirror head → pyramid on minio → tiles served) — the requirement is that
->   the mirror's bucket policy is open for anonymous Get/Put/List
->   (`mc anonymous set public <alias>/public-output`). No credentials are
->   involved. To redirect *only* tile output at the mirror while the default
->   backend stays on Ceph, add a scoped registry entry instead:
->   `{"name": "minio_output", "secret": {"endpoint": "minio.carlboettiger.info", "scope": "s3://public-output"}}`.
-> - **Booting mid-outage.** With `STAC_CATALOG_URL` swapped to the mirror as
->   above, the head starts normally. If you keep the Ceph catalog URL (or the
->   mirror lacks a root catalog), also set `STAC_ALLOW_DEGRADED_START=true`
->   (#262) or the fail-fast startup will crashloop until the primary returns —
->   discovery is empty in that mode, but inline/known-path queries all work.
+- **Hex-tile builds write.** `register_hex_tiles` writes its pyramid to
+  `s3://public-output` on the default backend, anonymously; the mirror must be
+  open for anonymous Get/Put/List (`mc anonymous set public <alias>/public-output`).
+  Verified end-to-end in [#279](https://github.com/boettiger-lab/mcp-data-server/issues/279).
+  To redirect *only* tile output while the default stays on Ceph, use a scoped
+  entry: `{"name":"minio_output","secret":{"endpoint":"minio.carlboettiger.info","scope":"s3://public-output"}}`.
+- **Booting mid-outage.** With `STAC_CATALOG_URL` on the mirror the head starts
+  normally. Keeping the Ceph catalog URL requires `STAC_ALLOW_DEGRADED_START=true`
+  (#262) or fail-fast startup crashloops until the primary returns.
 
-**b. Or keep your `mcp_url` and pass routing per query (#264/#267).** For a
-source the server doesn't know, `get_stac_details` now returns the derived
-`s3://` path **and an in-band ⚠️ line telling you exactly what to pass** — e.g.
-`s3_endpoint='minio.carlboettiger.info', s3_scope='s3://public-<name>'`
-(anonymous; add `s3_key`/`s3_secret` if private). Following that instruction
-routes the read to the mirror.
+## Zero-touch alternative
 
-> **When mixing sources, always pass `s3_scope`.** A per-request `s3_endpoint`
-> (or credentials) **without** a scope applies to *every* `s3://` path in that
-> query and disables the server default for the request (deterministic since
-> #273) — correct for a query hitting only your bucket, wrong for one mixing
-> your bucket with catalog data. The scope confines your endpoint to its prefix.
-
-## Reverting
-
-After the outage, flip the `catalog` / `collection_url` hosts back to
-`s3-west.nrp-nautilus.io` and point `mcp_url` back at the default MCP server.
-
-## Zero-touch alternative (infrastructure)
-
-If failover is handled at the DNS/proxy layer — resolving
-`s3-west.nrp-nautilus.io` to the mirror — then **all four paths** (collection
-JSON, PMTiles, COG, and query) redirect transparently with **no app or server
-changes at all**. That is the cleanest option when it's available, since every
-asset href and query path is already written against `s3-west`.
+If failover happens at the DNS/proxy layer — resolving `s3-west.nrp-nautilus.io`
+to the mirror — then **all four paths** (collection JSON, PMTiles, COG, query)
+redirect transparently with **no app or server changes**, and no revert to
+remember. Every asset href and query path is already written against `s3-west`,
+so this is the cleanest option whenever it's available, and it retires this
+entire runbook.
 
 ## Why it's this simple
 


### PR DESCRIPTION
Ceph was 503 across the board on 2026-07-30. Pointing an app at the mirror worked, but getting there meant reading `k8s/cirrus-deployment.yaml` + `cirrus-ingress.yaml` and guessing hostnames — and the one runbook an agent was likely to find first (`open-llm-proxy/headless/TESTING-DURING-CEPH-OUTAGE.md`) describes a different, lossier route.

Docs only, no behavior change. Net +6 lines.

## What changed

- **Runbook first.** Both surfaces must be switched or the app is half-broken (layers load, queries 503, or the reverse) — now a table plus three numbered steps. Calls out that an `mcp_url` living in a Deployment env var needs `kubectl apply`, not just a rollout restart.
- **New "For agents querying through MCP during an outage" section.** The important correction: `browse_stac_catalog` / `get_stac_details` / `get_collection` **all work** on a mirror-configured head. Outage notes in open-llm-proxy tell agents to avoid them and use only `get_schema` — correct for the partial source.coop fallback (no root catalog), actively harmful here. Verified against `duckdb-mcp.carlboettiger.info`: `browse_stac_catalog` → 219 collections.
- **Records two traps.** `minio.carlboettiger.info` is the object host; `data.carlboettiger.info` is the console and answers **200 with HTML for every path**, so a naive `curl -o /dev/null -w %{http_code}` coverage check passes on nonexistent objects. Also notes internal-vs-public host reporting and links #346.
- **Verification block** — three curls: collection JSON, browser prerequisites (CORS + range on a PMTiles object), and the query surface via a raw MCP `tools/call`.
- **Revert framed as a standing obligation**, with DNS-level failover flagged as the thing that retires the whole runbook.
- `AGENTS.md` gains a 6-line pointer, since it had no mention of outages or the mirror at all — agents reading it would never find this guide.

## Verified while writing (against the live cirrus head)

| Check | Result |
|---|---|
| `query` on `s3://public-padus/.../fee.parquet` | 296,456 rows |
| `s3://` glob over the hex pyramid | 609,968,495 rows |
| `browse_stac_catalog` | 219 collections |
| `get_collection("pad-us-4.1-fee")` emitted URLs | all public; **zero** internal-host leaks |
| PMTiles object, browser prerequisites | `206` + `access-control-allow-origin` echoing the app origin |
| TiTiler `/cog/info` on a mirror COG | `200` |
| All 32 padus catalog/collection URLs on the mirror | 200 + real JSON |

## Not in this PR

- The three superseded files in **open-llm-proxy** (`headless/TESTING-DURING-CEPH-OUTAGE.md`, `outage-systemprompt-addendum.md`, `TESTING-DURING-CEPH-OUTAGE.bosl.json` — all from one commit, `99e49e6`, 2026-07-04). That repo is another agent's; deletion should be their call. This PR makes the replacement canonical so that cleanup is a straight delete.
- **DNS-level failover**, which would retire this document. Belongs in ops.