### PR TITLE
guidance(#312): coarsening a coverage fraction is a mean over children, not MAX

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -120,6 +120,8 @@ Units: `'km'`, `'m'`, or `'rads'`.
 
 **Always join by converting the finer (higher-numbered) dataset to the coarser resolution — never look for child columns on the coarser dataset.**
 
+Pick the reducer for that conversion by what the value means: a measured quantity per cell rolls up with `SUM` or `AVG`, but a **coverage fraction** (the share of a cell covered by something) rolls up as the mean over the parent's child cells — see *Feature coarser than the overlay layer* under Problem 3.
+
 ### Step 1: Check for pre-computed parent columns (preferred)
 
 Many fine-resolution datasets (e.g. GEBCO h8) already carry pre-computed parent columns (`h7`, `h6`, `h5`, ...). Use these directly — they are faster than calling `h3_cell_to_parent()` on every row. Check the schema first:
@@ -309,6 +311,32 @@ ORDER BY pct_conserved;
 ```
 
 Asking about **one** class ("what percent of hardwood woodland is conserved") is the same query with `WHERE f.whr13num = <code>` — keep the `frac × weight` product. Joining to the *distinct conserved cells* instead (a `SEMI JOIN` on `(h10, h0)`) counts every partly-conserved cell as fully conserved and overstates the percentage.
+
+**Feature coarser than the overlay layer — average the child cells.** *(Skip unless the feature's native resolution is coarser than the layer you are overlaying — e.g. a res-8 or res-9 feature against a res-10 coverage layer.)* Two reductions are needed, in this order. Across the overlapping units **within one fine cell**, take `MAX` (or `LEAST(SUM(w), 1)`), as above. Across the **child cells of a coarse parent**, take the mean — `SUM(w) / <children per parent>`, which is `7` for one resolution step (res-10 → res-9) and `49` for two (res-10 → res-8). The parent's weight is the share of the parent that is covered, so `MAX` across children is the wrong reducer there: it scores a whole parent as covered whenever a single child is.
+
+```sql
+WITH cell_w AS (          -- one weight per res-10 cell: MAX across overlapping units
+  SELECT h10, h8, h0, MAX((Final_g1_p + Final_g2_p) / 100.0) AS w
+  FROM read_parquet('<conserved-areas hex>')
+  GROUP BY h10, h8, h0
+),
+parent_w AS (             -- res-10 → res-8: mean over the 49 children
+  SELECT h8, h0, SUM(w) / 49 AS w8
+  FROM cell_w
+  GROUP BY h8, h0
+),
+feat AS (
+  SELECT DISTINCT h8, h0
+  FROM read_parquet('<res-8 feature hex>')
+  WHERE <feature filter>
+)
+SELECT 100 * SUM(COALESCE(p.w8, 0) * h3_cell_area(f.h8, 'km^2'))
+           / SUM(h3_cell_area(f.h8, 'km^2')) AS pct_conserved
+FROM feat f
+LEFT JOIN parent_w p USING (h8, h0);
+```
+
+Group on `h3_cell_to_parent(h10, 8)` when the fine layer carries no `h8` column. When the coarse feature is itself a `hex-fractions` layer, keep its `frac` in the product as in the same-resolution case: `SUM(f.frac * COALESCE(p.w9, 0)) / SUM(f.frac)`. Matching the coarse feature against the fine layer's *distinct cells* treats a parent as fully covered when any one child is; the inflation grows with the number of children per parent.
 
 **If you plan to mask this result against another hex dataset:** put the
 `SEMI JOIN` on the raw `read_parquet(...)` *before* `GROUP BY`, not in a


### PR DESCRIPTION
Closes #312.

## What was wrong

`h3-guide.md` documented the fractional-coverage overlay only for the **same-resolution** case, where `MAX` reduces the overlapping *units within one cell* to a single weight. That is correct. But when the feature's native resolution is coarser than the overlay layer — ACE / plant-richness / freshwater-richness at res-8, connectivity at res-9, against the res-10 conserved layer — a second reduction is needed, *across the child cells of each parent*, and the guide said nothing about it. Models applied the same word one level up (`GROUP BY h8 … MAX(w)`), which says "if any res-10 sub-cell is conserved, the whole 0.74 km² res-8 cell is conserved."

Measured in #312 on the shipping models: claude-sonnet-5 and kimi-k3 both returned 32.7% for ACE BioRank 5 (gold 21.09) and 25.8% for channelized connectivity (gold 22.65), in both trials. glm-5.2 passed both by never coarsening. The inflation scales with children per parent — ×1.55 at res-8 (49 children), ×1.15 at res-9 (7), ×1.00 at res-10 — which is why the CWHR habitat family has looked healthy throughout.

## The change

One gated subsection in Problem 3, immediately after the existing overlay block, stating the two reductions in order with the divisor spelled out (`7` per resolution step, `49` for res-10 → res-8) and a worked res-8 example. Plus a one-sentence pointer from *Joining Different Resolutions* — the section that steers a model into coarsening in the first place — distinguishing a measured quantity (`SUM`/`AVG`) from a coverage fraction (mean over children).

Follows the prompt-artifact rules in `AGENTS.md`: correct-shape SQL only (no ❌ block), a `Skip unless …` gate so the dominant same-resolution workload skims past, and the concrete dataset used only as an illustration of the general pattern.

## Ground truth

The pattern as written in the guide, run against the public catalog:

| cell | pattern in this PR | MAX rollup (the failure) | report gold |
|---|--:|--:|--:|
| ACE BioRank 5 (res-8, ÷49) | **21.17%** | 32.68% | 21.09% |
| channelized connectivity (res-9, ÷7) | **22.30%** | 25.58% | 22.65% |

Both inside the ±1.0 pp tolerance on the benchmark cells.

## Validation

Per `AGENTS.md` → *Validating guidance changes*: merge → dev picks up `:main` → run the `regression` tier from `geo-agent-benchmark` against **dev**. The gates for this change are `car-19-ace-biorank5` (`trap: h3-rollup-mean-not-max-res8`) and `car-23-channelized-connectivity` (`-res9`), which ride in the same tier as the standing baseline, so fix and regression check share one run. Results posted below before any prod promotion.

## Not in scope

#312 also floats publishing res-8/res-9 GAP 1+2 companion assets of the conserved-areas layer so agents can join at the feature's native resolution without doing the rollup. That is a `data-workflows` change, not a guidance one, and is left for a separate issue.