### PR TITLE
deps: pin pandas==3.0.5 — the rendering layer must not float

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,15 @@ mcp>=1.29,<2
 # `INSTALL h3 FROM community` may have no candidate, breaking every tile path.
 # Bump only once community h3 ships for the target version.
 duckdb==1.5.4
-pandas
+# Pinned: `query` renders results through pandas -> tabulate, and the pandas major
+# version silently changes that rendering. Under pandas 3 a str-dtype column holds
+# missing values as the FLOAT nan, so one NULL makes tabulate type the whole column
+# as float and 18-digit H3 indexes collapse back to `6.13762e+17` (#387) — the exact
+# defect #387 fixed. The fix is version-robust (COALESCE to ''), but the rendering
+# layer #361/#387 live in is decided by this dependency, so it should not float.
+# Also: an unpinned pandas can differ between the image dev validated and the image
+# a release tag rebuilds, which is unverifiable drift in a promotion (#366).
+pandas==3.0.5
 uvicorn
 tabulate
 pystac


### PR DESCRIPTION
`query` renders results through **pandas → tabulate**, and the pandas *major* version silently changes that rendering. Under pandas 3, a str-dtype column holds missing values as the **float `nan`**, so a single NULL makes tabulate type the whole column as float and 18-digit H3 indexes collapse back to `6.13762e+17` — the exact defect #387 fixed.

## Which pandas does our code work with?

**Both, now** — this pin is about determinism, not compatibility:

| | pandas 2.3.3 | pandas 3.0.5 |
|---|---|---|
| the #387 bug itself | present | present |
| cast-only fix (first attempt) | ✅ works | ❌ **fails** — NULL → float nan → column re-typed float |
| cast + `COALESCE(…, '')` (shipped in #389) | ✅ works | ✅ works |

## Why leaving it floating is expensive — both costs hit in one session

**1. A broken fix passed local tests.** My local pandas is 2.3.3; CI and the deployed image run 3.0.5. The first #387 attempt was correct on 2.3.3 and wrong on 3.0.5, so the local suite went green on code that did not work where it ships. **The local suite still cannot catch that class** — CI is the real gate, and that only holds if CI's version is fixed.

**2. It makes a promotion unverifiable.** A release tag rebuilds rather than retags (#366 box 6), so an unpinned pandas can differ between the image dev validated and the image prod runs — silently reverting the very rendering fix being shipped. Promoting v0.8.16 required a throwaway-pod check to rule that out:

```
pandas 3.0.5 | duckdb 1.5.4 | tabulate 0.10.0   ← matched the dev-validated build
```

Pinned, that check becomes unnecessary rather than merely passing.

## Choice of version

**3.0.5 is the latest release and already what prod runs**, so this is a no-op for the deployment — it records the version we validated against rather than changing anything.

Comment written in the style of the existing `mcp` and `duckdb` pins, which both explain *why* and *when to bump*. `tabulate` is the other half of this rendering path and is still unpinned; worth considering separately, though it has not moved major versions on us.

Full suite **419 passed**.