### PR TITLE
feat(#384): EXTRA_INSTRUCTIONS — tier guidance sections, off by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,38 @@ Decision rule when you catch a model error:
   guidance in its proper layer; if it's a per-dataset fact, STAC is what surfaces it at
   the right moment.
 
+### Tiering: `core` vs `extra` (`EXTRA_INSTRUCTIONS`)
+
+Every section of `h3-guide.md` / `query-optimization.md` declares a tier in its `prov`
+line. `select_tiers()` in `server.py` assembles the description from it:
+
+| tier | who gets it | what belongs here |
+|---|---|---|
+| `core` (default) | everyone, including prod and dev | anything whose absence changes an **answer** |
+| `extra` | only deployments setting `EXTRA_INSTRUCTIONS=1` | rules whose absence costs **turns, not correctness**, and whose motivating failure was last seen on a model outside the shipping set |
+
+A section with no `prov`, or a `prov` with no `tier=`, is treated as **`core`** — guidance
+is load-bearing until shown otherwise. Demoting a `##` takes its `###` children with it.
+
+**The bar for `tier=extra` is evidence, not intuition.** Both current members
+(`query-optimization.md` §3 DESCRIBE+LIKE, and the h3-guide rows-per-hex diagnostic) are
+efficiency-only *and* qwen3-era. If a rule can produce a wrong number, it is `core` even
+if only weak models get it wrong — the flag is off in production, so `extra` means "the
+shipping models never see this."
+
+**Demotion is cheap to prove, which is the point.** The weak models keep the text either
+way, so a demotion only has to show the *core* models are unaffected: run the `regression`
+tier on the `standard` set with the flag off and compare **`tool_call_count`**, which the
+harness already records, against the same run before the change. Efficiency rules are
+graded on turns, not accuracy — that A/B is a couple of free NRP jobs.
+
+**What tiering will not do is shrink the prompt much.** Measured 2026-08-17: the two
+demotions together are **1,300 ch of 51,720** (2.5%). The audit behind #384 is the reason —
+of the sections originally flagged `cell=none`, nearly all turned out to be load-bearing
+with live consumers, and the honest remedy was to write cells for them, not to demote them.
+Treat the flag as a discipline for keeping weak-model-only text out of the shipping
+description, not as a budget lever.
+
 ---
 
 ## Validating guidance changes (headless model-suite test)

--- a/h3-guide.md
+++ b/h3-guide.md
@@ -87,7 +87,7 @@ The constants below are latitude/distortion-averaged, not true per-cell values (
 Use the constant for the dataset's **native** resolution — the column it is actually indexed on (check with `DESCRIBE`). Multiplying a cell count by the constant for a different resolution is off by ~7× per level.
 
 ## Coordinates from H3 Cells
-<!-- prov: issue=#104,#114 models=qwen3 added=2026-05-03 cell=none tier=core -->
+<!-- prov: issue=#104,#114 models=qwen3 added=2026-05-03 cell=bosl-nearest-fishing-jarvis tier=core -->
 
 To get latitude/longitude from a hex column (e.g. to supply a `fly_to` map
 center), call `h3_cell_to_lat(hN)` / `h3_cell_to_lng(hN)` on the cell **column**.
@@ -101,7 +101,7 @@ WHERE <feature filter>;
 ```
 
 ## Distance Between Hexes
-<!-- prov: issue=#168,#228 models=glm-5,kimi added=2026-06-21 cell=none tier=core -->
+<!-- prov: issue=#168,#228 models=glm-5,kimi added=2026-06-21 cell=bosl-nearest-fishing-jarvis tier=core -->
 
 `h3_great_circle_distance` measures between two coordinate pairs, not cell
 indices. To get the distance between two hex cells, convert each to its center
@@ -464,7 +464,7 @@ FROM per_feature;
 ---
 
 ### Diagnostic: check rows-per-hex before writing queries
-<!-- prov: issue=#3 models=unrecorded added=2026-05-28 cell=none tier=core -->
+<!-- prov: issue=#3 models=unrecorded added=2026-05-28 cell=none tier=extra -->
 
 When uncertain, run this check on a single h0 partition first:
 

--- a/query-optimization.md
+++ b/query-optimization.md
@@ -59,7 +59,7 @@ FROM lc_on_scope GROUP BY h8, h0;
 The `WHERE l.lc_class IS NOT NULL` here keeps a no-data cell from poisoning the aggregate — but it also **changes which cells the answer describes**. When that column is only partly populated, see §9 before reporting the result as a share of the whole.
 
 ### Scoping by name or feature id (no region mask)
-<!-- prov: issue=#163 models=unrecorded added=2026-06-07 cell=none tier=core -->
+<!-- prov: issue=#163 models=unrecorded added=2026-06-07 cell=bosl-pri-eez-area tier=core -->
 
 To filter a global `…/hex/h0=*/…` dataset by a name or `_cng_fid` and there is no region-mask hex to join, first restrict `h0` to the region, then apply the attribute filter:
 
@@ -82,7 +82,7 @@ FROM (
 ```
 
 ## 3. Trust your schema — don't grep with DESCRIBE+LIKE
-<!-- prov: issue=#108,#113 models=qwen3 added=2026-05-03 cell=none tier=core -->
+<!-- prov: issue=#108,#113 models=qwen3 added=2026-05-03 cell=none tier=extra -->
 
 For datasets already loaded in your app, the column list returned by `get_schema`
 (or `get_stac_details`) is canonical: every column, with type and description.
@@ -128,7 +128,7 @@ Avoid `SELECT *` on GeoParquet files; select only the columns you need. If you n
 coordinates, cast explicitly: `ST_AsText(geom) AS geom_wkt`.
 
 ## 6. Apostrophes in string literals
-<!-- prov: issue=unrecorded models=unrecorded added=2026-06-24 cell=none tier=core -->
+<!-- prov: issue=unrecorded models=unrecorded added=2026-06-24 cell=tpl-tates-hell-acres tier=core -->
 
 Site names and owner names can contain apostrophes (e.g. `O'Brien Ranch`). Double any
 single quote inside a SQL string literal — do not use a backslash:

--- a/server.py
+++ b/server.py
@@ -82,10 +82,69 @@ PROV_RE = re.compile(r"^[ \t]*<!--[ \t]*prov:.*?-->[ \t]*\n", re.MULTILINE)
 def strip_prov(text):
     return PROV_RE.sub("", text)
 
+# `tier=extra` marks guidance that only weak models need — a rule whose absence costs
+# turns rather than correctness, and whose motivating failure was last observed on a model
+# outside the shipping set (#384). Those sections are dropped unless EXTRA_INSTRUCTIONS is
+# set, so a deployment serving small open models can opt back in without forking the file.
+#
+# Single source of truth on purpose: the tier is one word in the section's own `prov` line,
+# adjacent to the rule it governs. A parallel weak-model-guide.md would drift within two
+# cycles, and a one-word change in a diff is reviewable.
+#
+# A section runs from its heading to the next heading at the SAME OR HIGHER level, so
+# demoting a `##` takes its `###` children with it. A section with no `prov` line, or none
+# naming a tier, is treated as `core` — the safe default, since guidance is load-bearing
+# until shown otherwise. CI (#384 stage 4) is what requires the line to exist at all.
+_HEADING_RE = re.compile(r"^(#{2,6})[ \t]+\S")
+_TIER_RE = re.compile(r"\btier=([A-Za-z0-9_-]+)")
+
+def _section_tier(lines, i):
+    """Tier declared by the `prov` line belonging to the heading at `lines[i]`, or None.
+
+    Only the run of lines between the heading and the first non-blank, non-prov line is
+    searched, so a `tier=` mentioned in prose further down cannot be picked up.
+    """
+    for line in lines[i + 1:]:
+        if not line.strip():
+            continue
+        m = PROV_RE.match(line if line.endswith("\n") else line + "\n")
+        if not m:
+            return None
+        t = _TIER_RE.search(line)
+        return t.group(1).lower() if t else None
+    return None
+
+def select_tiers(text, include_extra):
+    """Drop `tier=extra` sections unless `include_extra`. Prov lines are stripped either way."""
+    if include_extra:
+        return strip_prov(text)
+    lines = text.splitlines(keepends=True)
+    keep, i = [], 0
+    while i < len(lines):
+        m = _HEADING_RE.match(lines[i])
+        if m and _section_tier(lines, i) == "extra":
+            level = len(m.group(1))
+            j = i + 1
+            while j < len(lines):
+                m2 = _HEADING_RE.match(lines[j])
+                if m2 and len(m2.group(1)) <= level:
+                    break
+                j += 1
+            i = j
+            continue
+        keep.append(lines[i])
+        i += 1
+    return strip_prov("".join(keep))
+
+# Off by default: `duckdb-mcp` and `dev-duckdb-mcp` serve core only, which is what the
+# `standard`/shipping model sets are gated against.
+EXTRA_INSTRUCTIONS = os.environ.get("EXTRA_INSTRUCTIONS", "").strip().lower() in (
+    "1", "true", "yes", "on")
+
 SETUP_RAW = load_text_file("query-setup.md")
 SETUP_SQL = parse_setup_sql(SETUP_RAW)
-OPTIM_RAW = strip_prov(load_text_file("query-optimization.md"))
-H3_RAW = strip_prov(load_text_file("h3-guide.md"))
+OPTIM_RAW = select_tiers(load_text_file("query-optimization.md"), EXTRA_INSTRUCTIONS)
+H3_RAW = select_tiers(load_text_file("h3-guide.md"), EXTRA_INSTRUCTIONS)
 ROLE_RAW = load_text_file("assistant-role.md")
 
 # Opt-in DuckDB extensions beyond the stock httpfs/spatial/h3 set (issue #354).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,90 @@ from server import (
     parse_setup_sql,
     get_isolated_db,
     query,
+    select_tiers,
+    strip_prov,
 )
+
+
+DOC = """## Alpha
+<!-- prov: issue=#1 models=qwen3 added=2026-01-01 cell=a-cell tier=core -->
+
+alpha body
+
+## Bravo
+<!-- prov: issue=#2 models=qwen3 added=2026-01-01 cell=none tier=extra -->
+
+bravo body
+
+### Bravo child
+
+child body
+
+## Charlie
+<!-- prov: issue=#3 models=glm-5 added=2026-01-01 cell=c-cell tier=core -->
+
+charlie body
+
+### Delta
+<!-- prov: issue=#4 models=qwen3 added=2026-01-01 cell=none tier=extra -->
+
+delta body
+
+## Echo
+
+echo body, no prov line at all
+"""
+
+
+class TestGuidanceTiers:
+    """EXTRA_INSTRUCTIONS tiering (#384): `tier=extra` sections load only when opted in."""
+
+    def test_extra_sections_dropped_by_default(self):
+        out = select_tiers(DOC, include_extra=False)
+        assert "alpha body" in out
+        assert "charlie body" in out
+        assert "bravo body" not in out
+        assert "delta body" not in out
+
+    def test_demoting_a_parent_takes_its_children(self):
+        # `### Bravo child` has no prov of its own; it must not survive its `##` parent,
+        # or a demotion silently leaves an orphaned fragment in the description.
+        assert "child body" not in select_tiers(DOC, include_extra=False)
+        assert "child body" in select_tiers(DOC, include_extra=True)
+
+    def test_a_deeper_extra_section_ends_at_the_next_sibling(self):
+        # `### Delta` is extra and sits under a core `##`; dropping it must not swallow
+        # `## Echo`, the next same-or-higher heading.
+        out = select_tiers(DOC, include_extra=False)
+        assert "delta body" not in out
+        assert "echo body, no prov line at all" in out
+
+    def test_missing_or_tierless_prov_defaults_to_core(self):
+        # Guidance is load-bearing until shown otherwise, so an unlabelled section stays.
+        assert "echo body" in select_tiers(DOC, include_extra=False)
+        tierless = "## Solo\n<!-- prov: issue=#9 models=x added=2026-01-01 cell=none -->\n\nsolo body\n"
+        assert "solo body" in select_tiers(tierless, include_extra=False)
+
+    def test_prov_lines_are_stripped_on_both_paths(self):
+        for flag in (False, True):
+            assert "prov:" not in select_tiers(DOC, include_extra=flag)
+
+    def test_include_extra_is_the_full_document_minus_prov(self):
+        assert select_tiers(DOC, include_extra=True) == strip_prov(DOC)
+
+    def test_tier_word_in_prose_is_not_read_as_a_declaration(self):
+        doc = "## Solo\n\nWe use tier=extra pricing in this prose.\n"
+        assert "tier=extra pricing" in select_tiers(doc, include_extra=False)
+
+    def test_real_guides_shrink_with_the_flag_off_and_stay_valid(self):
+        for fn in ("h3-guide.md", "query-optimization.md"):
+            raw = load_text_file(fn)
+            core = select_tiers(raw, include_extra=False)
+            full = select_tiers(raw, include_extra=True)
+            assert len(core) <= len(full)
+            # Never leave a dangling ```sql fence: an odd count means a section was cut
+            # mid-block, which would ship the model a truncated query.
+            assert core.count("```") % 2 == 0, f"{fn}: unbalanced code fence after tiering"
 
 
 class TestFileLoading:


### PR DESCRIPTION
Stage 3 of #384. `tier=core|extra` already sits in every section's `prov` line from stage 2;
this makes the loader key on it.

```python
OPTIM_RAW = select_tiers(load_text_file("query-optimization.md"), EXTRA_INSTRUCTIONS)
H3_RAW    = select_tiers(load_text_file("h3-guide.md"),           EXTRA_INSTRUCTIONS)
```

Off by default — prod and dev serve `core` only, which is what the `standard`/shipping model
sets are gated against. A deployment serving small open models sets `EXTRA_INSTRUCTIONS=1`
and gets everything, without forking the file.

### Loader details that matter

- A section runs to the next heading at the **same or higher** level, so demoting a `##`
  takes its `###` children with it instead of orphaning a fragment mid-description.
- **No `prov`, or a `prov` with no `tier=`, is `core`.** Guidance is load-bearing until shown
  otherwise; the flag must never silently swallow an unlabelled section.
- Only the run between a heading and its first non-blank line is searched, so `tier=extra`
  appearing in prose is not read as a declaration.
- `prov` is still stripped on both paths — tiering costs zero tokens either way.

### Demoted (2 sections)

Both efficiency-only, both qwen3-era, both `cell=none`:

| section | ch | why it qualifies |
|---|---:|---|
| `query-optimization.md` §3 — don't grep with DESCRIBE+LIKE | 684 | symptom is wasted turns, not wrong answers |
| `h3-guide.md` — rows-per-hex diagnostic | 776 | a practice, not a dataset dependency |

**The bar is evidence, not intuition.** If a rule can produce a wrong number it stays `core`
even when only weak models get it wrong — the flag is off in production, so `extra` means
"the shipping models never see this."

### Also: four stale `cell=none` claims corrected

These gained cells in geo-agent-benchmark#31/#34 and the audit metadata never caught up:

| section | now cited |
|---|---|
| Distance Between Hexes | `bosl-nearest-fishing-jarvis` |
| Coordinates from H3 Cells | `bosl-nearest-fishing-jarvis` |
| Scoping by name / feature id | `bosl-pri-eez-area` |
| §6 Apostrophes | `tpl-tates-hell-acres` |

That leaves the true `cell=none` set at four sections, two of which are the ones demoted
here, one blocked on #345, and one (§5 GeoParquet geometry) a trim rather than a demotion.

### Effect, and the honest part

**`query` description 41,776 → 40,476 ch.** That is 1,300 ch — **2.5%** of the always-on
payload.

Worth stating plainly: **the "Done when" target of ≤30k ch is not reachable this way.** The
audit found nearly every `cell=none` section to be load-bearing with live consumers, and the
remedy was writing cells, not demoting. The flag earns its place as *discipline* — keeping
weak-model-only text out of the shipping description, and making every future demotion cheap
to prove — not as a budget lever. I'd suggest restating that checkbox against what tiering
can actually do.

### Testing

8 new cases: nesting, tierless and prov-less defaults, prose false positives, and a guard
that tiering never leaves an unbalanced ` ```sql ` fence (a section cut mid-block would ship
the model a truncated query). **427 passed.**

The guidance-SQL harness reads the `.md` files from disk, so demotion doesn't touch its
fixtures — **12 executed, 21 fragments, 0 failures**, unchanged.

### Validation plan after merge

Both demoted rules are efficiency-only, so the gate is **turn count**, which the harness
already records. The pre-change control exists: `2026-08-16-g394-dev-regression` ran the same
tier on the same model with both sections present. I'll re-run on dev with the flag off and
compare `tool_calls` per cell — and report it either way, including if turns go up.
