### PR TITLE
fix(#346): advertise a client-reachable STAC catalog URL

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -44,6 +44,7 @@ See [`AGENTS.md` → Rollout workflow](https://github.com/boettiger-lab/mcp-data
 
 | Variable | Default | Description |
 |---|---|---|
-| `STAC_CATALOG_URL` | NRP public catalog | URL of the STAC catalog to serve |
+| `STAC_CATALOG_URL` | NRP public catalog | URL of the STAC catalog to serve (the address *this server* reads) |
+| `STAC_PUBLIC_CATALOG_URL` | `STAC_CATALOG_URL` | The same catalog's client-reachable URL. Set it only when the server reads the catalog over an address clients can't resolve (e.g. an in-cluster mirror); this is what `browse_stac_catalog` and `GET /version` advertise |
 | `THREADS` | 100 | DuckDB thread count (S3 workloads are I/O-bound) |
 | `PORT` | 8000 | HTTP server port |

--- a/docs/guide/mirror-failover.md
+++ b/docs/guide/mirror-failover.md
@@ -38,6 +38,23 @@ In the app config (`layers-input.json`):
 If the app's `mcp_url` comes from a deployment env var rather than the config
 file, that is a manifest change: `kubectl apply` it, not just a rollout restart.
 
+### Don't guess the mirror host — ask the head
+
+A head reports the client-reachable URL of the catalog it is reading, so step 1
+can be read off the server instead of out of these manifests (#346):
+
+```bash
+curl -s https://duckdb-mcp.carlboettiger.info/version
+# {"version":"...","git_sha":"...",
+#  "stac_catalog_url":"https://minio.carlboettiger.info/public-data/stac/catalog.json",
+#  "public_base_url":"https://duckdb-mcp.carlboettiger.info"}
+```
+
+`/version` takes no MCP session and no auth token, so an app that has an
+`mcp_url` can derive its `catalog` at boot rather than carrying a hardcoded one
+that may be the very thing that's down. `browse_stac_catalog` reports the same
+URL in its header line.
+
 ### Verify before declaring it done
 
 ```bash
@@ -75,10 +92,12 @@ for how to stop owing it.
   paths and creates the matching anonymous, prefix-scoped DuckDB secrets. Never
   hand-edit an endpoint into query SQL.
 - **Internal vs public hosts.** A head's own read endpoint may be an in-cluster
-  address (e.g. `minio-svc.minio.svc.cluster.local`); the URLs it hands you for
-  client use are public. If `browse_stac_catalog` reports an in-cluster catalog
-  root, that's a display bug (#346) — the public equivalent is the mirror host
-  above; asset hrefs from `get_collection` are already public.
+  address (e.g. `minio-svc.minio.svc.cluster.local`), but every URL it hands you
+  for client use is public: asset hrefs from `get_collection`, tile URLs, and —
+  since #346 — the catalog root in `browse_stac_catalog`, which names the
+  in-cluster address only as a labelled aside when the two differ. An
+  unqualified in-cluster catalog root means the head predates #346; get the
+  public equivalent from `GET /version` (above).
 - **When mixing sources, always pass `s3_scope`.** A per-request `s3_endpoint`
   (or credentials) *without* a scope applies to every `s3://` path in that query
   and disables the server default for the request (deterministic since #273) —
@@ -94,6 +113,12 @@ S3_DEFAULT_ENDPOINT=minio.carlboettiger.info
 S3_SOURCES='[{"name":"minio","https_prefix":"https://minio.carlboettiger.info/","s3_prefix":"s3://"}]'
 STAC_CATALOG_URL=https://minio.carlboettiger.info/public-data/stac/catalog.json
 ```
+
+If your head reads the catalog over an address clients can't resolve (an
+in-cluster service DNS name, as the cirrus deployment does), also set
+`STAC_PUBLIC_CATALOG_URL` to the external URL of that same catalog — that is what
+`/version` and `browse_stac_catalog` advertise. It defaults to `STAC_CATALOG_URL`,
+so a head configured like the block above needs nothing.
 
 `s3://public-*` reads — and hex-tile reads, which honor the same default
 endpoint (#275) — then resolve to the mirror anonymously, with no per-query

--- a/k8s/cirrus-deployment.yaml
+++ b/k8s/cirrus-deployment.yaml
@@ -33,6 +33,12 @@ spec:
         # resolve to the on-node MinIO S3 endpoint (plain http, path-style).
         - name: STAC_CATALOG_URL
           value: "http://minio-svc.minio.svc.cluster.local:9000/public-data/stac/catalog.json"
+        # Same catalog, external address. STAC_CATALOG_URL above resolves only
+        # inside k3s, so it's useless in a client config; this is what
+        # browse_stac_catalog and GET /version advertise so a client can point
+        # itself at this mirror without reading these manifests (#346).
+        - name: STAC_PUBLIC_CATALOG_URL
+          value: "https://minio.carlboettiger.info/public-data/stac/catalog.json"
         # Reroute nrp_ceph STAC metadata fetches to in-cluster MinIO.
         - name: S3_ENDPOINT_URL
           value: "http://minio-svc.minio.svc.cluster.local:9000"

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.session import BaseSession
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-from stac import STAC_DATASETS, STAC_LOAD_ERRORS, STAC_CATALOG_URL, list_datasets as _stac_list, get_dataset as _stac_get, get_collection as _stac_get_collection, start_periodic_refresh as _stac_start_periodic_refresh
+from stac import STAC_DATASETS, STAC_LOAD_ERRORS, STAC_CATALOG_URL, list_datasets as _stac_list, get_dataset as _stac_get, get_collection as _stac_get_collection, public_catalog_url as _stac_public_catalog_url, start_periodic_refresh as _stac_start_periodic_refresh
 
 # Workaround for https://github.com/boettiger-lab/mcp-data-server/issues/5
 # send_notification crashes with ClosedResourceError when the client disconnects
@@ -398,6 +398,7 @@ from tiles.endpoint import serve_metadata, serve_tile
 from tiles.db import build_tile_connection
 from tiles.pyramid import (
     MVT_LAYER_NAME,
+    _public_base_url,
     prepare_hex_tiles,
     build_hex_tiles,
     cached_result_dict,
@@ -957,7 +958,20 @@ async def _healthz(_request):
 async def _version(_request):
     # App version + git SHA of the running image (issue #221). Lets consumers and
     # ops confirm what's deployed without cluster access.
-    return JSONResponse({"version": APP_VERSION, "git_sha": GIT_SHA})
+    #
+    # Also the server's self-configuration surface (#346): a client that holds only
+    # an `mcp_url` can GET <root>/version and learn where to fetch the catalog and
+    # tiles, with no MCP session and no markdown parsing. That closes the failure
+    # mode where a client's hardcoded `catalog` URL is down while this head is
+    # healthy on a mirror. Only *public* URLs go here — this route is deliberately
+    # auth-exempt, so the internal STAC_CATALOG_URL stays out of it (it is reported
+    # only in browse_stac_catalog, inside an authenticated session).
+    return JSONResponse({
+        "version": APP_VERSION,
+        "git_sha": GIT_SHA,
+        "stac_catalog_url": _stac_public_catalog_url(),
+        "public_base_url": _public_base_url(),
+    })
 
 # -------------------------------------------------------------------------
 # 10. SERVER START
@@ -1020,6 +1034,10 @@ if __name__ == "__main__":
 
     print("🚀 Starting DuckDB MCP Server...", file=sys.stderr)
     print(f"📂 STAC catalog: {STAC_CATALOG_URL}", file=sys.stderr)
+    if _stac_public_catalog_url() != STAC_CATALOG_URL:
+        # Worth a boot line: if this is wrong or unset, clients are told to fetch a
+        # catalog they can't reach (#346).
+        print(f"🌐 STAC catalog (advertised to clients): {_stac_public_catalog_url()}", file=sys.stderr)
     print(f"📊 Datasets loaded: {len(STAC_DATASETS)}", file=sys.stderr)
     # Keep every replica's STAC snapshot fresh without a rollout — a publish to S3
     # (new dataset OR new asset on an existing collection) becomes visible within

--- a/stac.py
+++ b/stac.py
@@ -23,6 +23,20 @@ STAC_CATALOG_URL = os.environ.get(
     "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
 )
 
+
+def public_catalog_url() -> str:
+    """The catalog URL a *client* should put in its own config.
+
+    `STAC_CATALOG_URL` is the address this server reads, which on some
+    deployments is in-cluster only (cirrus reads the MinIO mirror at
+    `minio-svc.minio.svc.cluster.local`). Advertising that verbatim leaves a
+    client unable to self-configure from the server (#346). Same pattern as
+    `MCP_PUBLIC_BASE_URL` in `tiles/pyramid.py`: read at call time, and default
+    to the internal URL so NRP prod — where the two are identical — is
+    unchanged.
+    """
+    return os.environ.get("STAC_PUBLIC_CATALOG_URL", "").strip() or STAC_CATALOG_URL
+
 # Backwards-compatible: STAC_TIMEOUT alone still works as a single knob; the two
 # new vars override it when set. Root is a hard prerequisite (generous timeout);
 # children are individually skippable (tight timeout). See
@@ -841,6 +855,9 @@ def list_datasets(
             lines.append(f"- **{cid}**: {first_line}")
         return "\n".join(lines)
 
+    # Set only when the server reads the catalog somewhere a client can't, so the
+    # advertised URL needs disambiguating (#346).
+    internal_note = ""
     if catalog_url:
         datasets = fetch_stac_catalog(catalog_url, catalog_token=catalog_token)
         url = catalog_url
@@ -853,11 +870,20 @@ def list_datasets(
         with _STAC_LOCK:
             datasets = dict(STAC_DATASETS)
             footer_errors = dict(STAC_LOAD_ERRORS)
-        url = STAC_CATALOG_URL
+        # Report the client-usable URL, not the one this process reads.
+        url = public_catalog_url()
+        if url != STAC_CATALOG_URL:
+            internal_note = (
+                f"(server reads it at {STAC_CATALOG_URL} — "
+                "use the first URL in client configs)"
+            )
     if not datasets and not footer_errors:
-        return f"No datasets loaded. STAC catalog: {url}"
+        msg = f"No datasets loaded. STAC catalog: {url}"
+        return f"{msg}\n{internal_note}" if internal_note else msg
     lines = [f"# Available Datasets ({len(datasets)} collections)\n"]
     lines.append(f"STAC catalog: `{url}`\n")
+    if internal_note:
+        lines.append(f"{internal_note}\n")
     for cid, summary in datasets.items():
         first_line = summary.split("\n")[0]
         lines.append(f"- **{cid}**: {first_line}")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -749,19 +749,51 @@ class TestHealthz:
         finally:
             server._MCP_AUTH_TOKEN = original
 
-    def test_version_returns_app_version_and_sha(self):
-        """GET /version reports the build-stamped app version + git SHA (issue #221)."""
+    def test_version_returns_app_version_and_sha(self, monkeypatch):
+        """GET /version reports the build-stamped app version + git SHA (issue #221),
+        plus the public URLs a client needs to configure itself (issue #346)."""
         import server
         from starlette.testclient import TestClient
+        monkeypatch.setenv("STAC_PUBLIC_CATALOG_URL", "https://mirror.test/catalog.json")
+        monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "https://mcp.test")
         orig_v, orig_s = server.APP_VERSION, server.GIT_SHA
         server.APP_VERSION, server.GIT_SHA = "v9.9.9", "deadbeef"
         try:
             client = TestClient(self._build_app())
             r = client.get("/version")
             assert r.status_code == 200
-            assert r.json() == {"version": "v9.9.9", "git_sha": "deadbeef"}
+            assert r.json() == {
+                "version": "v9.9.9",
+                "git_sha": "deadbeef",
+                "stac_catalog_url": "https://mirror.test/catalog.json",
+                "public_base_url": "https://mcp.test",
+            }
         finally:
             server.APP_VERSION, server.GIT_SHA = orig_v, orig_s
+
+    def test_version_never_leaks_the_internal_catalog_url(self, monkeypatch):
+        """/version is auth-exempt, so it reports only the client-facing catalog URL.
+        The in-cluster address stays inside authenticated MCP responses (#346)."""
+        import server, stac
+        from starlette.testclient import TestClient
+        monkeypatch.setattr(
+            stac, "STAC_CATALOG_URL", "http://minio-svc.minio.svc.cluster.local:9000/catalog.json"
+        )
+        monkeypatch.setenv("STAC_PUBLIC_CATALOG_URL", "https://minio.test/catalog.json")
+        client = TestClient(self._build_app())
+        body = client.get("/version").json()
+        assert body["stac_catalog_url"] == "https://minio.test/catalog.json"
+        assert "minio-svc" not in str(body)
+
+    def test_version_catalog_url_defaults_to_internal_when_no_public_set(self, monkeypatch):
+        """Unset → the server's own catalog URL, which on NRP prod is already public.
+        Clients get a usable value with no extra configuration."""
+        import server, stac
+        from starlette.testclient import TestClient
+        monkeypatch.delenv("STAC_PUBLIC_CATALOG_URL", raising=False)
+        monkeypatch.setattr(stac, "STAC_CATALOG_URL", "https://s3-west.test/catalog.json")
+        client = TestClient(self._build_app())
+        assert client.get("/version").json()["stac_catalog_url"] == "https://s3-west.test/catalog.json"
 
     def test_version_bypasses_auth_middleware(self):
         """/version is public (version discovery is the point) — reachable with no

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1714,6 +1714,111 @@ class TestInlineCollectionContent:
         assert result["id"] == "inline-col"
 
 
+class TestPublicCatalogUrl:
+    """`browse_stac_catalog` must advertise a catalog URL a *client* can fetch.
+
+    On cirrus the server reads an in-cluster MinIO address, so reporting
+    `STAC_CATALOG_URL` verbatim gave clients an unresolvable host and no way to
+    self-configure from the server (issue #346).
+    """
+
+    def _reset(self, stac_mod):
+        stac_mod.STAC_DATASETS.clear()
+        stac_mod._STAC_RAW.clear()
+        stac_mod.STAC_LOAD_ERRORS.clear()
+
+    def test_defaults_to_internal_url_when_unset(self, monkeypatch):
+        """No STAC_PUBLIC_CATALOG_URL → the internal URL, unchanged (NRP prod)."""
+        import stac
+
+        monkeypatch.delenv("STAC_PUBLIC_CATALOG_URL", raising=False)
+        monkeypatch.setattr(stac, "STAC_CATALOG_URL", "https://s3-west.example/catalog.json")
+        assert stac.public_catalog_url() == "https://s3-west.example/catalog.json"
+
+    def test_env_override_read_at_call_time(self, monkeypatch):
+        """Set → the public URL wins, with no module reload (same contract as
+        MCP_PUBLIC_BASE_URL in tiles/pyramid.py)."""
+        import stac
+
+        monkeypatch.setenv("STAC_PUBLIC_CATALOG_URL", "https://minio.example/catalog.json")
+        assert stac.public_catalog_url() == "https://minio.example/catalog.json"
+
+    def test_blank_env_falls_back_to_internal(self, monkeypatch):
+        """An empty/whitespace value is treated as unset, not as an empty URL —
+        otherwise a manifest with `value: ""` would advertise nothing."""
+        import stac
+
+        monkeypatch.setenv("STAC_PUBLIC_CATALOG_URL", "   ")
+        monkeypatch.setattr(stac, "STAC_CATALOG_URL", "http://internal.svc:9000/catalog.json")
+        assert stac.public_catalog_url() == "http://internal.svc:9000/catalog.json"
+
+    def test_list_datasets_reports_public_url_and_labels_internal(self, monkeypatch):
+        """When the two differ, the header line is the public URL and the internal
+        one appears only as a labelled aside."""
+        import stac
+
+        self._reset(stac)
+        stac.STAC_DATASETS["ds-1"] = "**DS 1**\nDescription"
+        monkeypatch.setattr(
+            stac, "STAC_CATALOG_URL", "http://minio-svc.minio.svc.cluster.local:9000/public-data/stac/catalog.json"
+        )
+        monkeypatch.setenv(
+            "STAC_PUBLIC_CATALOG_URL", "https://minio.carlboettiger.info/public-data/stac/catalog.json"
+        )
+
+        out = stac.list_datasets()
+
+        assert "STAC catalog: `https://minio.carlboettiger.info/public-data/stac/catalog.json`" in out
+        assert "server reads it at http://minio-svc.minio.svc.cluster.local:9000" in out
+        assert "use the first URL in client configs" in out
+        # The unresolvable host must never be the one presented as *the* catalog.
+        assert "STAC catalog: `http://minio-svc" not in out
+
+    def test_list_datasets_omits_note_when_urls_identical(self, monkeypatch):
+        """NRP prod (public catalog) output is byte-for-byte what it was — no aside."""
+        import stac
+
+        self._reset(stac)
+        stac.STAC_DATASETS["ds-1"] = "**DS 1**\nDescription"
+        monkeypatch.delenv("STAC_PUBLIC_CATALOG_URL", raising=False)
+        monkeypatch.setattr(stac, "STAC_CATALOG_URL", "https://s3-west.example/catalog.json")
+
+        out = stac.list_datasets()
+
+        assert "STAC catalog: `https://s3-west.example/catalog.json`" in out
+        assert "server reads it at" not in out
+
+    def test_empty_catalog_message_uses_public_url(self, monkeypatch):
+        """The degraded-start path (#262) is exactly when an operator is hunting for
+        a reachable catalog, so it must not hand back the in-cluster host either."""
+        import stac
+
+        self._reset(stac)
+        monkeypatch.setattr(stac, "STAC_CATALOG_URL", "http://minio-svc.minio.svc.cluster.local:9000/catalog.json")
+        monkeypatch.setenv("STAC_PUBLIC_CATALOG_URL", "https://minio.example/catalog.json")
+
+        out = stac.list_datasets()
+
+        assert "No datasets loaded" in out
+        assert "https://minio.example/catalog.json" in out
+        assert "server reads it at http://minio-svc" in out
+
+    def test_client_supplied_catalog_url_is_echoed_unchanged(self, monkeypatch):
+        """A caller-provided catalog_url is already client-usable — the public-URL
+        substitution must not leak into that branch."""
+        from unittest.mock import patch
+        import stac
+
+        self._reset(stac)
+        monkeypatch.setenv("STAC_PUBLIC_CATALOG_URL", "https://minio.example/catalog.json")
+        with patch("stac.fetch_stac_catalog", return_value={"ds-1": "**DS 1**\nDesc"}):
+            out = stac.list_datasets(catalog_url="https://elsewhere.example/catalog.json")
+
+        assert "STAC catalog: `https://elsewhere.example/catalog.json`" in out
+        assert "minio.example" not in out
+        assert "server reads it at" not in out
+
+
 class TestFormatCollectionUrl:
     """_format_collection surfaces the collection self href as collection_url."""
 


### PR DESCRIPTION
Closes #346.

## Problem

`browse_stac_catalog` reported the server-side `STAC_CATALOG_URL` verbatim. On cirrus that is an in-cluster address, so the one line telling a client where the catalog lives was the only URL in the whole session a client couldn't resolve. Still reproducible on `duckdb-mcp.carlboettiger.info` as of this PR:

```
# Available Datasets (219 collections)

STAC catalog: `http://minio-svc.minio.svc.cluster.local:9000/public-data/stac/catalog.json`
```

Meanwhile `get_collection` hands back hrefs on `https://minio.carlboettiger.info` — the exact mirror a client needs. Finding it during yesterday's Ceph outage meant reading `k8s/cirrus-*.yaml` and guessing hostnames.

## Change

1. **`stac.py`** — `public_catalog_url()` reads `STAC_PUBLIC_CATALOG_URL` at call time, defaulting to `STAC_CATALOG_URL`. Same contract as `MCP_PUBLIC_BASE_URL` in `tiles/pyramid.py`. Blank/whitespace is treated as unset.
2. **`list_datasets`** — reports the public URL; when the two differ, names the internal one as a labelled aside so the client knows which to put in its config:
   ```
   STAC catalog: `https://minio.carlboettiger.info/public-data/stac/catalog.json`
   (server reads it at http://minio-svc.minio.svc.cluster.local:9000/... — use the first URL in client configs)
   ```
   Covers the `No datasets loaded` branch too — degraded start (#262) is exactly when an operator is hunting for a reachable catalog. A caller-supplied `catalog_url` is echoed unchanged.
3. **`GET /version`** — item 4 of the issue, structured rather than prose:
   ```json
   {"version": "...", "git_sha": "...",
    "stac_catalog_url": "https://minio.carlboettiger.info/public-data/stac/catalog.json",
    "public_base_url": "https://duckdb-mcp.carlboettiger.info"}
   ```
   No MCP session, no auth token, no markdown parsing — a geo-agent app can take `mcp_url` alone and derive its `catalog` at boot, which retires the class of failure behind geo-agent#287. **Public URLs only**: this route is deliberately auth-exempt, so the internal address stays inside authenticated MCP responses (asserted by a test).
4. **`k8s/cirrus-deployment.yaml`** — sets `STAC_PUBLIC_CATALOG_URL`.
5. Docs: env-var table in `deployment.md`; `mirror-failover.md` gains an "ask the head" step and its stale "#346 is a display bug" bullet is corrected.

NRP prod is unaffected — `STAC_CATALOG_URL` there is already public, the two strings are equal, and output is byte-for-byte what it was (asserted by a test).

## Verification

- `395 passed` (full unit suite), including 7 new `TestPublicCatalogUrl` cases and 3 on `/version`.
- Advertised cirrus URL is fetchable from outside the cluster — the value in the manifest is correct, not just plausible:
  ```
  $ curl -sI https://minio.carlboettiger.info/public-data/stac/catalog.json | head -1
  HTTP/2 200
  ```

### Not done here

The cirrus rollout. This k3s cluster isn't in the kubeconfig available to me (only NRP `nautilus`), so it needs to be run from a machine with cirrus access — the deployment tracks `:main`, so after merge:

```
kubectl apply -f k8s/cirrus-deployment.yaml           # picks up STAC_PUBLIC_CATALOG_URL
kubectl rollout status deployment/duckdb-mcp -n mcp
curl -s https://duckdb-mcp.carlboettiger.info/version  # expect stac_catalog_url on minio.carlboettiger.info
```

The issue's second verification step (a geo-agent client configured only from that URL boots and answers the ca-30x30 slice) needs the client-side change to consume `/version`, which lives in geo-agent — worth filing there against #287 once this is deployed.