### PR TITLE
ci(#377): serialize per-ref docker builds + scope gha cache per ref

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,18 @@ on:
     - cron: '0 6 * * 1'  # Mondays 06:00 UTC — refresh base image + unpinned deps
   workflow_dispatch:
 
+# Serialize builds per ref so rapid merges to main don't run concurrently and
+# corrupt each other's build (#377): concurrent buildx builds sharing one gha
+# cache scope can import a half-written manifest and reuse a code layer from a
+# different commit's context — a tag then ships another commit's bytes. With
+# cancel-in-progress:false the in-flight build finishes and the newest queued
+# ref builds last, so `:main` deterministically lands on the latest commit with
+# its own code. (Intermediate commits' `:<sha>` may be skipped during a burst;
+# the durable one-image-per-commit guarantee is #366's build-once/promote.)
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -83,8 +95,13 @@ jobs:
           # cache-to still warms the cache for subsequent pushes.
           # (When no-cache=true, cache-from is ignored by design; cache-to is kept
           # so the next code-push still gets a warm cache.)
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope the gha cache per ref (#377): the per-ref concurrency guard above
+          # serializes builds of the *same* ref, and a distinct scope per ref keeps
+          # cross-ref builds (e.g. a release tag building while main builds) from
+          # sharing — and poisoning — one cache. Reuse is preserved *within* a ref
+          # (main reuses main's deps layer across commits).
+          cache-from: type=gha,scope=${{ github.ref_name }}
+          cache-to: type=gha,scope=${{ github.ref_name }},mode=max
           no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           pull: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 


### PR DESCRIPTION
Closes #377.

## The bug
Five PRs merged to `main` within ~15s each triggered a `docker.yml` build. With no `concurrency:` guard and a **shared** `type=gha` cache scope, concurrent buildx builds imported a half-written cache manifest and reused a `COPY`/context layer from a *different commit's* build — so a tag minted for commit `b150441` shipped commit `7a91b04`'s bytes. `/version` on the resulting `:main` reported the wrong `git_sha`, and dev (which tracks `:main`) served stale code under a fresh tag — invalidating guidance validation until a manual `no-cache` rebuild.

It's a **build-integrity** failure: `:main` was wrong, not the deploy.

## The fix — close both sharing paths
The root cause is *concurrent builds sharing one gha cache scope*. Two independent guards remove every sharing path:

1. **Serialize per ref** — workflow-level `concurrency: { group: docker-build-${{ github.ref }}, cancel-in-progress: false }`. Same-ref builds (the observed main burst) run one at a time; the in-flight build finishes and the newest queued ref builds last, so **`:main` deterministically lands on the latest commit with its own code**.
2. **Isolate the cache per ref** — `cache-from`/`cache-to: type=gha,scope=${{ github.ref_name }}`. Cross-ref builds (a release tag building while `main` builds — which the per-ref concurrency guard does *not* serialize) no longer share a scope. Deps-layer reuse is preserved **within** a ref.

Together: no concurrent build ever shares a cache scope again.

## Trade-off (documented in-file)
During a same-ref burst, intermediate commits' `:<sha>` tags may be skipped (only the first + latest build). That's acceptable here — under the bug those tags were *wrong* anyway — and the durable one-image-per-commit guarantee is **#366**'s build-once/promote-the-digest, which this composes toward. Release tag builds are unaffected (distinct ref → distinct group + scope).

## Verification
- `docker.yml` parses; `concurrency` is top-level (`group: docker-build-${{ github.ref }}`, `cancel-in-progress: false`); cache is `scope=${{ github.ref_name }}`.
- No behavior change for the single-build common case; `docker.yml` doesn't run on `pull_request`, so this takes effect on the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)