### PR TITLE
k8s(prod): promote v0.8.14 by digest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.12@sha256:332d6df730c1fc66e7b2d317b121828fcb3785339a3a43b49789c3e22e6e0ffd
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.14@sha256:9dda8e42f0bcaec6237e8cb677ce26dc515d16bab17fd1500e108cb27ad8b880
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod **v0.8.12 → v0.8.14**. Replaces #362 (v0.8.13), closed as superseded.

```
-  image: …:v0.8.12@sha256:332d6df730c1fc66e7b2d317b121828fcb3785339a3a43b49789c3e22e6e0ffd
+  image: …:v0.8.14@sha256:9dda8e42f0bcaec6237e8cb677ce26dc515d16bab17fd1500e108cb27ad8b880
```

Digest cross-checked two ways — the `v0.8.14` tag and the `0f2fc25…` git-sha tag resolve to the same digest — and the method validated by resolving `v0.8.12`, which returns `sha256:332d6df…`, exactly the digest this commit replaces.

## Why this matters

**Prod has been on v0.8.12 the whole time**, so it is still serving the pre-#357 unweighted overlay guidance — the silent-wrong-answer bug from #356 that a partner reported against the published 2025 Biodiversity Assessment. This is the first release that actually fixes it.

## What ships

| PR | |
|---|---|
| #357 | fractional-overlay examples weight by `h3_cell_area`, use published `hex-weights`, bound with the ecoregion land grid (#356) |
| #360 | rebuts "the area terms cancel" — the rationalization that survived #357 |
| #365 | coarse-overlay example uses `land_area_km2`, not the removed `nland` (#364) |
| #358 | opt-in experimental raster+zarr image — separate tag/endpoint, inert here |
| #351, #342 | guidance-validation runbook fix; dev digest pin + convergence check (#341) |

## Validation

**res-10 path — gated on dev, 3 trials × 2 models: 6/6.** Zero occurrences of the pre-fix 28.8% form and zero of the 32.1% wrong-method-inside-tolerance form. Every trial carried the area term and applied the California mask.

**res-8 path — verified by hand, because the tier cannot test it.** This is the honest caveat: the regression tier has no res-8 question, which is exactly how #364 shipped through a green 6/6 gate. Direct check of the shipped recipe:

| | |
|---|---:|
| shipped recipe, res 8 | **26.135** |
| res-10 ground truth, same scope | **26.135** |
| pre-data-workflows#522 `nland` count-weighting | 25.684 |
| what v0.8.13 shipped | *binder error* |

Coverage gap filed as geo-agent-benchmark#21; do not read the 6/6 as covering the coarse path.

**Baseline unchanged**: Mojave 7,373,400 · GAP 1+2 26,471,500 · hardwood woodland 13.6% · California 26.08–26.1% · BioRank 21.18–21.2 · channelized 22.5%.

## After merge

```
kubectl apply -f k8s/deployment.yaml
kubectl rollout restart deployment/duckdb-mcp -n biodiversity
kubectl -n biodiversity get pods -l app=duckdb-mcp \
  -o custom-columns='NAME:.metadata.name,IMAGE:.status.containerStatuses[0].imageID'   # all 6 converge
```

## Coordination

Further edits to this guidance block are sequenced under #367, behind the gate-coverage work (geo-agent-benchmark#21, #16, #9). This should be the last patch to that section before a single design pass covering #363/#354/#355/#289/#353.