### PR TITLE
h3-guide: area-weight the fractional-overlay examples, and use the published per-cell weights assets

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -292,51 +292,48 @@ GROUP BY class;
 
 `get_schema` names the fractions asset and the no-data code. Per cell `SUM(frac) <= 1`; the shortfall is outside-raster/quantization, so do not treat the layer as covering 100% of a cell.
 
-**Overlaying two partial-coverage layers — multiply the coverage fractions; never count a cell as all-or-nothing.** *(Skip unless you are intersecting a fractional-coverage layer with another layer that only partly covers its cells — e.g. "what percent of each habitat class is conserved".)* Treating a cell as fully inside the other layer whenever it matches over-counts every partly-covered cell. Weight by the coverage fraction on **both** sides. The other layer's per-cell weight is either its own `frac`, or — for a vector layer tiled from features — a per-feature coverage share its STAC documents (e.g. ca30x30 conserved-areas: a unit's GAP 1+2 share is `Acres / Total_Acre`). Reduce to one weight per cell (`MAX` over the features on it), then multiply:
+**Overlaying two partial-coverage layers — multiply the coverage fractions, then weight by cell area; never count a cell as all-or-nothing.** *(Skip unless you are intersecting a fractional-coverage layer with another layer that only partly covers its cells — e.g. "what percent of each habitat class is conserved".)* Treating a cell as fully inside the other layer whenever it matches over-counts every partly-covered cell. Weight by the coverage fraction on **both** sides, and carry `h3_cell_area` through numerator and denominator: cells are not equal-area, so dividing by `SUM(frac)` alone biases the share toward whichever latitudes hold more cells.
+
+The other layer's per-cell weight comes from a companion **per-cell weights asset** when one exists — `get_schema` names it (e.g. ca30x30 conserved-areas publishes `…-hex-weights` at res 10, with `w1`–`w4` giving the share of each cell in GAP status 1–4). Otherwise reduce the layer's features to one weight per cell first: `MAX` over the features on the cell of the per-feature coverage share its STAC documents.
+
+A weights asset covers only its own footprint, so `LEFT JOIN` it and `COALESCE(…, 0)`. Bound the result with a dense land grid for the region (California: `ca30x30-ecoregion` at res 10) — without it the denominator picks up cells outside the region.
 
 ```sql
-WITH cell_w AS (   -- per cell: covering unit's GAP 1+2 coverage share (STAC-documented overlay weight)
-  SELECT h10, h0, MAX(Acres / NULLIF(Total_Acre, 0)) AS w
-  FROM (SELECT DISTINCT h10, h0, _cng_fid, Acres, Total_Acre
-        FROM read_parquet('<conserved-areas hex>'))
-  GROUP BY h10, h0
+WITH land AS (   -- dense res-10 land grid bounding the region
+  SELECT DISTINCT h10, h0 FROM read_parquet('<ecoregion hex>')
 )
 SELECT f.whr13num,
-       100 * SUM(f.frac * COALESCE(c.w, 0)) / SUM(f.frac) AS pct_conserved
+       100 * SUM(f.frac * COALESCE(c.w1 + c.w2, 0) * h3_cell_area(f.h10, 'km^2'))
+           / SUM(f.frac * h3_cell_area(f.h10, 'km^2')) AS pct_conserved
 FROM read_parquet('<cwhr13 hex-fractions>') f
-LEFT JOIN cell_w c ON f.h10 = c.h10 AND f.h0 = c.h0
+JOIN land l ON f.h10 = l.h10 AND f.h0 = l.h0
+LEFT JOIN read_parquet('<conserved-areas hex-weights>') c ON f.h10 = c.h10 AND f.h0 = c.h0
 WHERE f.whr13num <> 0
 GROUP BY f.whr13num
 ORDER BY pct_conserved;
 ```
 
-Asking about **one** class ("what percent of hardwood woodland is conserved") is the same query with `WHERE f.whr13num = <code>` — keep the `frac × weight` product. Joining to the *distinct conserved cells* instead (a `SEMI JOIN` on `(h10, h0)`) counts every partly-conserved cell as fully conserved and overstates the percentage.
+Asking about **one** class ("what percent of hardwood woodland is conserved") is the same query with `WHERE f.whr13num = <code>` — keep the `frac × weight × area` product. Joining to the *distinct conserved cells* instead (a `SEMI JOIN` on `(h10, h0)`) counts every partly-conserved cell as fully conserved and overstates the percentage.
 
