### PR TITLE
fix(#378): disable DuckDB statistics_propagation (S3 join crash)

### DIFF
--- a/server.py
+++ b/server.py
@@ -170,6 +170,22 @@ def get_isolated_db(s3_key: str = None, s3_secret: str = None, s3_endpoint: str 
                 conn.sql(stmt)
             except Exception as e:
                 print(f"⚠️ Setup statement skipped: {stmt!r}: {e}", file=sys.stderr)
+        # Work around a DuckDB `statistics_propagation` bug (#378): a SEMI/INNER
+        # join whose probe side is a multi-row-group, UINT64-key-sorted parquet
+        # read over S3 raises `INTERNAL Error: SetMin or SetMax ... does not match
+        # statistics' column value` when the build side's key range is disjoint
+        # from some row groups' zonemaps (empty intersection asserts instead of
+        # pruning). Present in DuckDB 1.5.3/1.5.4; S3-transport-specific. This hits
+        # real queries — masking the nhd-flowline / ACE families by a region scope
+        # (the car-28 line-length cell) crashes instead of returning a number.
+        # Disabling this one optimizer fixes it with no measurable perf cost (h0
+        # hive-partition pruning is independent of it). An engine workaround, not
+        # model guidance, so it lives here rather than in query-setup.md. Remove
+        # when the upstream fix ships and the pin moves past it.
+        try:
+            conn.sql("SET disabled_optimizers='statistics_propagation'")
+        except Exception as e:
+            print(f"⚠️ disabled_optimizers setup skipped: {e}", file=sys.stderr)
         # Opt-in extras (experimental image only — empty list on the default tag).
         # Warn rather than raise: a missing extension should degrade this connection's
         # capability, not fail every query the replica serves.

--- a/tests/guidance_sql/run.py
+++ b/tests/guidance_sql/run.py
@@ -96,6 +96,12 @@ def make_connection():
         "URL_STYLE 'path', USE_SSL 'true', SCOPE 's3://public-')"
     )
     con.sql("SET THREADS=4")  # external endpoint is happier at low concurrency
+    # Mirror the server preamble (server.py): a DuckDB statistics_propagation bug
+    # (#378) crashes SEMI/INNER joins over some S3 hex parquet (nhd-flowline, ACE)
+    # with `INTERNAL Error: SetMin or SetMax ...`. The server disables this optimizer
+    # per connection; the harness must too, so CI executes the same plan the server
+    # runs (else a real, server-runnable example would fail here, or vice versa).
+    con.sql("SET disabled_optimizers='statistics_propagation'")
     return con
 
 


### PR DESCRIPTION
Closes #378 (chunk H on the #371 board).

## The bug

On the pinned DuckDB (**1.5.4**, confirmed on **1.5.3**), a `SEMI`/`INNER` join whose probe side is a hex parquet read **over S3** raises, at plan time:

```
INTERNAL Error: SetMin or SetMax called with Value that does not match statistics' column value
```

`statistics_propagation` computes an empty/inverted parquet zonemap intersection for a row group (multi-row-group, `UINT64`-key-sorted probe vs. a partially-overlapping build side) and asserts instead of pruning. **S3-transport-specific**: the identical bytes read from local disk or over plain `http://` do not crash.

This is not hypothetical — it crashes **real production queries**: masking the `nhdplus-hr/flowline` and ACE families by a region scope (the live `car-28` "% of headwater streams conserved" benchmark cell, and the #363 / #355 guidance examples) errors on current `:main` instead of returning a number. Single-file joins (`carbon`, `census`) are unaffected (one row group, no disjoint zonemap).

Minimal, credential-free repro (anonymous public S3):

```python
import duckdb
con = duckdb.connect(); con.sql("INSTALL httpfs; LOAD httpfs")
con.sql("CREATE SECRET ceph (TYPE S3, ENDPOINT 's3-west.nrp-nautilus.io', URL_STYLE 'path', USE_SSL true, SCOPE 's3://public-')")
p="s3://public-usgs-nhd/nhdplus-hr/flowline/hex/h0=577762574070710271/data_0.parquet"
b="s3://public-ca30x30/ecoregion/hex-res8/h0=577762574070710271/data_0.parquet"
q=f"SELECT count(*) FROM read_parquet('{p}') s SEMI JOIN (SELECT DISTINCT h8,h0 FROM read_parquet('{b}')) l ON s.h8=l.h8 AND s.h0=l.h0"
con.sql(q).fetchone()                                      # -> InternalException
con.sql("SET disabled_optimizers='statistics_propagation'"); con.sql(q).fetchone()  # -> (33569,)
```

## The fix

Disable this single optimizer per connection in the `server.py` preamble (alongside the `memory_limit` SET — an engine workaround, not model guidance, so it does **not** go in `query-setup.md`), and mirror it in the `#369` guidance-SQL harness (`tests/guidance_sql/run.py`) so CI executes the same plan the server runs.

**Performance: negligible.** Measured on/off over S3 on representative queries: **−3.0%** (mask-carbon-by-state) and **+2.7%** (res-10 overlay) — within noise. The join min/max pushdown this optimizer provides buys nothing here because h0 hive-partition pruning already prunes at the file level and is independent of it.

## Verification

- `tests/guidance_sql/run.py`: 8 executed, 0 failures (with the optimizer disabled).
- `pytest tests/test_server.py tests/test_dbconfig.py tests/test_s3config.py`: 146 passed.
- The exact crashing shape (`nhd-flowline SEMI JOIN ecoregion-res8`) now returns `33569` through the harness connection.

## Follow-ups

- **Upstream DuckDB issue** — minimal repro drafted; no prior report exists for this string / numeric-UINT64 case (near-matches #22649/#24384/#23888 are all *string* stats). Link to be added. Revisit the DuckDB pin when the upstream fix ships.
- **CI regression fixture** for the nhd-flowline shape rides chunk F (#367) — its line-length example encodes exactly this join, so once F lands the guidance-SQL job guards it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)