### PR TITLE
k8s(prod): promote v0.8.17 (pandas pin)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.16@sha256:9b7f2f5053576bf573b37d01c6a82ad6c9bf823c8903280c8eaeb8db48b0700d
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.17@sha256:b23f1db2ddfa0e77fe482716addcb42d095e35619c6b9e96822fc3cd4648a160
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes **v0.8.16 → v0.8.17@sha256:b23f1db2**. Sole change since v0.8.16 is #392, pinning `pandas==3.0.5`.

**Behaviourally a no-op.** Prod already resolved pandas 3.0.5, so nothing the server does changes. What changes is that the version is *recorded* rather than *incidental* — `query` renders through pandas → tabulate, and the pandas major version silently decides that rendering (#387: under pandas 3 a single NULL re-types a str column as float and 18-digit H3 indexes collapse back to `6.13762e+17`).

## Artifact verified before promoting

Same throwaway-pod check as v0.8.16:

```
APP_VERSION: v0.8.17
pandas 3.0.5 | duckdb 1.5.4 | tabulate 0.10.0
pin recorded in image: pandas==3.0.5
#387 fix present: True
```

The difference from last time: this check is now **confirming the pin** rather than **compensating for its absence**. With pandas floating, a release rebuild (#366 box 6) could resolve a different version than the one dev validated and silently revert the rendering fix being shipped. It cannot now.

## No gate

No prompt artifact changed since v0.8.16, which was validated on dev with `deepseek-v4-flash` (regression tier ×2, no regression).

After merge: `kubectl apply` + `rollout restart`, then verify `/version` = v0.8.17 and replica convergence.