### PR TITLE
ci(#366): digest-pin guard + non-main :main guard + single dev mandate

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,8 +43,15 @@ jobs:
               ;;
             *)
               # schedule / workflow_dispatch: dep+base refresh. Move ONLY the dev
-              # tag — never mint a :sha or :vX.Y.Z from a non-push event.
-              tags="$repo:main"
+              # tag — never mint a :sha or :vX.Y.Z from a non-push event. And only
+              # publish :main from the main branch: a dispatch from a feature
+              # branch must NOT push that branch's code to :main (which dev
+              # tracks) — tag a branch-scoped image instead (#366).
+              if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+                tags="$repo:main"
+              else
+                tags="$repo:branch-${{ github.ref_name }}"
+              fi
               ;;
           esac
           # Version stamp baked into the image: the tag on release builds, else "main".

--- a/.github/workflows/k8s-image-pin.yml
+++ b/.github/workflows/k8s-image-pin.yml
@@ -1,0 +1,32 @@
+name: k8s image pin
+
+# Fails if any Deployment in k8s/*.yaml references this repo's image by a mutable
+# tag instead of an @sha256: digest (#366). A mutable tag re-resolves per pod at
+# each restart, so multi-replica pods silently drift onto different builds (#341).
+# A deliberately-moving deployment opts out with a `# ci-image-pin: allow-mutable`
+# comment; see tests/check_k8s_image_pins.py.
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'k8s/**'
+      - 'tests/check_k8s_image_pins.py'
+      - '.github/workflows/k8s-image-pin.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'k8s/**'
+      - 'tests/check_k8s_image_pins.py'
+      - '.github/workflows/k8s-image-pin.yml'
+
+jobs:
+  image-pin:
+    name: Deployments are digest-pinned
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+      - name: Check image pins
+        run: python tests/check_k8s_image_pins.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,23 @@
 
 ## Development & test environment — READ FIRST
 
-**The dev server is for development: deploy your branch there and test against it.**
-`dev-duckdb-mcp.nrp-nautilus.io` exists precisely so changes are exercised on real
-infrastructure before prod. All MCP/guidance testing runs against **dev**, never a
-local process.
+**Dev is the pre-prod canary: it tracks `main` and is never repointed by hand.**
+`dev-duckdb-mcp.nrp-nautilus.io` runs the current `:main` build (pinned by digest,
+≥2 replicas) precisely so merged changes are exercised on real infrastructure —
+including cross-pod skew — before prod. All MCP/guidance testing runs against
+**dev**, never a local process. Dev has one job; it is *not* a place to host a
+branch. Repointing dev to a branch stomps `main` and decays into the hand-pinning
+loop that keeps breaking it (#341/#366).
+
+**To test a change before it merges**, do not repoint dev. Options:
+- **Merge-then-validate (works today):** merge to `main` → dev rolls onto that
+  digest → run the headless matrix with `MCP_URL=dev`. This is the current gate.
+- **Preview env (planned, #366):** a `preview` label builds `:pr-<n>` for an
+  ephemeral `dev-pr-<n>` — the build trigger and CI deploy land with the NRP
+  deploy token.
+- **Guidance PR gate (planned, #245):** the matrix Job runs the PR's `server.py`
+  as a sidecar (git-checkout of the branch — no image build) so the *exact* PR
+  guidance is validated pre-merge.
 
 **Never run `server.py` (the MCP server) locally in this JupyterLab environment.**
 It loads DuckDB plus the full STAC catalog in-process; running it here OOM'd the shared

--- a/k8s/cirrus-deployment.yaml
+++ b/k8s/cirrus-deployment.yaml
@@ -26,8 +26,11 @@ spec:
         kubernetes.io/hostname: cirrus
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:main
-        imagePullPolicy: Always
+        # Digest-pinned so cirrus's 2 replicas converge on one build. :main +
+        # Always was non-convergent here too (#341/#366). Bump on redeploy; this
+        # cluster is self-hosted (k3s), so apply it from a cirrus context.
+        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:458a014dc1763d6fef21574f7889e3c8199d442640e5a2df16f343dd50c973ef
+        imagePullPolicy: IfNotPresent
         env:
         # In-cluster MinIO mirror (matches gpu-mcp). STAC metadata + S3 data both
         # resolve to the on-node MinIO S3 endpoint (plain http, path-style).

--- a/k8s/experimental-deployment.yaml
+++ b/k8s/experimental-deployment.yaml
@@ -27,6 +27,9 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
+        # ci-image-pin: allow-mutable — single-replica throwaway test endpoint
+        # (replicas: 1, "nothing should depend on this"), so no cross-pod skew;
+        # tracks the moving :experimental tag on purpose as extensions land (#354).
         image: ghcr.io/boettiger-lab/mcp-data-server:experimental
         imagePullPolicy: Always
         env:

--- a/tests/check_k8s_image_pins.py
+++ b/tests/check_k8s_image_pins.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Fail if any of our Deployment images in k8s/*.yaml is not pinned by digest (#366).
+
+A mutable tag (`:main`, `:vX.Y.Z`) resolves to a different build per pod at each
+(re)start, so multi-replica pods silently drift onto different images — the
+cross-pod skew dev's >=2 replicas exist to catch (#341). Every `image:` that
+references this repo's image must carry an `@sha256:` digest; the tag prefix is
+for humans, the digest is what's enforced.
+
+A deployment that deliberately tracks a moving tag (e.g. a single-replica,
+throwaway test endpoint where cross-pod skew cannot arise) opts out with a
+`# ci-image-pin: allow-mutable — <reason>` comment on the image line or the line
+directly above it. The exception is then greppable and justified in-tree.
+
+Runs in CI on any k8s/*.yaml change, and locally: `python tests/check_k8s_image_pins.py`.
+"""
+import glob
+import os
+import re
+import sys
+
+REPO_IMAGE = "ghcr.io/boettiger-lab/mcp-data-server"
+IMAGE_LINE = re.compile(r"^\s*image:\s*(\S+)")
+ALLOW_MUTABLE = "ci-image-pin: allow-mutable"
+
+
+def main():
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    violations = []
+    checked = allowed = 0
+    for path in sorted(glob.glob(os.path.join(root, "k8s", "*.yaml"))):
+        lines = open(path).read().splitlines()
+        for i, line in enumerate(lines):
+            m = IMAGE_LINE.match(line)
+            if not m:
+                continue
+            ref = m.group(1).strip().strip("'\"")
+            if not ref.startswith(REPO_IMAGE):
+                continue  # sidecars / other images are out of scope
+            checked += 1
+            if "@sha256:" in ref:
+                continue
+            # Opt-out marker on the image line or anywhere in the contiguous
+            # comment block directly above it.
+            window = [line]
+            j = i - 1
+            while j >= 0 and lines[j].lstrip().startswith("#"):
+                window.append(lines[j])
+                j -= 1
+            if any(ALLOW_MUTABLE in w for w in window):
+                allowed += 1
+                continue
+            rel = os.path.relpath(path, root)
+            violations.append(f"{rel}:{i + 1}: not digest-pinned -> {ref}")
+
+    if violations:
+        print("k8s image-pin check FAILED — pin these by @sha256: (see AGENTS.md rollout, #366):")
+        for v in violations:
+            print(f"  ✗ {v}")
+        return 1
+    print(
+        f"k8s image-pin check OK — {checked} repo image reference(s): "
+        f"{checked - allowed} digest-pinned, {allowed} explicit allow-mutable"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Chunk E on board #371 — the safe, verifiable slice of #366, plus the foundation for PR preview testing. The riskier pipeline rewrite (which I can't exercise from here and which needs the NRP deploy token) is specced below for a token-gated follow-up.

## Shipped here
- **`tests/check_k8s_image_pins.py` + `.github/workflows/k8s-image-pin.yml`** — fail CI if any Deployment references our image by a mutable tag instead of `@sha256:` (the cross-pod skew of #341). Deliberately-moving deployments opt out with a greppable `# ci-image-pin: allow-mutable` marker. Runs locally too.
- **`k8s/cirrus-deployment.yaml` → pinned.** The check immediately caught cirrus running **`replicas: 2` + `:main` + `Always`** — the exact non-convergent pattern on the self-hosted cluster. Pinned to the current `:main` digest. ⚠️ **cirrus is a separate k3s cluster I have no kubectl for — apply from a cirrus context to actually converge it.**
- **`k8s/experimental-deployment.yaml` → allow-mutable.** Single-replica throwaway test endpoint ("nothing should depend on this"), no cross-pod skew, tracks `:experimental` on purpose (#354). Justified, greppable exception.
- **`docker.yml` non-main guard.** A `schedule`/`workflow_dispatch` from a non-`main` ref now tags `:branch-<ref>`, never `:main` — closes the latent hazard where dispatching a build from a feature branch would publish that branch's code to the tag **dev tracks**.
- **`AGENTS.md` single mandate.** Resolves the contradiction (`:10` "deploy your branch there" vs `:81/:19/:264` "dev tracks `:main`"). Dev is the pre-prod canary that tracks `main` and is **never repointed by hand**; pre-merge testing goes to merge-then-validate (works today), a preview env (planned), or the #245 sidecar gate.

Verified locally: image-pin check passes (3 pinned + 1 justified opt-out); all YAML parses.

## `#366` "Done when" progress
- [x] AGENTS.md states one mandate for dev
- [x] `workflow_dispatch`/schedule from a non-`main` ref cannot publish `:main`
- [x] CI fails any `k8s/*.yaml` image reference lacking `@sha256:` (with an explicit opt-out)
- [ ] `:<git-sha>` genuinely immutable — release tag no longer re-mints it *(deferred; see below)*
- [ ] Cron rebuilds mint an immutable reference or are dropped *(deferred)*
- [ ] CI deploy step sets dev's digest on merge *(needs NRP token — yours)*
- [ ] Prod promotion pins the digest dev validated, no rebuild between *(follows the retag)*

## Deferred to a token-gated follow-up (specced, not blind-shipped)
These change a production release pipeline I can't exercise in CI here, so I'm proposing rather than shipping them:
1. **Release = retag, not rebuild.** On a `vX.Y.Z` tag, don't rebuild — `docker buildx imagetools create --tag $repo:vX.Y.Z $repo:<sha>` to promote the *exact* digest already built from that commit on the `main` push. This makes `:<sha>` truly immutable (today a release rebuild re-mints it — #366 showed `f9be5dae` vs `1a3409d5` for the same commit) and makes prod bytes == dev-validated bytes.
2. **`pull_request` → `:pr-<n>` build**, gated on a `preview` label + same-repo head (fork PRs can't push to GHCR), for ephemeral preview envs.
3. **CI deploy step** that sets dev's digest on merge to `main` (one NRP service-account token as a repo secret, patch on the one Deployment) — removes the manual `kubectl` convergence that just had to be done by hand again today (#374).

Happy to implement 1–3 once the NRP token is in place; 1 can also land on its own if you want to review the retag flow first.