-**Feature coarser than the overlay layer — average the child cells.** *(Skip unless the feature's native resolution is coarser than the layer you are overlaying — e.g. a res-8 or res-9 feature against a res-10 coverage layer.)* Two reductions are needed, in this order. Across the overlapping units **within one fine cell**, take `MAX` (or `LEAST(SUM(w), 1)`), as above. Across the **child cells of a coarse parent**, take the mean — `SUM(w) / <children per parent>`, which is `7` for one resolution step (res-10 → res-9) and `49` for two (res-10 → res-8). The parent's weight is the share of the parent that is covered, so `MAX` across children is the wrong reducer there: it scores a whole parent as covered whenever a single child is.
+**Feature coarser than the overlay layer — read the weights asset at the feature's own resolution.** *(Skip unless the feature's native resolution is coarser than the layer you are overlaying — e.g. a res-8 or res-9 feature against a res-10 coverage layer.)* Weights assets are published per resolution (`…-hex-weights-res9`, `…-hex-weights-res8`) and the coarser ones are already averaged over the fine cells inside each parent, so no rollup is needed. Weight each coarse cell by its **land** area — `nland * h3_cell_area(h8, 'km^2')`, where `nland` counts the fine land cells inside it — since coastal and border cells are only partly land.
 
 ```sql
-WITH cell_w AS (          -- one weight per res-10 cell: MAX across overlapping units
-  SELECT h10, h8, h0, MAX((Final_g1_p + Final_g2_p) / 100.0) AS w
-  FROM read_parquet('<conserved-areas hex>')
-  GROUP BY h10, h8, h0
-),
-parent_w AS (             -- res-10 → res-8: mean over the 49 children
-  SELECT h8, h0, SUM(w) / 49 AS w8
-  FROM cell_w
-  GROUP BY h8, h0
-),
-feat AS (
+WITH feat AS (
   SELECT DISTINCT h8, h0
   FROM read_parquet('<res-8 feature hex>')
   WHERE <feature filter>
 )
-SELECT 100 * SUM(COALESCE(p.w8, 0) * h3_cell_area(f.h8, 'km^2'))
-           / SUM(h3_cell_area(f.h8, 'km^2')) AS pct_conserved
+SELECT 100 * SUM((p.w1 + p.w2) * p.nland * h3_cell_area(f.h8, 'km^2'))
+           / SUM(p.nland * h3_cell_area(f.h8, 'km^2')) AS pct_conserved
 FROM feat f
-LEFT JOIN parent_w p USING (h8, h0);
+JOIN read_parquet('<conserved-areas hex-weights-res8>') p USING (h8, h0);
 ```
 
-Group on `h3_cell_to_parent(h10, 8)` when the fine layer carries no `h8` column. When the coarse feature is itself a `hex-fractions` layer, keep its `frac` in the product as in the same-resolution case: `SUM(f.frac * COALESCE(p.w9, 0)) / SUM(f.frac)`. Matching the coarse feature against the fine layer's *distinct cells* treats a parent as fully covered when any one child is; the inflation grows with the number of children per parent.
+The res-9 and res-8 weights assets carry a row for every land cell in the region, so this join also bounds the result to land — no separate land grid is needed.
+
+When no weights asset is published at the coarse resolution, roll the fine layer up in two reductions, in this order: `MAX` (or `LEAST(SUM(w), 1)`) across the units overlapping **one fine cell**, then the mean across the **child cells of a coarse parent** — `SUM(w) / <children per parent>`, `7` for one resolution step (res-10 → res-9) and `49` for two (res-10 → res-8). `MAX` is the wrong reducer across children: it scores a whole parent as covered whenever a single child is.
+
+Group on `h3_cell_to_parent(h10, 8)` when the fine layer carries no `h8` column. When the coarse feature is itself a `hex-fractions` layer, keep its `frac` in the product as in the same-resolution case: `SUM(f.frac * p.w9 * p.nland * h3_cell_area(f.h9, 'km^2')) / SUM(f.frac * p.nland * h3_cell_area(f.h9, 'km^2'))`. Matching the coarse feature against the fine layer's *distinct cells* treats a parent as fully covered when any one child is; the inflation grows with the number of children per parent.
 
 **If you plan to mask this result against another hex dataset:** put the
 `SEMI JOIN` on the raw `read_parquet(...)` *before* `GROUP BY`, not in a


### PR DESCRIPTION
Closes #356.

> [!IMPORTANT]
> **Not validated yet — do not promote to prod on the strength of this PR.** Per AGENTS.md §"Validating guidance changes", a prompt-artifact change is not done until the headless model suite on dev shows both (a) the targeted failure fixed and (b) no baseline regression. That run happens *after* merge, since dev tracks `:main`. Everything below is operator SQL establishing ground truth — which AGENTS.md is explicit does **not** substitute: it proves the pattern works, not that the guidance steers the model to it. Two blockers are flagged at the bottom.

