### PR TITLE
k8s(prod): promote v0.8.12 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.10@sha256:df2ddd2734f9dce60d29bf0aeb7b4c6c9bc03328eff41db3ebdff41f9549eda8
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.12@sha256:332d6df730c1fc66e7b2d317b121828fcb3785339a3a43b49789c3e22e6e0ffd
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod from `v0.8.10@sha256:df2ddd2` to `v0.8.12@sha256:332d6df`.

Built by `docker.yml` on the `v0.8.12` tag (run 30852533090, green); `release.yml` also green. Digest read from GHCR — tag for humans, digest enforced.

## What ships

- **#350 (#312)** — `h3-guide`: coarsening a coverage fraction to a parent cell is a mean over child cells, not `MAX`. This is the reason for the release. Gated on dev at `main@7a4403e`: `car-19-ace-biorank5` (res-8) and `car-23-channelized-connectivity` (res-9) pass **12/12** across glm-5.2 / kimi-k3 / claude-sonnet-5 × 2 trials, the `MAX`-rollup values (32.68 / 25.58) occur zero times, and **30/30** non-clarify baseline cells in the same run still pass. Details in #350.
- **#348 (#346)** — advertise a client-reachable STAC catalog URL.
- **#347** — mirror-failover is the single outage runbook.
- **#349** — pin the mcp SDK to 1.x (2.0.0 moved `mcp.server.fastmcp`).

`v0.8.11` was tagged 2026-07-21 but never promoted, so this is the first prod move since v0.8.10 and carries those three extra merges along with the guidance fix. Only #348 changes behavior beyond guidance text, and it has been on dev since it merged.

Rollout after merge, per `AGENTS.md`: `kubectl apply -f k8s/deployment.yaml`, then `kubectl rollout restart deployment/duckdb-mcp -n biodiversity`, then confirm all 6 replicas report the one digest and `/version` says `v0.8.12`.
