### PR TITLE
k8s(prod): promote v0.8.15

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.14@sha256:9dda8e42f0bcaec6237e8cb677ce26dc515d16bab17fd1500e108cb27ad8b880
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.15@sha256:62febce2da4dd498e1a6b68679fecd844936738ab4a0981537fd4f6daf4ec661
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod (`k8s/deployment.yaml`) from **v0.8.14** → **v0.8.15@sha256:62febce2…** — the batch merged since #365.

## What ships
- **#361** DATE/TIMESTAMP rendering (#370)
- **#256** agg=SUM/AVG/MAX guidance (#372)
- **#367 overlay design pass** (#380) — one geometry-keyed weight rule (area / length / presence); query-opt §8/§9
- **#378 DuckDB `statistics_propagation` crash mitigation** (#379) — fixes the live nhd/ACE S3-join crash in prod
- **#377** build-integrity (serialize per-ref docker builds + scoped cache)

## Validation (chunk G, dev @ f3b096b)
- Targeted cells pass + fast, zero timeouts: car-19 ACE res-8 **21.18/21.2** (gold 21.09), car-23 connectivity res-9 **22.5** (22.65), car-28 headwater streams **27.46/27.5** (27.0±1.5) — car-28 38–133s vs the pre-fix 528s + 4/8 timeouts.
- No baseline regression (GAP1/2 acres, hardwood %, Mojave, statewide % consistent).
- **#353 cost regression resolved** — models now use the pre-averaged `hex-weights-res8/9` asset.
- Presence branch (car-31, new cell): shipping models **glm-5.2 2/2 + deepseek-v4-flash-0731 2/2** (gold 1.74); guidance provably correct (1.71 statewide).

## Deploy
Image smoke-tested green in the build (httpfs/spatial/h3 load + functional). After merge, `kubectl apply` to prod and verify `/version` = v0.8.15 + pod imageID convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)