### PR TITLE
ci(#369): execute the guidance-file SQL examples in CI

### DIFF
--- a/.github/workflows/guidance-sql.yml
+++ b/.github/workflows/guidance-sql.yml
@@ -1,0 +1,49 @@
+name: Guidance SQL
+
+# Executes the ```sql examples embedded in the guidance files (h3-guide.md,
+# query-optimization.md, query-setup.md) — which server.py injects verbatim into
+# the query tool description — against public data, so a broken example (a moved
+# column like #364's `nland`, a renamed function, a path that no longer resolves)
+# fails CI before it ships. The model gate cannot catch this: a model routes
+# around a broken example, so the gate goes green either way (#369).
+#
+# No secrets: reads go anonymously to the public source.coop mirror / Ceph
+# external endpoint, same posture as examples.yml. The runner installs the h3
+# community extension itself. The weekly cron catches the catalog rolling forward
+# under a still-valid-looking example.
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'h3-guide.md'
+      - 'query-optimization.md'
+      - 'query-setup.md'
+      - 'tests/guidance_sql/**'
+      - '.github/workflows/guidance-sql.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'h3-guide.md'
+      - 'query-optimization.md'
+      - 'query-setup.md'
+      - 'tests/guidance_sql/**'
+      - '.github/workflows/guidance-sql.yml'
+  schedule:
+    - cron: '17 6 * * 1'   # Mondays 06:17 UTC — catch catalog drift
+  workflow_dispatch:
+
+jobs:
+  guidance-sql:
+    name: Execute guidance SQL examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+      - name: Install DuckDB
+        run: |
+          python -m pip install --upgrade pip
+          pip install 'duckdb==1.5.4'
+      - name: Run guidance SQL harness
+        run: python tests/guidance_sql/run.py

--- a/tests/guidance_sql/fixture.py
+++ b/tests/guidance_sql/fixture.py
@@ -1,0 +1,84 @@
+"""Classification of every ```sql block in the guidance files (#369).
+
+Keyed by `<file>:<sha1(block-text)[:10]>` — see run.py. Editing a block changes
+its key, forcing re-classification (a stale entry then fails CI).
+
+EXECUTABLE[key] = {placeholder: value} — every `<placeholder>` in the block must
+be mapped; the substituted statement is executed against public data.
+
+FRAGMENTS[key] = "reason" — an illustrative snippet that is not a standalone
+statement (a bare clause, a CTE referencing an undefined relation, a write-path
+COPY, or a real query whose datasets are not yet mapped).
+
+Placeholders map to a SINGLE `h0=` partition so a block binds every path and
+column and runs cheaply — enough to catch a moved column (#364), a renamed
+function, or a path that no longer resolves, which is what the model gate cannot
+see. It is not a result-value check (that is the model gate's job).
+
+Datasets/paths verified 2026-08-11. To grow coverage, promote a FRAGMENT whose
+reason is "not yet mapped" to EXECUTABLE with real mappings and confirm it runs.
+"""
+
+# One CA partition present in every dataset used below (verified).
+_H0 = "577762574070710271"
+
+# ca30x30 conserved-areas assessment family (the #364 coarse-overlay surface)
+ECO8 = f"s3://public-ca30x30/ecoregion/hex-res8/h0={_H0}/data_0.parquet"          # h8, nland, land_area_km2, h0
+CW8 = f"s3://public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-res8/h0={_H0}/data_0.parquet"  # h8, w1..w4, h0
+# cross-dataset staples
+CENSUS = f"s3://public-census/census-2024/state/hex/h0={_H0}/data_0.parquet"      # h8, STUSPS, GEOID, h0
+CARBON = f"s3://public-carbon/irrecoverable-carbon-2024/hex/h0={_H0}/data_0.parquet"  # carbon, h5..h9, h0
+
+EXECUTABLE = {
+    # [1] region/feature area in acres — DISTINCT cells, h3_cell_area
+    "h3-guide.md:eec81dd65f": {"<hex>": ECO8, "<scope>": "nland > 0"},
+    # [3] feature centroid via h3_cell_to_lat/lng
+    "h3-guide.md:c39c327be6": {"<hex parquet path>": ECO8, "<feature filter>": "nland > 0"},
+    # [5] DESCRIBE — which resolution columns exist
+    "h3-guide.md:7a099891c4": {"<STAC_PATH>": ECO8},
+    # [8] value masked to a state via IN (h0) + IN (h8) subqueries
+    "h3-guide.md:3b2c2a2998": {"<value_hex>": CARBON, "<census_state_hex>": CENSUS},
+    # [9] same, via SEMI JOIN (the recommended mask-before-aggregate form)
+    "h3-guide.md:b6baef4cdf": {"<value_hex>": CARBON, "<census_state_hex>": CENSUS},
+    # [16] res-8 coarse-feature overlay weighted by land_area_km2 + (w1+w2) —
+    #      the exact shape #364 shipped broken; binds land_area_km2 (ecoregion)
+    #      and w1/w2 (weights) so a moved column fails here.
+    "h3-guide.md:40c748d887": {
+        "<res-8 feature hex>": ECO8,
+        "<feature filter>": "nland > 0",
+        "<ecoregion hex-res8>": ECO8,
+        "<conserved-areas hex-weights-res8>": CW8,
+    },
+    # [19] rows-per-hex profiling on a single partition
+    "h3-guide.md:2aab9a5de8": {"<STAC_HEX_PATH_SINGLE_PARTITION>": ECO8},
+    # query-setup.md — the required SET/LOAD preamble (no S3); validates it runs
+    "query-setup.md:0cc5a10e39": {},
+}
+
+FRAGMENTS = {
+    # --- h3-guide.md ---
+    "h3-guide.md:523cd143ac": "two-query block; the per-group form needs a literal `state` column not present in a clean mapping",
+    "h3-guide.md:21d7da17ad": "incomplete — `FROM ...` ellipsis (illustrative approx-area shortcut)",
+    "h3-guide.md:da9876be19": "incomplete — `FROM ...` ellipsis (great-circle distance illustration)",
+    "h3-guide.md:39e204c12b": "GEBCO x geomorphology h6 join; two co-indexed datasets not yet mapped",
+    "h3-guide.md:e258e8fec8": "bare JOIN clauses over undefined dataset_a/b, wdpa/gfw (resolution-conversion idiom)",
+    "h3-guide.md:598ddf3355": "needs dataset-specific columns (_cng_fid, amount, state_id); no representative mapping",
+    "h3-guide.md:e2dfe983ec": "CTE fragment referencing an undefined `flat_funding` relation",
+    "h3-guide.md:ec06ef4087": "CTE fragment referencing undefined `countries`/`carbon_data` relations",
+    "h3-guide.md:377ec327e2": "two-query block over generic `value`/`class` columns (SUM/AVG vs MODE illustration)",
+    "h3-guide.md:b774ac61d1": "fractional-coverage overlay; a class+frac dataset is not yet mapped (promote in the #367 design pass)",
+    "h3-guide.md:a3af36a53b": "res-10 fractional overlay; cwhr13 fractions + res-10 conserved weights not yet mapped (design pass)",
+    "h3-guide.md:1ccc1fb7d7": "references an undefined `mask` relation (DPP mask-first illustration)",
+    "h3-guide.md:acf2ad1267": "line-mileage over line/aoi hex + geoparquet datasets not yet mapped (promote with #363)",
+    "h3-guide.md:ae094c7f8c": "COPY to a write path with a `SELECT ...` ellipsis (export idiom)",
+    # --- query-optimization.md ---
+    "query-optimization.md:2f7793ba77": "bare JOIN clause (include-h0-in-join idiom)",
+    "query-optimization.md:a941d3b637": "regions x padus x carbon 3-way; regions/padus hex paths not yet mapped",
+    "query-optimization.md:0681d81d61": "references an undefined `scope` CTE (join-before-aggregate illustration)",
+    "query-optimization.md:48c32ed53a": "`<bucket>/<dataset>` with `_cng_fid` and `data_00.parquet`; dataset not yet mapped",
+    "query-optimization.md:e103e0c492": "`read_parquet('…')` ellipsis placeholder (DESCRIBE-to-find-a-column idiom)",
+    "query-optimization.md:b344ccbf7e": "bare WHERE clause (fuzzy text match)",
+    "query-optimization.md:557a390cc8": "bare WHERE clause (exact text match)",
+    "query-optimization.md:b63ace2673": "bare WHERE clauses incl. a deliberate parse-error illustration; not executable",
+    "query-optimization.md:29b78ebc22": "generic `value`/`lc_class` columns with sentinel exclusion; dataset not yet mapped",
+}

--- a/tests/guidance_sql/run.py
+++ b/tests/guidance_sql/run.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Execute the SQL examples embedded in the guidance files, in CI (#369).
+
+`h3-guide.md`, `query-optimization.md` and `query-setup.md` are runtime prompt
+artifacts: `server.py` injects them verbatim into the `query` tool description.
+An example that no longer runs is a defect in a shipped artifact — a moved column
+(#364's `nland`), a renamed function, a path that no longer resolves — and the
+model gate cannot see it (a model that can route around a broken example does,
+so the gate goes green either way). This runs the examples so a broken one fails
+CI before merge.
+
+## How a block is handled
+
+Every ```sql block in the three guides must be **classified** in `fixture.py`,
+keyed by a hash of its text:
+
+  - EXECUTABLE — a placeholder->value map. Every `<placeholder>` in the block
+    must be mapped; the block is substituted and **run**. An unmapped
+    placeholder is a failure, not a skip (else the check quietly passes
+    everything as examples drift). Execution error is a failure.
+  - FRAGMENT — an illustrative snippet that is not a standalone statement
+    (a bare JOIN/WHERE clause, a CTE referencing an undefined relation, a COPY
+    to a write path). Declared with a one-line reason, visible in review.
+
+A block that is in **neither** map fails: you cannot add an example to a guide
+without either mapping it (so CI runs it) or explicitly declaring it a fragment.
+A fixture entry whose key matches no current block also fails (stale mapping) —
+so editing a block forces re-classification rather than silently keeping the old
+verdict.
+
+Reads go to the public source.coop mirror / the public Ceph external endpoint —
+no secrets, no cluster access (same posture as examples.yml). Placeholder paths
+are mapped to a single `h0=` partition so a block binds every path and column
+and executes cheaply, without a full-catalog scan.
+
+Usage:
+    python tests/guidance_sql/run.py            # classify + execute; non-zero on any failure
+    python tests/guidance_sql/run.py --list     # print each block's key, first line, placeholders
+"""
+import hashlib
+import os
+import re
+import sys
+import pathlib
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+GUIDES = ["h3-guide.md", "query-optimization.md", "query-setup.md"]
+PLACEHOLDER_RE = re.compile(r"<[^>\n]+>")
+SQL_BLOCK_RE = re.compile(r"```sql\n(.*?)\n```", re.DOTALL)
+
+
+def block_key(filename, text):
+    """Stable id: filename + hash of the block's text. Changes when the block
+    is edited, so a stale fixture verdict cannot ride along."""
+    h = hashlib.sha1(text.strip().encode()).hexdigest()[:10]
+    return f"{filename}:{h}"
+
+
+def extract_blocks():
+    blocks = []
+    for fn in GUIDES:
+        txt = (REPO / fn).read_text()
+        for text in SQL_BLOCK_RE.findall(txt):
+            blocks.append((fn, block_key(fn, text), text))
+    return blocks
+
+
+def substitute(text, mapping):
+    for ph, val in mapping.items():
+        text = text.replace(ph, val)
+    return text
+
+
+def make_connection():
+    import duckdb
+
+    con = duckdb.connect()
+    for ext, src in (("httpfs", ""), ("spatial", ""), ("h3", " FROM community")):
+        try:
+            con.sql(f"INSTALL {ext}{src}")
+        except Exception:
+            pass  # already installed in the image / runner extension dir
+        con.sql(f"LOAD {ext}")
+    # Anonymous, prefix-scoped reads. The mirror is fast and public; the Ceph
+    # external endpoint is the fallback for datasets not mirrored. Neither needs
+    # a credential — the fixture only maps to public paths.
+    con.sql(
+        "CREATE SECRET scoop (TYPE S3, KEY_ID '', SECRET '', "
+        "ENDPOINT 's3.us-west-2.amazonaws.com', REGION 'us-west-2', "
+        "URL_STYLE 'path', USE_SSL 'true', "
+        "SCOPE 's3://us-west-2.opendata.source.coop')"
+    )
+    con.sql(
+        "CREATE SECRET ceph_ext (TYPE S3, ENDPOINT 's3-west.nrp-nautilus.io', "
+        "URL_STYLE 'path', USE_SSL 'true', SCOPE 's3://public-')"
+    )
+    con.sql("SET THREADS=4")  # external endpoint is happier at low concurrency
+    return con
+
+
+def cmd_list():
+    from fixture import EXECUTABLE, FRAGMENTS
+
+    for fn, key, text in extract_blocks():
+        first = next((l for l in text.strip().splitlines() if l.strip()), "")
+        phs = sorted(set(PLACEHOLDER_RE.findall(text)))
+        state = "EXEC" if key in EXECUTABLE else "FRAG" if key in FRAGMENTS else "UNCLASSIFIED"
+        print(f"{state:12} {key}")
+        print(f"             {first[:88]}")
+        if phs:
+            print(f"             placeholders: {phs}")
+
+
+def main():
+    sys.path.insert(0, str(HERE))
+    from fixture import EXECUTABLE, FRAGMENTS
+
+    if "--list" in sys.argv:
+        cmd_list()
+        return 0
+
+    blocks = extract_blocks()
+    seen_keys = {key for _, key, _ in blocks}
+
+    # Stale fixture entries (a key that no longer matches any block) are a failure:
+    # a block was edited or removed and its verdict wasn't revisited.
+    stale = (set(EXECUTABLE) | set(FRAGMENTS)) - seen_keys
+    failures = []
+    for key in sorted(stale):
+        failures.append(f"STALE fixture entry {key} matches no current block — re-classify or remove it")
+
+    con = None
+    executed = fragments = 0
+    for fn, key, text in blocks:
+        if key in FRAGMENTS:
+            fragments += 1
+            continue
+        if key not in EXECUTABLE:
+            first = next((l for l in text.strip().splitlines() if l.strip()), "")
+            failures.append(
+                f"UNCLASSIFIED block {key} ({first[:70]!r}) — add to fixture.py as "
+                f"EXECUTABLE (with placeholder mappings) or FRAGMENT (with a reason)"
+            )
+            continue
+        sql = substitute(text, EXECUTABLE[key])
+        left = sorted(set(PLACEHOLDER_RE.findall(sql)))
+        if left:
+            failures.append(f"UNMAPPED placeholder(s) in {key}: {left}")
+            continue
+        if con is None:
+            con = make_connection()
+        try:
+            con.sql(sql)
+            executed += 1
+            print(f"  ok   {key}")
+        except Exception as e:
+            failures.append(f"EXECUTION FAILED {key}: {str(e).splitlines()[0][:200]}")
+            print(f"  FAIL {key}: {str(e).splitlines()[0][:120]}")
+
+    print(f"\n{executed} executed, {fragments} fragments, {len(failures)} failures")
+    for f in failures:
+        print(f"  ✗ {f}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #369. Chunk D on board #371 — unblocks the #367 design pass.

## Why
The guidance files are runtime artifacts (server.py injects them verbatim into the `query` tool description), but nothing checked that their SQL runs. #364 shipped a coarse-overlay example that read a moved column (`nland`, relocated by data-workflows#522) and it went out in a tagged release. The model gate can't catch this: a model that can route around a broken example does, so the gate goes green whether the example works or not.

## What
`tests/guidance_sql/run.py` extracts every ```sql block from the three guides and requires each to be **classified** in `tests/guidance_sql/fixture.py`:
- **EXECUTABLE** — a placeholder→value map. Every `<placeholder>` must be mapped; the substituted statement is **run**. An **unmapped placeholder is a failure, not a skip**.
- **FRAGMENT** — a non-standalone snippet (bare clause, CTE over an undefined relation, write-path COPY, or a real query whose datasets aren't mapped yet), declared with a one-line reason.

Enforcement that keeps it honest:
- a block in **neither** map → fail (you can't add a guide example without CI running it or an explicit fragment declaration);
- a fixture entry matching **no current block** → fail (editing a block changes its hash key, so a stale verdict can't ride along).

## Cost / posture
Anonymous reads against the public source.coop mirror / Ceph external endpoint — **no secrets, no cluster access** (same as `examples.yml`). Placeholders map to a **single `h0=` partition**, so a block binds every path and column and executes in **~1s total** — enough to catch a moved column, a renamed function, or a path that no longer resolves. It is not a result-value check (that's the model gate's job). This is the cheap, deterministic first slice of #245.

## First slice
**8 executable**, **23 fragments** (0 failures). The executable set includes the res-8 coarse overlay weighting by `land_area_km2` + `(w1+w2)` — **exactly the #364 shape**. Verified the mechanism catches it: reading `nland` off the weights asset raises `Binder Error: Referenced column "nland" not found`. Coverage grows by promoting "not yet mapped" fragments (several overlay ones get promoted in the #367 design pass, chunk F).

## ⚠️ Maintainer action
The workflow file `.github/workflows/guidance-sql.yml` (push/PR path-filtered to the guides + harness, weekly cron, `workflow_dispatch`) could not be pushed — my token lacks the `workflow` scope. It's ready; I'll post the exact YAML in a comment. Either add it directly, or run `gh auth refresh -h github.com -s workflow` for me and I'll push it.

Run locally: `python tests/guidance_sql/run.py` (needs `pip install duckdb==1.5.4`).