### PR TITLE
k8s(prod): promote v0.8.18 (AOI-clip recipe fix)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.17@sha256:b23f1db2ddfa0e77fe482716addcb42d095e35619c6b9e96822fc3cd4648a160
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.18@sha256:64f5f8f6a5c18541c938dfffc772b74c3e05d69f848f3794f8126c02069b2c1d
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Ships #395. Dev-gated first per AGENTS.md — full gate evidence in #397.

**Gate (NRP `deepseek-v4-flash`, regression tier, 4 apps, 27 cells, 2 trials):**

- (a) `tplca-trail-miles-siskiyou` → **1,178 / 1,177.9 mi** vs gold 1,177.9, with the model emitting the corrected recipe verbatim — `tg.geometry` alongside `cg.geom`, zero occurrences of `1609.344`. `bosl-pri-eez-area` 1,969,000 km², `bosl-nearest-fishing-jarvis` 153/156 km, `tpl-tates-hell-acres` 204,576 ac — all on gold.
- (b) All 10 shared ca-30x30 cells **grade-identical** to the pre-change control run on v0.8.17. `car-28` (adjacent line-length recipe) unchanged at 27.46/27.5 vs gold 27.0±1.5.

**Rollout verified:** all 6 endpoint-backing pods on `sha256:64f5f8f6…`; the 3 `Ready=False` pods are disrupted-node orphans on old ReplicaSets, excluded per the runbook. `/version` → `v0.8.18 @ 5d01287`, and the corrected text confirmed live over `tools/list`.

Always-on payload **50,811 → 51,720 ch** (~14.5k → ~14.8k tok).