### PR TITLE
guidance(#367): state the overlay weight once, keyed on geometry [gate]

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -292,11 +292,17 @@ GROUP BY class;
 
 `get_schema` names the fractions asset and the no-data code. Per cell `SUM(frac) <= 1`; the shortfall is outside-raster/quantization, so do not treat the layer as covering 100% of a cell.
 
-**Overlaying two partial-coverage layers — multiply the coverage fractions, then weight by cell area; never count a cell as all-or-nothing.** *(Skip unless you are intersecting a fractional-coverage layer with another layer that only partly covers its cells — e.g. "what percent of each habitat class is conserved".)* Treating a cell as fully inside the other layer whenever it matches over-counts every partly-covered cell. Weight by the coverage fraction on **both** sides, and carry `h3_cell_area` through numerator and denominator. It looks like it divides out; it does not — cells at the same resolution differ in area, which is what `h3_cell_area` exists to measure.
+**Overlaying a feature with a partial-coverage layer — the weight is fixed by the feature's geometry, and it is the same weight at every resolution.** *(Skip unless you are intersecting one layer with another that only partly covers its cells — e.g. "what percent of each habitat class is conserved".)* Reduce the overlay layer to one coverage fraction per cell, then weight each of the feature's cells by:
 
-The other layer's per-cell weight comes from a companion **per-cell weights asset** when one exists — `get_schema` names it (e.g. ca30x30 conserved-areas publishes `…-hex-weights` at res 10, with `w1`–`w4` giving the share of each cell in GAP status 1–4). Otherwise reduce the layer's features to one weight per cell first: `MAX` over the features on the cell of the per-feature coverage share its STAC documents.
+- **polygon or raster feature → area:** `h3_cell_area(hN, 'km^2')`, or the region land grid's `land_area_km2` where cells are partly ocean or border.
+- **line feature → length, never area:** dedup the feature's `length_*` and length-weight the fraction — see Problem 4.
+- **presence-only layer, no fraction column → the presence flag, averaged over the finer layer's cells:** presence at the finer resolution *is* the fraction.
 
-A weights asset covers only its own footprint, so `LEFT JOIN` it and `COALESCE(…, 0)`. Bound the result with a dense land grid for the region (California: `ca30x30-ecoregion` at res 10) — without it the denominator picks up cells outside the region.
+Two invariants make each branch correct. **Multiply the coverage fractions on both sides** — a cell that is 40% habitat and 30% conserved contributes 0.4 × 0.3, never all-or-nothing — and **carry the weight through both numerator and denominator** (it looks like `h3_cell_area` divides out; it does not, because cells differ in area). The overlay layer's per-cell fraction comes from a companion **`…-hex-weights` asset** when one exists — `get_schema` names it (ca30x30 conserved-areas publishes it at res 10, `w1`–`w4` = the cell's share in GAP status 1–4); otherwise it is the layer's own `frac`. A weights asset covers only its own footprint, so `LEFT JOIN` it and `COALESCE(…, 0)`, and bound the result with a dense **land grid** for the region (California: `ca30x30-ecoregion`) or the denominator picks up cells outside it.
+
+Self-check, needs no gold: **if the coarsening is right, the answer does not change with the resolution you joined at.**
+
+At the same resolution — feature and overlay both at res 10 — the area weight is `h3_cell_area` and the land grid bounds the denominator:
 
 ```sql
 WITH land AS (   -- dense res-10 land grid bounding the region
@@ -332,9 +338,33 @@ LEFT JOIN read_parquet('<conserved-areas hex-weights-res8>') p USING (h8, h0);
 
 The land grid has a row for every land cell in the region, so it is both the weight and the denominator — no `h3_cell_area()` call and no separate mask.
 
-When no weights asset is published at the coarse resolution, roll the fine layer up in two reductions, in this order: `MAX` (or `LEAST(SUM(w), 1)`) across the units overlapping **one fine cell**, then the mean across the **child cells of a coarse parent** — `SUM(w) / <children per parent>`, `7` for one resolution step (res-10 → res-9) and `49` for two (res-10 → res-8). `MAX` is the wrong reducer across children: it scores a whole parent as covered whenever a single child is.
+When no weights asset is published at the coarse resolution — or the finer layer carries **only presence**, no fraction column — roll the fine layer up yourself: a coarse parent's value is the **mean over its res-10 land children**, `SUM(child value) / <children per parent>` (`7` per resolution step res-10 → res-9, `49` for two res-10 → res-8). It is the same reduction whether the child value is a weight, a coverage fraction, or a 0/1 presence flag — presence at the finer resolution *is* the fraction, so average it. Reduce multiple units overlapping **one** fine cell with `MAX` (or `LEAST(SUM(w), 1)`) first; but never `MAX`/`MIN`/`EXISTS`/`DISTINCT` **across children** — that scores a whole parent as covered when a single child is, and the overstatement grows with the children per parent.
 
-Group on `h3_cell_to_parent(h10, 8)` when the fine layer carries no `h8` column. At res 9 read `ecoregion-hex-res9` and the `…-hex-weights-res9` weights the same way. When the coarse feature is itself a `hex-fractions` layer, keep its `frac` in the product on both sides, as in the same-resolution case. Matching the coarse feature against the fine layer's *distinct cells* treats a parent as fully covered when any one child is; the inflation grows with the number of children per parent.
+Averaging a res-10 presence flag over the land children of a res-8 feature — the ACE × wetlands case, no GAP column anywhere:
+
+```sql
+WITH feat AS (          -- coarse (res-8) feature cells
+  SELECT DISTINCT h8, h0
+  FROM read_parquet('<res-8 feature hex>')
+  WHERE <feature filter>
+),
+land AS (               -- res-10 land grid: the child cells to average over
+  SELECT DISTINCT h8, h10, h0 FROM read_parquet('<ecoregion hex>')
+),
+present AS (            -- res-10 presence layer; no fraction column
+  SELECT DISTINCT h10, h0
+  FROM read_parquet('<presence hex>')
+  WHERE <presence filter>
+)
+SELECT 100.0 * AVG(CASE WHEN p.h10 IS NOT NULL THEN 1 ELSE 0 END) AS pct_present
+FROM feat f
+JOIN land l USING (h8, h0)
+LEFT JOIN present p USING (h10, h0);
+```
+
+Presence promoted straight to the res-8 cell (`does any child match`) overstates badly — worse for sparser features. The mean over land children is the fraction; the `DISTINCT h8,h0` feature cells and the `AVG` over their children make the answer independent of the join resolution.
+
+Group on `h3_cell_to_parent(h10, 8)` when the fine layer carries no `h8` column. At res 9 read `ecoregion-hex-res9` and the `…-hex-weights-res9` weights the same way. When the coarse feature is itself a `hex-fractions` layer, keep its `frac` in the product on both sides, as in the same-resolution case.
 
 **If you plan to mask this result against another hex dataset:** put the
 `SEMI JOIN` on the raw `read_parquet(...)` *before* `GROUP BY`, not in a
@@ -355,7 +385,7 @@ GROUP BY a.h8;
 
 ### Problem 4 — Lines: per-segment columns and AOI boundaries
 
-*(Applies only to line-derived hex: source geometry is `LineString`/`MultiLineString`, columns like `length_miles`, `length_km`. Skip if your dataset has area/acres columns or is raster-derived.)*
+*(Applies whenever the feature you are measuring is line-derived — source geometry `LineString`/`MultiLineString`, columns like `length_miles`, `length_km`, `lengthkm` — **including** when you overlay it on an area layer that carries acres/area columns. The test is the feature's own geometry, not the overlay's. Skip only if the feature itself is polygon- or raster-derived.)*
 
 Per-segment values are **replicated on every row of any JOIN that matches a segment to multiple things**. Two unrelated mechanisms produce that replication:
 
@@ -383,6 +413,32 @@ GROUP BY rg.name_en ORDER BY miles DESC;
 ```
 
 The geometry column is `geometry` on the GeoParquets — not `geom`.
