### PR TITLE
k8s(prod): promote v0.8.13 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.12@sha256:332d6df730c1fc66e7b2d317b121828fcb3785339a3a43b49789c3e22e6e0ffd
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.13@sha256:1a3409d56f62bc8c9ba252a8960eb0dad16a240e24c400620eb7afae5233db7f
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
> **On hold — see #364.** `v0.8.13` carries the #357 coarse-resolution overlay example, which reads
> `nland` from the `…-hex-weights-res8`/`-res9` assets. data-workflows#524 removed that column an hour
> after #357 merged, so promoting this digest would ship an example that is a binder error on any
> res-8/res-9 question. Fixed in #365; this promotion should be re-cut on a tag that includes it and
> re-gated. The gate below stays valid for what it covered — it exercised the res-10 path
> (CWHR13 percent-conserved), which is unaffected — but it never touched the broken branch, so a
> re-gate wants a cell that asks a res-8 or res-9 feature question.

Promotes prod from **v0.8.12** to **v0.8.13**.

```
-  image: …:v0.8.12@sha256:332d6df730c1fc66e7b2d317b121828fcb3785339a3a43b49789c3e22e6e0ffd
+  image: …:v0.8.13@sha256:1a3409d56f62bc8c9ba252a8960eb0dad16a240e24c400620eb7afae5233db7f
```

Digest resolved via the GHCR anonymous-pull manifest HEAD (docker CLI unavailable in this environment). **Method validated**: resolving `v0.8.12` the same way returns `sha256:332d6df…`, exactly the digest this commit replaces. The `v0.8.13` tag and the `19b3c709` git-sha tag resolve to the same digest.

## What ships

| PR | |
|---|---|
| #357 | fractional-overlay examples weight by `h3_cell_area`, use the published `hex-weights` assets, bound the denominator with the ecoregion land grid |
| #360 | rebuts the "area terms cancel" rationalization that survived #357 |
| #358 | opt-in experimental raster+zarr image — separate tag and endpoint, inert here (`EXTRA_DUCKDB_EXTENSIONS` unset on the default image) |
| #351 | guidance-validation runbook fix |

## Gate result (dev @ 19b3c709, regression tier, 3 trials × 2 models)

| model | t1 | t2 | t3 |
|---|---|---|---|
| z-ai/glm-5.2 | 33.3 ✅ | 33.3 ✅ | 33.3 ✅ |
| deepseek/deepseek-v4-flash-0731 | 33.3 ✅ | 33.3 ✅ | 33.3 ✅ |

**Zero occurrences** of the pre-fix 28.8% form, and zero of the 32.1% marginal form seen in the first gate. Every trial carried the area term and applied the California mask; deepseek stated the ratio explicitly as `100 × SUM(frac × (w1+w2) × cell_area) / SUM(frac × cell_area)`.

Worth recording: 33.3 is only reachable *with both* corrections — unweighted+mask gives 32.07, weighted-without-mask 29.89 — so the value corroborates the method independently. But 32.07 rounds inside the cell's ±3pt tolerance, so tolerance alone never separates a correct method from a lucky one; this cell needs a method audit.

Baseline unchanged: Mojave 7,373,400 · GAP 1+2 26,471,500 · hardwood woodland 13.6% · California 26.08–26.1% · BioRank 21.18–21.2 · channelized 22.5% (last two matching the 2026-08-03 run).

## Deploy steps after merge

```
kubectl apply -f k8s/deployment.yaml
kubectl rollout restart deployment/duckdb-mcp -n biodiversity
kubectl -n biodiversity get pods -l app=duckdb-mcp \
  -o custom-columns='NAME:.metadata.name,IMAGE:.status.containerStatuses[0].imageID'   # all 6 must converge
```

## Note

`geo-agent-benchmark` gold for `ca-cwhr13-pct-conserved` was corrected in geo-agent-benchmark#13 — it had encoded the same unweighted formula as the guidance, so the suite could not have caught this. ~~data-workflows#523 (res-9/res-8 STAC rollup recipe) is still open and contradicts the shipped guidance at the per-dataset layer; it does not block this promotion but should land soon after.~~ **Stale as written:** the per-dataset STAC text was corrected by data-workflows#524 on 2026-08-07, before this PR was opened, and #523 is closed as superseded — there is no remaining contradiction at that layer. What #524 also did was drop `nland` from the weights assets, which is what puts this promotion on hold (#364).
