### PR TITLE
k8s(dev): converge dev onto current :main (5d01287)

### DIFF
--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         # dev's ≥2 replicas exist to catch. Bump this digest on redeploy (see
         # AGENTS.md → Rollout workflow). The tag prefix is for humans; the digest
         # is enforced. See issue #341.
-        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:458a014dc1763d6fef21574f7889e3c8199d442640e5a2df16f343dd50c973ef
+        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:fcd02946808587e394da975dfa523563585cba0b9e8194ad26840fe758d3219a
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Rolls dev onto the `:main` build carrying #395, so the guidance change can be gated on dev before prod.

Digest `sha256:fcd0294…` resolved via the anonymous registry-v2 route documented in AGENTS.md (no docker CLI here); the method was sanity-checked against `v0.8.17` first and matched `k8s/deployment.yaml` exactly.

**Convergence verified** — both endpoint-backing pods report the manifest digest:

```
dev-duckdb-mcp-7bfd966f8f-q8wkj   Ready=True   …@sha256:fcd0294…
dev-duckdb-mcp-7bfd966f8f-4clxb   Ready=True   …@sha256:fcd0294…
```

`/version` reports `git_sha 5d01287`. Over the wire, the `query` description now carries the ratio form, the degrees warning and the read-the-schema line, and `/ 1609.344) AS miles` is gone (still on prod v0.8.17, as expected).

Always-on payload measured like-for-like via `tools/list`: **prod 50,811 ch → dev 51,720 ch (+909)**.

Regression tier is running on dev against tpl-ca, tpl, bosl-high-seas and ca-30x30 with NRP `deepseek-v4-flash` (free); results to follow before any prod promotion.