+
+- **Share of a line network's length under a fractional per-cell overlay** ("what percent of streams are conserved", "what share of trail miles burned"): weight by the **line's own length**, never by cell area — the hex supplies only the per-cell fraction. Dedup the feature's `length_*` first (it is replicated on every cell it touches), take the mean overlay fraction across that feature's cells, then `SUM(length × fraction) / SUM(length)`:
+
+```sql
+WITH land AS (          -- res-8 land grid: the per-cell scope for the network
+  SELECT DISTINCT h8, h0 FROM read_parquet('<ecoregion hex-res8>')
+),
+seg AS (                -- one row per (flowline, cell); lengthkm is the feature's
+                        -- full length, replicated on every cell it crosses
+  SELECT s._cng_fid AS fid, s.lengthkm AS len, s.h8, s.h0
+  FROM read_parquet('<line hex>') s
+  SEMI JOIN land l USING (h8, h0)
+  WHERE <feature filter>
+),
+cell AS (               -- attach each cell's conserved fraction (res-8 weights)
+  SELECT seg.fid, seg.len, COALESCE(w.w1 + w.w2, 0) AS frac
+  FROM seg LEFT JOIN read_parquet('<conserved-areas hex-weights-res8>') w USING (h8, h0)
+),
+per_feature AS (        -- dedup length per feature; mean its cells' fractions
+  SELECT fid, ANY_VALUE(len) AS len, AVG(frac) AS frac FROM cell GROUP BY fid
+)
+SELECT 100 * SUM(len * frac) / SUM(len) AS pct_conserved
+FROM per_feature;
+```
+
+  Weighting by `h3_cell_area` or a `land_area_*` column answers a different question — the conserved share of the *cells* the lines touch — and on a one-row-per-(feature, cell) set it also silently weights each cell by how many features cross it.
 
 ---
 

