### PR TITLE
guidance(#256): agg=COUNT drops a pre-aggregated value column — steer to SUM/AVG/MAX

### DIFF
--- a/server.py
+++ b/server.py
@@ -601,7 +601,11 @@ def register_hex_tiles(
       `SELECT h3_cell_to_parent(h10, 6) AS h6, ...`).
     - `agg`: aggregation applied at each coarser pyramid level.
         - "COUNT" (default): SQL needs only the H3 column; output property
-          is `count` (row count per hex).
+          is `count` (row count per hex). Use it for raw, un-grouped
+          point/polygon rows. If your SELECT already produced one row per
+          cell (you wrote `GROUP BY h<H>`), pass "SUM" to total that value up
+          the pyramid, or "AVG"/"MAX" for an intensity — COUNT would count the
+          single row per cell and drop your value column.
         - "AVG" / "SUM" / "MIN" / "MAX": SQL must return at least one
           numeric value column after the H3 index; each is aggregated by
           `agg` at every coarser level.


### PR DESCRIPTION
Closes #256.

## Problem
`register_hex_tiles` with `agg="COUNT"` counts rows per hex and ignores the value column. When a model's SELECT already aggregated to one value per cell (`GROUP BY hN`), COUNT returns `1` at native resolution and the computed value is discarded; the coarse levels then read `343 / 49 / 7` — nested child-cell counts (7³/7²/7¹), not the intended quantity. A model reading "count of X per hex" → `COUNT` does the locally-reasonable thing and loses its own column.

## Change
Extend the `"COUNT"` bullet in the `register_hex_tiles` docstring — the layer surfaced exactly when the model picks `agg`, per the AGENTS.md layering model (docstring, **not** `h3-guide.md`). Positive-framed, prose rationale in the same style as the adjacent `COUNT_DISTINCT` bullet, no ❌/antipattern SQL block:

> Use it for raw, un-grouped point/polygon rows. If your SELECT already produced one row per cell (you wrote `GROUP BY h<H>`), pass `"SUM"` to total that value up the pyramid, or `"AVG"`/`"MAX"` for an intensity — COUNT would count the single row per cell and drop your value column.

## ⚠️ Validation gate — do not merge to prod until green
This edits an injected prompt artifact, so per AGENTS.md *Validating guidance changes* it must pass the headless model-suite on **dev** first:
- **Trap:** "show iucn endangered species richness across africa/globally as hex" (the exact failing shape; `qwen3` exhibited it) + a spread (`glm-5 kimi gpt-oss minimax-m2`).
- **Pass:** models emit `agg="SUM"` (or `COUNT_DISTINCT` via pattern 3 for richness) with the pre-aggregated column, **zero** COUNT-on-grouped-SQL recurrences, and **no regression** on the standing baseline.
- On success, add the trap question to the `regression` tier.

Tracked as chunk C on the board #371; validation is chunk G.

Local `test_server.py` green (docstring/tool tests: 16 passed).