## What was wrong

`h3-guide.md` carried two worked examples for overlaying a partial-coverage feature against a partial-coverage layer, and they disagreed on whether to weight by cell area. The same-resolution one (line 305, repeated at 339) divided by `SUM(frac)`; the coarse-feature one (line 333) divided by `SUM(h3_cell_area)`. Line 36 of the same file states the rule — H3 cells are not equal-area — and line 38 calls the scoped case the accuracy-critical one.

The unweighted branch is the one that fires for a res-10 feature, which is the CWHR13-vs-conserved-areas question a partner asked the California 30x30 app.

## The fix

1. **Carry `h3_cell_area` through both fractional-overlay examples**, matching line 333.
2. **Point the examples at the published per-cell weights assets** (`…-hex-weights`, `…-hex-weights-res9`, `…-hex-weights-res8`, from data-workflows#506/#508) instead of deriving the weight by hand from `MAX(Acres / Total_Acre)` and a `SUM(w) / 49` rollup. The issue flagged this as worth doing in the same pass; it also removes a second source of error, since `Acres / Total_Acre` is a unit's GAP 1+2 share, not its share of the cell.
3. **Bound the denominator with the dense land grid.** The res-10 weights asset is sparse (52.5M-acre inventory footprint, not California's 101.5M acres), so the example keeps `LEFT JOIN` + `COALESCE(…, 0)` and joins `ca30x30-ecoregion` at res 10. This turned out to be load-bearing, not cosmetic: the cwhr13 layer extends past California, and without the mask code 32 comes out at 29.89 rather than 33.31.
4. **Weight the coarse case by land area**, `nland * h3_cell_area(h8, 'km^2')`, since coastal and border res-8 cells are only partly land.

The general reductions (`MAX` within a fine cell, mean across children) are kept in prose as the fallback for layers with no published weights asset. No antipattern blocks, per AGENTS.md:137. The section grows 547 → 598 words (+9%) — worth a reviewer's eye against AGENTS.md's "tighter wording is safer wording"; the growth is the fallback paragraph.

## Ground truth (operator SQL, prod MCP)

The issue's reproduce query, after the fix:

| CWHR13 class | before (guide as written) | after | 2025 assessment |
|---|---:|---:|---:|
| Conifer Woodland (32) | 32.07 | **33.31** | 33.27 |
| Hardwood Forest (51) | 21.32 | **21.65** | 21.59 |
| Conifer Forest (31) | 23.75 | **24.20** | 24.14 |
| Shrub (70) | 27.57 | **27.82** | 27.79 |
| Barren/Other (20) | 51.97 | **51.70** | 51.67 |

Two independent totals cross-check the corrected form: per-class areas now sum to **101.45M acres** (California's land area) against 96.4M for the old formula, and GAP 1+2 to **26.51M** against the 26.47M stated in the collection description, where the old formula gave 24.49M.

For the coarse case, statewide GAP 1+2 share from the res-8 weights asset:

| weighting | result |
|---|---:|
| `nland * h3_cell_area(h8)` (this PR) | **26.135%** |
| `nland` alone | 25.684% |
| res-10 ground truth | 26.135% |

`105 passed` on `tests/`.

## Blockers before this can ship

1. **The benchmark gold is wrong in the same way and will report this fix as a regression.** `geo-agent-benchmark/suite/gold/ca-30x30.md` Q4 and `suite/questions/ca-30x30/ca-cwhr13-pct-conserved.yaml` carry gold SQL that is *verbatim the old line-305 formula* — same `MAX(Acres/Total_Acre)` CTE, same `SUM(frac*w)/SUM(frac)`. Gold says 28.8% for Conifer Woodland against a `±3pt` tolerance; the corrected guidance yields 33.3%, so the `regression` tier fails the fix. The gold needs re-deriving first (branch prepared, PR held — see 2). Q5 (hardwood woodland, L3 report-authoritative, 13.6%) is unaffected: the corrected form still gives 13.60%.
2. **data-workflows#523 contradicts this change at the STAC layer.** The `-hex-weights-res9`/`-res8` asset descriptions document `SUM((w1+w2)*nland)/SUM(nland)` as correct — the 25.684% row above. Until that lands, the injected guide and the per-dataset text tell a model opposite things about the same operation.

Suggested order: data-workflows#523 → re-derive gold → merge here → dev matrix (`MODELS="z-ai/glm-5.2 deepseek/deepseek-v4-flash-0731"`, the cost-bounded standard pair) → prod.