### PR TITLE
guidance(#384): drop the h3-literal warning — #387 removed the defect it described [gate]

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -100,12 +100,6 @@ FROM read_parquet('<hex parquet path>')
 WHERE <feature filter>;
 ```
 
-**Always pass the column** (`h8`, `h0`) — never copy a displayed h3 ID as a
-literal. Markdown table output may render the BIGINT in scientific notation
-(e.g. `6.15323e+17`), which DuckDB parses as DOUBLE (function rejects it) and
-which loses precision even when accepted. Accepted argument types are
-`VARCHAR`, `UBIGINT`, and `BIGINT`.
-
 ## Distance Between Hexes
 <!-- prov: issue=#168,#228 models=glm-5,kimi added=2026-06-21 cell=none tier=core -->
 


### PR DESCRIPTION
Follow-up to #389 (#387), first removal under #384.

## What goes

The "Coordinates from H3 Cells" section carried a warning built entirely on a tool defect:

> **Always pass the column** (`h8`, `h0`) — never copy a displayed h3 ID as a literal. Markdown table output may render the BIGINT in scientific notation (e.g. `6.15323e+17`), which DuckDB parses as DOUBLE (function rejects it) and which loses precision even when accepted.

#387 (merged as `1f7de11`) makes that false. Verified live on dev against prod, same query:

| prod (unfixed) | dev @ `1f7de11` |
|---|---|
| `6.13762e+17` | `613762311359823871` |
| `6.13762e+17` | `613762311519207423` |

Those are **two different cells** that prod renders as the same string. A displayed index is now exact and safe to copy, so the rule has nothing left to protect against.

## Deliberately partial

Only the warning paragraph goes. The `h3_cell_to_lat/lng` recipe **stays** — which function to call, and to average across a feature's cells, is capability information, not a workaround, and #387 does nothing to it.

#384 listed this whole 802-char section as a demotion candidate. Reading it closely, 337 chars were dead and 465 are working guidance. That is the same pattern the consumer sweep found repeatedly: `cell=none` marks *untested*, not *unneeded*, and the honest unit of removal is usually smaller than the section.

## Effect

**−337 chars (~−96 tok)** off every call, for every consumer. Modest, but the right kind: retired because the defect it described is gone, not because we argued the model no longer needs it. Third instance of the pattern that actually shrinks this prompt — fix the tool, then the text follows (after #385's dedup and §5's geometry sentence).

Harness unchanged: 11 executed, 0 failures.

## Gate

Prompt-artifact change, so per AGENTS.md this needs model-suite validation on dev before prod. Validation with `deepseek-v4-flash` (NRP, free) to follow on this PR — the check is that no baseline cell regresses, since the removed text has no cell of its own (`cell=none`).

Worth stating plainly about what that validation can and cannot show: the argument for this removal is **constructive, not statistical**. The warning described a rendering behaviour that no longer exists, which is verifiable directly (above) rather than by sampling model outputs. The matrix run is a regression check on everything else, not the evidence for the removal.
