### PR TITLE
k8s(prod): promote v0.8.16 (H3 index rendering fix + guidance dedup)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.15@sha256:62febce2da4dd498e1a6b68679fecd844936738ab4a0981537fd4f6daf4ec661
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.16@sha256:9b7f2f5053576bf573b37d01c6a82ad6c9bf823c8903280c8eaeb8db48b0700d
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes prod **v0.8.15 → v0.8.16@sha256:9b7f2f50**.

## What ships
| issue | PR | change |
|---|---|---|
| **#387** | #389 | H3 indexes rendered as `6.13762e+17` — 18-digit cell ids truncated to 6 significant digits, naming a **different cell**, on every hex dataset. NULLs also printed as literal `nan`. |
| #384 Stage 1 | #385 | map-rendering guidance folded into `register_hex_tiles` (~90% duplicate; steered models at `finest_res`, which #125 deliberately hides) |
| #384 Stage 2 | #386 | provenance on all 28 guidance sections, stripped at injection (zero token cost) |
| #384 | #390 | dropped the h3-literal warning that #387 made false |

Always-on tool payload **56,205 → 53,657 ch** (~16.1k → ~15.3k tok).

## Validation
`deepseek-v4-flash` (NRP, free) on dev @ `5be1180`, regression tier ×2 trials, ca-30x30 + biodiversity:

- answer **7 pass / 14 needs-judge / 1 timeout**, tool_call **6 pass**, clarify 2 needs-judge — no regression
- `car-28` headwater streams **27.46 / 27.5** vs gold 27.0±1.5, matching a direct SQL reproduction on live data
- the lone timeout is `car-31`, which also timed out 1/2 on prior runs

## The promoted artifact — #366 box 6, in the open

The release build produced a **different digest from the `:main` build of the same commit**: `9b7f2f50` vs the dev-validated `6be3a832`. Six of ten layers differ. That is box 6 of #366 ("prod promotion pins the digest dev validated, with no rebuild in between") still being unchecked.

Rather than assume it benign, I inspected the artifact in a throwaway pod **before** promoting:

```
APP_VERSION: v0.8.16
pandas 3.0.5 | duckdb 1.5.4 | tabulate 0.10.0     <- identical to the dev-validated build
#387 COALESCE fix present: True
h3-literal warning removed: True
```

**That check earned its keep:** `pandas` is *unpinned* in `requirements.txt`, and pandas 3's handling of missing values is precisely what #387 turns on — a rebuild resolving a different pandas could have silently undone the fix being shipped.

So the deltas are build non-determinism plus the intended `APP_VERSION` stamp. This **does not close #366 box 6** — prod runs bytes dev never ran, verified *equivalent* rather than *identical*. Also worth recording there: the fix is not purely a CI change, because `APP_VERSION` is baked at build time, so "retag don't rebuild" also requires decoupling the version stamp from the image.

After merge: `kubectl apply -f k8s/deployment.yaml` then `rollout restart`, then verify `/version` = v0.8.16 and replica digest convergence.