### PR TITLE
k8s(prod): promote v0.8.19 (EXTRA_INSTRUCTIONS tiering)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.18@sha256:64f5f8f6a5c18541c938dfffc772b74c3e05d69f848f3794f8126c02069b2c1d
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.19@sha256:f38f2d8c1630aaeae7fc5aed40e575c7583b87ff247cfa874954efabcca79e65
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Ships #399 (stage 3 of #384). Flag is off in this image, so prod serves **core only** — §3 `DESCRIBE+LIKE` and the rows-per-hex diagnostic are out of the `query` description.

**Dev gate** (full evidence in #400): regression tier, NRP `deepseek-v4-flash`, 4 apps, 27 cells, 2 trials, against control `2026-08-16-g394-dev-regression`.

- **Accuracy: 27/27 grade-identical.**
- **The behaviour §3 targets: zero `DESCRIBE` statements in either condition.** The model reaches for `get_schema` (122 → 125) and never for `DESCRIBE` — the rule was inert for the shipping model whether present or absent.
- rows-per-hex profiling queries: 3 → 3.

Aggregate `tool_calls` went 235.0 → 221.0 (−6.0%), **not claimed as a win**: median per-cell delta 0.0, stdev 4.43 vs mean −0.52, and the total is carried by a few swings including one with a known unrelated cause. Turn count at 2 trials can't grade a rule worth a fraction of a turn — logged on #384 as a correction to the plan, which had proposed that metric.

**Always-on payload 51,720 → 50,420 ch** (~14.8k → ~14.4k tok).

**Rollout verified:** all 6 endpoint-backing pods on `sha256:f38f2d8…`, `/version` → `v0.8.19 @ e1a4a1d`, and prod/dev now serve byte-identical always-on payloads.

One note: this image's digest differs from the dev build that was gated (`16abf69`) despite the same source commit — the non-reproducible-rebuild issue tracked in #366.