### PR TITLE
fix(#387): render 64-bit integers exactly — H3 indexes were truncated to 6 digits

### DIFF
--- a/server.py
+++ b/server.py
@@ -379,18 +379,27 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
             # shape-dependent: a single-column frame renders scientific too.
             # Casting is only a display change — a count still renders as `3`,
             # right-aligned, because tabulate re-parses the numeric string.
+            # NULLs must become '' rather than staying NULL. Under pandas 3 a
+            # str-dtype column holds missing values as the FLOAT nan, so one NULL
+            # makes tabulate type the whole column as float and every wide int
+            # reverts to `6.13762e+17` — the cast silently undone by a single
+            # missing cell (the IUCN size-stratified assets have NULL finer
+            # h-columns, so this is live). It also stops a NULL date printing as
+            # the literal `nan`, which reads as a value.
             WIDE_INTS = ("BIGINT", "UBIGINT", "HUGEINT", "UHUGEINT")  # > 2^53
             rendered = []
             for c, t in zip(result.columns, result.dtypes):
                 tu, q = str(t).upper(), f'"{c}"'
                 if tu == "DATE":
-                    rendered.append(f"strftime({q}, '%Y-%m-%d') AS {q}")
+                    expr = f"strftime({q}, '%Y-%m-%d')"
                 elif tu.startswith("TIMESTAMP"):
-                    rendered.append(f"strftime({q}, '%Y-%m-%d %H:%M:%S') AS {q}")
+                    expr = f"strftime({q}, '%Y-%m-%d %H:%M:%S')"
                 elif tu in WIDE_INTS:
-                    rendered.append(f"CAST({q} AS VARCHAR) AS {q}")
+                    expr = f"CAST({q} AS VARCHAR)"
                 else:
                     rendered.append(None)
+                    continue
+                rendered.append(f"COALESCE({expr}, '') AS {q}")
             if any(rendered):
                 proj = [expr or f'"{c}"' for expr, c in zip(rendered, result.columns)]
                 result = result.select(", ".join(proj))

--- a/server.py
+++ b/server.py
@@ -369,17 +369,30 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
             # a space-separated form (mixed frame) depending on the other columns
             # — neither is YYYY-MM-DD. strftime here is authoritative and
             # shape-independent (#361).
-            temporal = []
+            #
+            # Same treatment, same reason, for 64-bit+ integers (#387). tabulate
+            # formats them through float64, which is exact only to 2^53
+            # (9.007e15) — so an H3 index (~6.1e17) printed as `6.13762e+17` has
+            # lost ~11 digits and names a different cell. Every hex asset carries
+            # `h0`…`h15`, and h0 is BIGINT while h8/h10 are UBIGINT, so both
+            # signed and unsigned must be cast. Unlike #361 this was never
+            # shape-dependent: a single-column frame renders scientific too.
+            # Casting is only a display change — a count still renders as `3`,
+            # right-aligned, because tabulate re-parses the numeric string.
+            WIDE_INTS = ("BIGINT", "UBIGINT", "HUGEINT", "UHUGEINT")  # > 2^53
+            rendered = []
             for c, t in zip(result.columns, result.dtypes):
                 tu, q = str(t).upper(), f'"{c}"'
                 if tu == "DATE":
-                    temporal.append(f"strftime({q}, '%Y-%m-%d') AS {q}")
+                    rendered.append(f"strftime({q}, '%Y-%m-%d') AS {q}")
                 elif tu.startswith("TIMESTAMP"):
-                    temporal.append(f"strftime({q}, '%Y-%m-%d %H:%M:%S') AS {q}")
+                    rendered.append(f"strftime({q}, '%Y-%m-%d %H:%M:%S') AS {q}")
+                elif tu in WIDE_INTS:
+                    rendered.append(f"CAST({q} AS VARCHAR) AS {q}")
                 else:
-                    temporal.append(None)
-            if any(temporal):
-                proj = [expr or f'"{c}"' for expr, c in zip(temporal, result.columns)]
+                    rendered.append(None)
+            if any(rendered):
+                proj = [expr or f'"{c}"' for expr, c in zip(rendered, result.columns)]
                 result = result.select(", ".join(proj))
 
             # Fetch one extra row to detect truncation without a second COUNT scan.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -174,6 +174,55 @@ class TestQueryFunction:
         assert "2024-12-30 13:45:06" in result
         assert ".000000" not in result
 
+    def test_query_h3_index_renders_exactly(self):
+        """An H3 index must render all 18 digits, not `6.13762e+17` (#387).
+
+        tabulate formats numbers through float64, exact only to 2^53 — so the
+        scientific form has dropped ~11 digits and names a DIFFERENT cell. A
+        model cannot round-trip a cell id it reads out of a result.
+        """
+        result = query("SELECT 613762179077668863::UBIGINT AS h8, COUNT(*) AS n FROM range(3)")
+        assert "613762179077668863" in result
+        assert "6.13762e+17" not in result and "e+17" not in result
+
+    def test_query_h3_index_exact_for_signed_and_unsigned(self):
+        """h0 is BIGINT while h8/h10 are UBIGINT — both must survive (#387)."""
+        result = query(
+            "SELECT 577762574070710271::BIGINT AS h0, 613762179077668863::UBIGINT AS h8"
+        )
+        assert "577762574070710271" in result and "613762179077668863" in result
+        assert "e+17" not in result
+
+    def test_query_wide_int_rendering_is_shape_independent(self):
+        """Unlike #361, this was never shape-dependent — a lone wide-int column
+        renders scientific too. Both shapes must be exact (#387)."""
+        alone = query("SELECT 613762179077668863::UBIGINT AS h8")
+        mixed = query("SELECT 613762179077668863::UBIGINT AS h8, 27.4638 AS pct, 'x' AS filler")
+        for r in (alone, mixed):
+            assert "613762179077668863" in r and "e+17" not in r
+
+    def test_query_small_ints_and_floats_unaffected(self):
+        """The cast is display-only: counts stay plain integers (not `3.0`) and
+        floats keep their formatting (#387)."""
+        result = query("SELECT COUNT(*) AS n, 27.4638 AS pct FROM range(3)")
+        assert "| 27.4638 " in result
+        assert "3.0" not in result
+        assert "|   3 |" in result or "| 3 " in result
+
+    def test_query_nullable_wide_int_still_exact(self):
+        """A NULL in the column must not reintroduce float coercion (#387)."""
+        result = query(
+            "SELECT h8 FROM (VALUES (613762179077668863::UBIGINT), (NULL::UBIGINT)) t(h8)"
+        )
+        assert "613762179077668863" in result and "e+17" not in result
+
+    def test_query_negative_and_hugeint_exact(self):
+        """Signed negatives and HUGEINT aggregates render exactly (#387)."""
+        result = query("SELECT (-577762574070710271)::BIGINT AS neg, "
+                       "SUM(9223372036854775807::HUGEINT) AS huge FROM range(2)")
+        assert "-577762574070710271" in result
+        assert "18446744073709551614" in result
+
 
 class TestResourceFunctions:
     """Test MCP resource functions."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -210,11 +210,30 @@ class TestQueryFunction:
         assert "|   3 |" in result or "| 3 " in result
 
     def test_query_nullable_wide_int_still_exact(self):
-        """A NULL in the column must not reintroduce float coercion (#387)."""
+        """A NULL must not reintroduce float coercion (#387).
+
+        Under pandas 3 a str-dtype column stores missing as the FLOAT nan, so a
+        single NULL makes tabulate type the column as float and every wide int
+        reverts to `6.13762e+17` — the cast undone by one missing cell. The
+        IUCN size-stratified assets have NULL finer h-columns, so this is live.
+        """
         result = query(
             "SELECT h8 FROM (VALUES (613762179077668863::UBIGINT), (NULL::UBIGINT)) t(h8)"
         )
         assert "613762179077668863" in result and "e+17" not in result
+        assert "nan" not in result
+
+    def test_query_null_date_is_blank_not_nan(self):
+        """A NULL date renders blank, never the literal `nan` (#387).
+
+        Same pandas-3 mechanism as above. `nan` in a date column reads as a
+        value rather than as missing.
+        """
+        result = query(
+            "SELECT d FROM (VALUES (DATE '2024-12-30'), (NULL::DATE)) t(d)"
+        )
+        assert "2024-12-30" in result
+        assert "nan" not in result
 
     def test_query_negative_and_hugeint_exact(self):
         """Signed negatives and HUGEINT aggregates render exactly (#387)."""


### PR DESCRIPTION
Fixes #387.

## The bug

Every H3 index in `query` output was rendered in scientific notation:

```
| h8          |
| 6.13762e+17 |
```

The true value is 18 digits. tabulate formats numbers through `float64`, exact only to **2^53 (9.007e15)** — so ~11 digits are gone and the printed number **names a different res-8 cell**. Nothing errors. A model reads a cell id out of a result, uses it in the next query, and silently gets the wrong cell.

This affects **every hex dataset in the catalog** — `h0`…`h15` are on every hex asset.

## Same mechanism as #361, but worse in two ways

`server.py:389` renders via `df.to_markdown()`; the comment at `:366` already names the pandas/tabulate mechanism from the temporal fix. The integer case was never covered.

- **Not shape-dependent.** #361 flipped format depending on the other columns in the projection. This renders scientific even for a **single-column frame** — it was always wrong, in every query.
- **Lossy, not just ugly.** #361 produced a correct-but-ill-formatted timestamp. This produces a **wrong number**.

## Fix

Cast in DuckDB before `.df()`, folded into the existing DATE/TIMESTAMP projection loop rather than added as a second pass. Only the SQL-side cast works — measured:

| approach | h8 | side effects |
|---|---|---|
| current | `6.13762e+17` | — |
| `disable_numparse=True` | `6.137621790776689e+17` | worse; also turns `3` into `3.0`, left-aligns everything |
| `floatfmt=".10g"` | `6.137621791e+17` | still scientific |
| **`::VARCHAR` in SQL** | **`613762179077668863`** | **none** |

Covers `BIGINT` / `UBIGINT` / `HUGEINT` / `UHUGEINT` — every type whose range exceeds 2^53. **Both signed and unsigned are required**: `h0` is `BIGINT` while `h8`/`h10` are `UBIGINT`, so a UBIGINT-only rule would still corrupt `h0`. `INTEGER` and narrower (max 4.29e9) are exact in float64 and left alone.

## Nullable columns were hit hardest

Pre-fix, through the real `query()` path:

```
|            h8 |          |                 h8 |
|--------------:|   -->    |-------------------:|
|   6.13762e+17 |          | 613762179077668863 |
| nan           |          |                    |
```

A literal `nan` next to a truncated value — a model can read that as data. (The IUCN size-stratified assets have NULL finer h-columns, so this is live, not hypothetical.)

## Display-only

A count still renders `3`, not `3.0`, right-aligned — tabulate re-parses the numeric string. Floats keep their formatting (`27.4638`, `1.5e-07` unchanged). Verified by test.

## Verification

- **6 tests added** beside the #361 ones: exact rendering, signed + unsigned, shape-independence, small-int/float non-regression, nullable, negative + HUGEINT aggregate.
- **5 of the 6 fail without the fix** — they discriminate rather than merely pass.
- Full suite: **418 passed**.

## Not gated

No prompt artifact changes, so no model-suite validation needed.

**Follow-up for #384:** h3-guide's 802-char "Coordinates from H3 Cells" section (from #104) exists to teach models around exactly this defect — reference the column, never the displayed value. With the renderer fixed it should become removable. That *is* a guidance change and needs the gate on its own, so it is deliberately not in this PR. It is the third case in this series where the prompt shrinks by fixing the tool rather than editing the text (after #385 and §5's geometry sentence).
