### PR TITLE
k8s(dev): converge dev onto current :main (7a91b04)

### DIFF
--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         # dev's ≥2 replicas exist to catch. Bump this digest on redeploy (see
         # AGENTS.md → Rollout workflow). The tag prefix is for humans; the digest
         # is enforced. See issue #341.
-        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:f9be5daeb9af3d96dc77a10d78c557e911c687d5091b1e513eb8b6068b048144
+        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:458a014dc1763d6fef21574f7889e3c8199d442640e5a2df16f343dd50c973ef
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Repoints dev from the stale `f9be5dae` digest (the `19b3c709` build) to the current `:main` `sha256:458a014d`. **Already applied live** — both current-RS pods run `458a014d` and `/version` reports `git_sha 7a91b04` (main HEAD); the Service's only `ready=True` endpoints are those two pods. Two orphan pods from deleted ReplicaSets remain `Ready=False` on disrupted nodes (out of rotation; not force-deleted per NRP policy). Merging keeps the repo manifest == cluster. This manual step is exactly the decay #366/#341 track.