### PR TITLE
k8s(dev): converge dev onto current :main (e1a4a1d)

### DIFF
--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         # dev's ≥2 replicas exist to catch. Bump this digest on redeploy (see
         # AGENTS.md → Rollout workflow). The tag prefix is for humans; the digest
         # is enforced. See issue #341.
-        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:fcd02946808587e394da975dfa523563585cba0b9e8194ad26840fe758d3219a
+        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:16abf693eb28cd0652c4eac52e6751f45b7c9e29ea42af444c30ee4a2169b843
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Rolls dev onto the `:main` build carrying #399, so the two `tier=extra` demotions can be gated on turn count before prod.

Digest sanity-checked against `v0.8.18` first (still matched `k8s/deployment.yaml` exactly) before trusting it for `:main`.

**Convergence:** both endpoint-backing pods on `sha256:16abf69…`, `/version` → `git_sha e1a4a1d`.

**The flag is off in the default image and doing its job**, verified over `tools/list`:

| | always-on | DESCRIBE+LIKE | rows-per-hex |
|---|---:|---|---|
| dev (tiered) | **50,420 ch** | absent | absent |
| prod v0.8.18 | 51,720 ch | present | present |

Regression tier running on dev across all four apps with NRP `deepseek-v4-flash`; the pre-change control is `2026-08-16-g394-dev-regression`, same model and tier with both sections present. Both demoted rules are efficiency-only, so the comparison that matters is `tool_calls` per cell — reported either way, including if turns go up.