### PR TITLE
guidance(#394): fix the AOI-clip recipe — ST_Length is degrees, and the geometry-column line was backwards

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -414,14 +414,14 @@ WITH cand AS (
   FROM read_parquet('<line_hex>') t
   JOIN read_parquet('<aoi_hex>') r ON t.h8 = r.h8 AND t.h0 = r.h0
 )
-SELECT rg.name_en AS aoi,
+SELECT rg.<aoi_name> AS aoi,
        SUM(tg.length_miles
-           * ST_Length(ST_Intersection(tg.<geom>, rg.<geom>))
-           / ST_Length(tg.<geom>)) AS miles
+           * ST_Length(ST_Intersection(tg.<line_geom>, rg.<aoi_geom>))
+           / ST_Length(tg.<line_geom>)) AS miles
 FROM cand c
 JOIN read_parquet('<line_geoparquet>') tg ON tg._cng_fid = c.trail_fid
 JOIN read_parquet('<aoi_geoparquet>') rg ON rg._cng_fid = c.aoi_fid
-GROUP BY rg.name_en ORDER BY miles DESC;
+GROUP BY rg.<aoi_name> ORDER BY miles DESC;
 ```
 
 **`ST_Length` returns degrees, not metres,** because these GeoParquets store lon/lat. Dividing
@@ -430,9 +430,10 @@ by `1609.344` is off by ~5 orders of magnitude, and the usual repairs are unavai
 ratio above is the way through — both lengths carry the same wrong unit, so it cancels, and
 `length_miles` supplies the real scale. Same idea as the fractional-overlay recipe below.
 
-**Read the geometry column name off the schema** (`DESCRIBE`, or the STAC `table:columns`) —
+**Read each geometry column name off the schema** (`DESCRIBE`, or the STAC `table:columns`) —
 it is `geom` on the census layers, `geometry` on trails and seafloor-geomorphology, and
-`SHAPE` on PAD-US and the WWF ecoregions. There is no safe default.
+`SHAPE` on PAD-US and the WWF ecoregions. There is no safe default, and the two sides of this
+join often differ.
 
 - **Share of a line network's length under a fractional per-cell overlay** ("what percent of streams are conserved", "what share of trail miles burned"): weight by the **line's own length**, never by cell area — the hex supplies only the per-cell fraction. Dedup the feature's `length_*` first (it is replicated on every cell it touches), take the mean overlay fraction across that feature's cells, then `SUM(length × fraction) / SUM(length)`:
 

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -393,7 +393,7 @@ GROUP BY a.h8;
 ---
 
 ### Problem 4 — Lines: per-segment columns and AOI boundaries
-<!-- prov: issue=#153,#155,#363,#367 models=deepseek-v4-flash-0731,glm-5.2 added=2026-08-12 cell=line-length-not-hex-area,stream-order-class-boundary,streamorder-use-nhdplus-hr-not-base-nhd tier=core -->
+<!-- prov: issue=#153,#155,#363,#367,#394 models=deepseek-v4-flash-0731,glm-5.2 added=2026-08-12 cell=line-length-not-hex-area,stream-order-class-boundary,streamorder-use-nhdplus-hr-not-base-nhd,line-length-clip-not-sum tier=core -->
 
 *(Applies whenever the feature you are measuring is line-derived — source geometry `LineString`/`MultiLineString`, columns like `length_miles`, `length_km`, `lengthkm` — **including** when you overlay it on an area layer that carries acres/area columns. The test is the feature's own geometry, not the overlay's. Skip only if the feature itself is polygon- or raster-derived.)*
 
@@ -406,7 +406,7 @@ Per-segment values are **replicated on every row of any JOIN that matches a segm
 
 - **Total per agency / class / surface** (no AOI): dedup by feature first. `SELECT admin_agency, SUM(length_miles) FROM (SELECT DISTINCT _cng_fid, admin_agency, length_miles FROM <line_hex>) GROUP BY admin_agency`.
 - **Presence / count** ("which trails cross this AOI"): hex SEMI JOIN + `COUNT(DISTINCT _cng_fid)`. No spatial functions.
-- **Mileage *inside* an AOI** (per-state, per-county, per-perimeter): `length_miles` is the **wrong column** — it's the segment's *full* length, not the AOI-clipped length. Default pattern: hex SEMI JOIN to a candidate `(trail _cng_fid, aoi _cng_fid)` list, then `ST_Intersection` on the GeoParquets joined by `_cng_fid` (the per-feature key, deterministic — avoid joining on names which can repeat across admin levels).
+- **Mileage *inside* an AOI** (per-state, per-county, per-perimeter): `length_miles` is the **wrong column** — it's the segment's *full* length, not the AOI-clipped length. Default pattern: hex SEMI JOIN to a candidate `(trail _cng_fid, aoi _cng_fid)` list, then `ST_Intersection` on the GeoParquets joined by `_cng_fid` (the per-feature key, deterministic — avoid joining on names which can repeat across admin levels). **Never convert a geometry length to real units — take the clipped-to-whole ratio and scale the feature's own `length_miles`** (why: below the query).
 
 ```sql
 WITH cand AS (
@@ -415,14 +415,24 @@ WITH cand AS (
   JOIN read_parquet('<aoi_hex>') r ON t.h8 = r.h8 AND t.h0 = r.h0
 )
 SELECT rg.name_en AS aoi,
-       SUM(ST_Length(ST_Intersection(tg.geometry, rg.geometry)) / 1609.344) AS miles
+       SUM(tg.length_miles
+           * ST_Length(ST_Intersection(tg.<geom>, rg.<geom>))
+           / ST_Length(tg.<geom>)) AS miles
 FROM cand c
 JOIN read_parquet('<line_geoparquet>') tg ON tg._cng_fid = c.trail_fid
 JOIN read_parquet('<aoi_geoparquet>') rg ON rg._cng_fid = c.aoi_fid
 GROUP BY rg.name_en ORDER BY miles DESC;
 ```
 
-The geometry column is `geometry` on the GeoParquets — not `geom`.
+**`ST_Length` returns degrees, not metres,** because these GeoParquets store lon/lat. Dividing
+by `1609.344` is off by ~5 orders of magnitude, and the usual repairs are unavailable here:
+`ST_Transform` returns `POINT (inf inf)` and every `*_Spheroid` function returns `nan`. The
+ratio above is the way through — both lengths carry the same wrong unit, so it cancels, and
+`length_miles` supplies the real scale. Same idea as the fractional-overlay recipe below.
+
+**Read the geometry column name off the schema** (`DESCRIBE`, or the STAC `table:columns`) —
+it is `geom` on the census layers, `geometry` on trails and seafloor-geomorphology, and
+`SHAPE` on PAD-US and the WWF ecoregions. There is no safe default.
 
 - **Share of a line network's length under a fractional per-cell overlay** ("what percent of streams are conserved", "what share of trail miles burned"): weight by the **line's own length**, never by cell area — the hex supplies only the per-cell fraction. Dedup the feature's `length_*` first (it is replicated on every cell it touches), take the mean overlay fraction across that feature's cells, then `SUM(length × fraction) / SUM(length)`:
 

--- a/tests/guidance_sql/fixture.py
+++ b/tests/guidance_sql/fixture.py
@@ -33,6 +33,14 @@ CW10 = f"s3://public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/h0={_H
 NHD = f"s3://public-usgs-nhd/nhdplus-hr/flowline/hex/h0={_H0}/data_0.parquet"     # _cng_fid, lengthkm, innetwork, streamorde, h8, h0
 NWI = f"s3://public-wetlands/nwi-v2/hex/h0={_H0}/data_0.parquet"                  # WETLAND_TYPE, state_code, h10, h0
 ACE = f"s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex/h0={_H0}/data_0.parquet"  # BioRankSW, h8, h0
+# line + AOI GeoParquet pair for the AOI-clip recipe (#394). Deliberately a pair
+# whose geometry columns DIFFER — trails `geometry` vs census `geom` — since asserting
+# one name for both is exactly the defect this block shipped with.
+TRAILS_HEX = f"s3://public-trails/federal-trails-2026/hex/h0={_H0}/data_0.parquet"   # _cng_fid, length_miles, h8, h0
+TRAILS_GPQ = "s3://public-trails/federal-trails-2026.parquet"                        # _cng_fid, length_miles, geometry
+CD_HEX = f"s3://public-census/census-2024/cd/hex/h0={_H0}/data_0.parquet"            # _cng_fid, GEOID, h8, h0
+CD_GPQ = "s3://public-census/census-2024/cd.parquet"                                 # _cng_fid, GEOID, NAMELSAD, geom
+
 # cross-dataset staples
 CENSUS = f"s3://public-census/census-2024/state/hex/h0={_H0}/data_0.parquet"      # h8, STUSPS, GEOID, h0
 CARBON = f"s3://public-carbon/irrecoverable-carbon-2024/hex/h0={_H0}/data_0.parquet"  # carbon, h5..h9, h0
@@ -73,6 +81,22 @@ EXECUTABLE = {
         "<feature filter>": "s.innetwork = 1 AND s.streamorde IN (1, 2)",
         "<conserved-areas hex-weights-res8>": CW8,
     },
+    # AOI-clipped line mileage (#394). Was a FRAGMENT ("AOI geoparquets not
+    #   mapped") — which is why the block shipped with `tg.geometry` against
+    #   datasets whose column is `geom`, and with ST_Length (degrees) divided by
+    #   1609.344. Binding this pair is what catches the first of those; the
+    #   trap cell tplca-trail-miles-siskiyou (geo-agent-benchmark#34) catches
+    #   the second. Mapped to a line/AOI pair with DIFFERENT geometry column
+    #   names on purpose.
+    "h3-guide.md:989f348f87": {
+        "<line_hex>": TRAILS_HEX,
+        "<aoi_hex>": CD_HEX,
+        "<line_geoparquet>": TRAILS_GPQ,
+        "<aoi_geoparquet>": CD_GPQ,
+        "<line_geom>": "geometry",
+        "<aoi_geom>": "geom",
+        "<aoi_name>": "NAMELSAD",
+    },
     # presence-only over res-10 land children (#355): mean of a 0/1 flag, never
     #   promoted to the res-8 parent. ACE feature x NWI wetlands, no GAP column.
     "h3-guide.md:da766d501c": {
@@ -105,7 +129,6 @@ FRAGMENTS = {
     "h3-guide.md:377ec327e2": "two-query block over generic `value`/`class` columns (SUM/AVG vs MODE illustration)",
     "h3-guide.md:b774ac61d1": "single-layer fractional overlay over a literal `class` column; no mapped dataset uses that column name (cwhr13 uses `whr13num`)",
     "h3-guide.md:1ccc1fb7d7": "references an undefined `mask` relation (DPP mask-first illustration)",
-    "h3-guide.md:acf2ad1267": "line-mileage via ST_Intersection over line+AOI GeoParquet; those AOI geoparquets are not mapped (the conserved-share line example IS executable — see da766d501c's sibling 0c6ddd1d29)",
     "h3-guide.md:ae094c7f8c": "COPY to a write path with a `SELECT ...` ellipsis (export idiom)",
     # --- query-optimization.md ---
     "query-optimization.md:2f7793ba77": "bare JOIN clause (include-h0-in-join idiom)",


### PR DESCRIPTION
Fixes the guidance half of #394. Three defects in one twelve-line block, all in the
"mileage *inside* an AOI" recipe in h3-guide Problem 4 — a section #384's audit had as
`cell=none`, which turned out to mean *nobody had ever run it*.

### 1. `ST_Length` returns degrees, and every conversion route is broken

The recipe divided by `1609.344`, which assumes metres. These GeoParquets store lon/lat, so
`ST_Length` returns **degrees** — a 74-mile trail reported as **0.00074 miles**.

The standard repairs don't exist on the deployed server:

| call | returns |
|---|---|
| `ST_Transform(…, 'EPSG:4326','EPSG:5070')` | `POINT (inf inf)` |
| `ST_Length_Spheroid` / `ST_Area_Spheroid` / `ST_Distance_Spheroid` | `nan` |
| `…::LINESTRING_2D` typed overload | `2.888e+71` |

Reproduced on stock DuckDB 1.5.4 **and** 1.4.1, so it's the extension build rather than our
deployment — but the consequence is ours: **no length or area in real units is currently
obtainable from geometry on this server.** That half of #394 needs its own issue and an
upstream report; it does not block this fix.

**The fix needs no conversion at all.** Take the clipped-to-whole ratio and scale the
feature's own `length_miles` — both lengths carry the same wrong unit, so it cancels:

```sql
SUM(tg.length_miles
    * ST_Length(ST_Intersection(tg.<geom>, rg.<geom>))
    / ST_Length(tg.<geom>)) AS miles
```

Which makes this recipe the same idea as the fractional-overlay one directly below it —
weight by the line's own length, use geometry only for the fraction — that `car-28`/`car-29`
already validate. The two adjacent recipes now agree in method as well as in subject.

### 2. The geometry-column line was backwards

> ~~The geometry column is `geometry` on the GeoParquets — not `geom`.~~

Measured across nine collections:

| column | collections |
|---|---|
| `geom` | census county / cd / place, ebsa, landvote |
| `geometry` | federal-trails-2026, seafloor-geomorphology |
| `SHAPE` | pad-us-4.1-combined, wwf-ecoregions-2017 |

There is no safe default, so the line now says to read the name off the schema. This is the
one defect of the three that failed loudly.

### 3. `_cng_fid` — no change, and that is the finding

My first pass here proposed weakening the `_cng_fid` join. **Withdrawn.** It is a per-file
row id doing exactly its job, and the advice to join on it is correct: 14 of 16 collections
checked agree, and every one that does had both assets written by a single build run.

`census-2024-county` and `-state` disagree because their hex was rebuilt **33 days** after
their flat (2026-04-22 vs 2026-03-20) from a GEOID-sorted read, so the positional id was
assigned twice with a sort in between. That is build staleness in two assets —
data-workflows#549 — not a property of the key, and not something to teach around.

### Verification

Run verbatim on prod against `census-2024-cd`, chosen because its `_cng_fid` agrees 444/444,
so the recipe shape is what's under test rather than the upstream bug:

| district | recipe as now written | naive `SUM(length_miles)` | old `/1609.344` |
|---|---:|---:|---:|
| CA-03 | **5,195.2 mi** | 5,629.9 (+8.4%) | 0.053 |
| CA-02 | **1,333.7 mi** | 1,554.0 (+16.5%) | 0.014 |

`419 passed` locally.

### Provenance

The section's `prov` gains `#394` and `line-length-clip-not-sum`, the trap tag on
`tplca-trail-miles-siskiyou` (geo-agent-benchmark#34) — so it stops being `cell=none` and
this block is guarded for the first time.

Net +14/−4 lines. It grows the prompt slightly, which is the right trade: the block it
replaces could not produce a correct answer.
