### PR TITLE
fix(ci): pin mcp SDK to 1.x — 2.0.0 moved mcp.server.fastmcp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-mcp
+# Pinned: the SDK's 2.0.0 (2026-07-28) moved/removed `mcp.server.fastmcp`, which
+# server.py imports. Unpinned, every fresh install resolves to 2.x and CI fails at
+# collection on every branch. Bump only together with the 2.x import migration.
+mcp>=1.29,<2
 # Pinned: the community `h3` extension is built per exact DuckDB version and
 # lags new releases. Unpinned, CI/image builds pull the latest DuckDB for which
 # `INSTALL h3 FROM community` may have no candidate, breaking every tile path.


### PR DESCRIPTION
**CI is red on every branch right now, including docs-only PRs.** One-line fix.

## Diagnosis

`requirements.txt` carried a bare `mcp`. The SDK released **2.0.0 on 2026-07-28**, and it moved/removed `mcp.server.fastmcp` — which `server.py:10` imports:

```
tests/test_server.py:10: in <module>
    from server import (
server.py:10: in <module>
    from mcp.server.fastmcp import FastMCP
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Branch-independent, and the timeline matches exactly:

| Run | Branch | Result |
|---|---|---|
| 2026-07-31 | `docs/consolidate-outage-runbook` (docs only) | fail |
| 2026-07-31 | `fix/346-public-catalog-url` | fail |
| 2026-07-21 | `main` | pass |
| 2026-07-20 | `fix/341-dev-digest-pin` | pass |

Nothing in the failing branches touches Python; the resolver simply started picking 2.x.

## Fix

`mcp>=1.29,<2` — the same reasoning as the `duckdb==1.5.4` pin immediately below it in the same file, and commented in the same style so the next person knows when it's safe to bump.

Deliberately **not** attempting the 2.x import migration here: that's a real API change and belongs to whoever owns the server surface, unblocked from this. Suggest an issue for it once CI is green.

Unblocks #347 and #348.