--- a/query-optimization.md
+++ b/query-optimization.md
@@ -54,6 +54,8 @@ SELECT h8, h0, MODE(lc_class) AS dominant
 FROM lc_on_scope GROUP BY h8, h0;
 ```
 
+The `WHERE l.lc_class IS NOT NULL` here keeps a no-data cell from poisoning the aggregate — but it also **changes which cells the answer describes**. When that column is only partly populated, see §9 before reporting the result as a share of the whole.
+
 ### Scoping by name or feature id (no region mask)
 
 To filter a global `…/hex/h0=*/…` dataset by a name or `_cng_fid` and there is no region-mask hex to join, first restrict `h0` to the region, then apply the attribute filter:
@@ -145,3 +147,39 @@ WHERE value IS NOT NULL AND NOT isnan(value)
 
 Take the sentinel codes from the dataset's STAC description. A `NaN` total or a
 total far smaller than expected is the signature of this trap.
+
+## 8. Total a partial-coverage feature by its own measure, not a hex count
+
+A vector feature's area or length is the value in its **own** column (`acres`,
+`length_km`), summed over `DISTINCT` feature id — tiling replicates that value on
+every cell the feature touches, so dedup by `_cng_fid` before summing.
+`COUNT(DISTINCT hN) * h3_cell_area(...)` is a larger, different number: it counts
+every partially-covered boundary cell as if the feature filled it. Use the hex
+only to *locate* the feature (mask, join, overlay); take the magnitude from the
+measured column. For the conserved or overlaid **share** of that total, weight by
+the coverage fraction — area for polygons and rasters, length for lines — and keep
+the weight inside the same `SUM()` as the measure, not derived in a subquery the
+outer aggregate then ignores. (See the overlay rules in the H3 guide.)
+
+## 9. Filtering no-data changes what you measured — say so
+
+`WHERE col IS NOT NULL` (or excluding sentinels) fixes the arithmetic but replaces
+the population. Missing values are rarely missing at random: incomplete columns are
+usually incomplete in patterns that track geography, feature type, or source
+vintage, so the rows that survive are a biased sample, and any share computed from
+them describes that sample, not the whole. Before using a partially-populated
+column as a filter, a class selector, or a denominator:
+
+1. **Quantify coverage** — what fraction of rows, and of the relevant measure
+   (area, length, count), survive the filter?
+2. **Check it against at least one independent grouping** — a partition key,
+   region, category, or date. Uniform coverage is safe to filter on; coverage that
+   is near 0% in some groups and near 100% in others means the filter is a group
+   selector wearing an attribute's clothes.
+3. **Confirm how absence is encoded.** `IS NOT NULL` misses sentinel values
+   (`0`, `-9999`, `''`); take them from the STAC description and exclude them before
+   measuring coverage — a sentinel can fake coverage a column does not have.
+4. **Report it.** If coverage is materially incomplete, state the covered fraction
+   and what it covers alongside the number. If coverage is concentrated in part of
+   the study area, the honest answer is that the breakdown is unavailable for the
+   whole — not a number with a caveat.

--- a/tests/guidance_sql/fixture.py
+++ b/tests/guidance_sql/fixture.py
@@ -25,6 +25,14 @@ _H0 = "577762574070710271"
 # ca30x30 conserved-areas assessment family (the #364 coarse-overlay surface)
 ECO8 = f"s3://public-ca30x30/ecoregion/hex-res8/h0={_H0}/data_0.parquet"          # h8, nland, land_area_km2, h0
 CW8 = f"s3://public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-res8/h0={_H0}/data_0.parquet"  # h8, w1..w4, h0
+# res-10 members of the same family (the #367 design-pass overlay/presence examples)
+ECO10 = f"s3://public-ca30x30/ecoregion/hex/h0={_H0}/data_0.parquet"              # h8, h9, h10 land grid, h0
+CWHR = f"s3://public-ca30x30/cwhr13/hex-fractions/h0={_H0}/data_0.parquet"        # whr13num, frac, h10, h0
+CW10 = f"s3://public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/h0={_H0}/data_0.parquet"  # h10, w1..w4, h0
+# line + presence layers (#363 line-length, #355 presence-only)
+NHD = f"s3://public-usgs-nhd/nhdplus-hr/flowline/hex/h0={_H0}/data_0.parquet"     # _cng_fid, lengthkm, innetwork, streamorde, h8, h0
+NWI = f"s3://public-wetlands/nwi-v2/hex/h0={_H0}/data_0.parquet"                  # WETLAND_TYPE, state_code, h10, h0
+ACE = f"s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex/h0={_H0}/data_0.parquet"  # BioRankSW, h8, h0
 # cross-dataset staples
 CENSUS = f"s3://public-census/census-2024/state/hex/h0={_H0}/data_0.parquet"      # h8, STUSPS, GEOID, h0
 CARBON = f"s3://public-carbon/irrecoverable-carbon-2024/hex/h0={_H0}/data_0.parquet"  # carbon, h5..h9, h0
@@ -49,6 +57,35 @@ EXECUTABLE = {
         "<ecoregion hex-res8>": ECO8,
         "<conserved-areas hex-weights-res8>": CW8,
     },
+    # res-10 fractional overlay (#289/#367): frac x GAP weight x area, weight
+    #   inside the SUM; binds cwhr13 fractions + res-10 land grid + res-10 weights.
+    "h3-guide.md:a3af36a53b": {
+        "<ecoregion hex>": ECO10,
+        "<cwhr13 hex-fractions>": CWHR,
+        "<conserved-areas hex-weights>": CW10,
+    },
+    # line-network conserved share (#363): dedup lengthkm per _cng_fid, length-
+    #   weight the res-8 GAP fraction. This is the shape that crashed pre-#378
+    #   (nhd-flowline SEMI JOIN), so it also guards that regression.
+    "h3-guide.md:0c6ddd1d29": {
+        "<ecoregion hex-res8>": ECO8,
+        "<line hex>": NHD,
+        "<feature filter>": "s.innetwork = 1 AND s.streamorde IN (1, 2)",
+        "<conserved-areas hex-weights-res8>": CW8,
+    },
+    # presence-only over res-10 land children (#355): mean of a 0/1 flag, never
+    #   promoted to the res-8 parent. ACE feature x NWI wetlands, no GAP column.
+    "h3-guide.md:da766d501c": {
+        "<res-8 feature hex>": ACE,
+        "<feature filter>": "BioRankSW = 5",
+        "<ecoregion hex>": ECO10,
+        "<presence hex>": NWI,
+        "<presence filter>": (
+            "state_code = 'CA' AND WETLAND_TYPE IN ("
+            "'Freshwater Emergent Wetland','Freshwater Forested/Shrub Wetland',"
+            "'Estuarine and Marine Wetland')"
+        ),
+    },
     # [19] rows-per-hex profiling on a single partition
     "h3-guide.md:2aab9a5de8": {"<STAC_HEX_PATH_SINGLE_PARTITION>": ECO8},
     # query-setup.md — the required SET/LOAD preamble (no S3); validates it runs
@@ -66,10 +103,9 @@ FRAGMENTS = {
     "h3-guide.md:e2dfe983ec": "CTE fragment referencing an undefined `flat_funding` relation",
     "h3-guide.md:ec06ef4087": "CTE fragment referencing undefined `countries`/`carbon_data` relations",
     "h3-guide.md:377ec327e2": "two-query block over generic `value`/`class` columns (SUM/AVG vs MODE illustration)",
-    "h3-guide.md:b774ac61d1": "fractional-coverage overlay; a class+frac dataset is not yet mapped (promote in the #367 design pass)",
-    "h3-guide.md:a3af36a53b": "res-10 fractional overlay; cwhr13 fractions + res-10 conserved weights not yet mapped (design pass)",
+    "h3-guide.md:b774ac61d1": "single-layer fractional overlay over a literal `class` column; no mapped dataset uses that column name (cwhr13 uses `whr13num`)",
     "h3-guide.md:1ccc1fb7d7": "references an undefined `mask` relation (DPP mask-first illustration)",
-    "h3-guide.md:acf2ad1267": "line-mileage over line/aoi hex + geoparquet datasets not yet mapped (promote with #363)",
+    "h3-guide.md:acf2ad1267": "line-mileage via ST_Intersection over line+AOI GeoParquet; those AOI geoparquets are not mapped (the conserved-share line example IS executable — see da766d501c's sibling 0c6ddd1d29)",
     "h3-guide.md:ae094c7f8c": "COPY to a write path with a `SELECT ...` ellipsis (export idiom)",
     # --- query-optimization.md ---
     "query-optimization.md:2f7793ba77": "bare JOIN clause (include-h0-in-join idiom)",


### PR DESCRIPTION
Chunk F on the #371 board — the fractional-overlay / coarse-feature design pass. Resolves #363, #355, #289, #359; folds #367.

> **Stacked on #379 (#378).** The line and presence examples only *run* with DuckDB's `statistics_propagation` disabled, which #379 does. Review/merge #379 first; this branch is based on it (the diff shows only the guidance changes).

## The rewrite

The overlay block of `h3-guide.md` had been rewritten four times in five weeks — three scattered weight expressions, each edit exposing the next defect. This states the weight **once**, keyed on the feature's geometry:

- **polygon / raster → area** (`h3_cell_area`, or `land_area_km2` on a coarse land grid)
- **line → length, deduped per feature** (#363 — Problem 4)
- **presence-only layer → the 0/1 flag, meaned over res-10 land children** (#355)

Two invariants stated once (multiply fractions on both sides; carry the weight through numerator *and* denominator), plus a gold-free self-check: **if the coarsening is right, the answer doesn't change with the resolution you joined at.** Positive framing, only correct SQL shapes, niche cases gated with *"Skip unless…"*, per AGENTS.md — and the section is now one rule instead of three.

## What changed

- **h3-guide.md** — geometry-keyed opening; generalised the coarse-feature rollup to *weight | fraction | presence*; added the presence example (#355); fixed the Problem-4 preamble so a "% of streams conserved" question routes there even though the overlay asset carries area columns (#363), with a length-weighted line example.
- **query-optimization.md** — §8: total a partial-coverage feature by its own acre/length column deduped per feature, not `COUNT(DISTINCT hN)*cell_area`, and keep the overlay weight inside the `SUM` (#289). §9: filtering no-data replaces the population — quantify coverage, check it against an independent grouping, distinguish sentinels from NULL, report the covered fraction (#359); §2's `IS NOT NULL` example now points to it.
- **tests/guidance_sql/fixture.py** — promoted the res-10 overlay example to executable and added the line + presence examples. **11 executed (was 8), 0 failures.** The line example is the exact shape that crashed before #378, so the #369 harness now guards that regression too.

## Verification

- `tests/guidance_sql/run.py`: **11 executed, 22 fragments, 0 failures** — the three new/promoted examples bind every path and column on the single CA partition and run.
- Gold numbers (for chunk G): car-28 headwater streams **27.0 ±1.5**, wetland presence MRE **1.74 ±0.3**, cwhr13 pct-conserved, car-19/car-23 coarse-overlay regression clean.

## [gate] — not for prod until validated

Guidance artifact → needs the headless regression matrix on dev (chunk G, #371) with `MCP_URL=dev`, after this merges to main and dev is rolled+convergent onto it. Confirms the targeted cells (car-28 length weighting, wetland presence) fix and zero baseline regression before prod promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)