### PR TITLE
feat(#384): stage 4 — CI gate on guidance provenance, tiers and budget

### DIFF
--- a/.github/workflows/guidance-gate.yml
+++ b/.github/workflows/guidance-gate.yml
@@ -1,0 +1,58 @@
+name: Guidance gate
+
+# Stage 4 of #384. Holds three properties on the guidance files that server.py injects
+# verbatim into the `query` tool description on every call:
+#
+#   1. every section carries a well-formed `prov` line (issue, models, added, cell, tier),
+#      so a rule cannot merge without naming why it exists and what guards it;
+#   2. `tier=` is spelled correctly — select_tiers() treats an unrecognised tier as `core`,
+#      so a typo'd demotion is silently a no-op that keeps shipping to prod;
+#   3. the assembled description stays under a committed ceiling, and a deferred
+#      guidance-SQL exemption names a tracking issue (#394's lesson: an exemption with a
+#      good reason is indistinguishable from coverage until someone checks).
+#
+# Deliberately not gated: `cell=none`. That is the audit signal, not a violation — banning
+# it would push authors to invent a cell reference instead of writing a cell.
+#
+# No secrets and no network: importing server.py to measure the description logs a STAC
+# catalog warning and continues, which is the intended degraded-start behaviour (#260).
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'h3-guide.md'
+      - 'query-optimization.md'
+      - 'query-setup.md'
+      - 'assistant-role.md'
+      - 'server.py'
+      - 'tests/check_guidance_prov.py'
+      - 'tests/guidance_sql/fixture.py'
+      - '.github/workflows/guidance-gate.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'h3-guide.md'
+      - 'query-optimization.md'
+      - 'query-setup.md'
+      - 'assistant-role.md'
+      - 'server.py'
+      - 'tests/check_guidance_prov.py'
+      - 'tests/guidance_sql/fixture.py'
+      - '.github/workflows/guidance-gate.yml'
+  workflow_dispatch:
+
+jobs:
+  guidance-gate:
+    name: Guidance provenance + budget
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Check guidance provenance, tiers and budget
+        run: python tests/check_guidance_prov.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,44 @@ with live consumers, and the honest remedy was to write cells for them, not to d
 Treat the flag as a discipline for keeping weak-model-only text out of the shipping
 description, not as a budget lever.
 
+**Grade an efficiency demotion on the behaviour it targets, not on turn count.** Aggregate
+`tool_calls` is recorded and cheap, and it is also too noisy to use: at 2 trials over 27
+cells the per-cell delta was −0.52 with a stdev of 4.43, so a −6% total meant nothing.
+Count the move the rule exists to prevent instead. For §3 that is
+`DESCRIBE … WHERE column_name LIKE '%…%'`, and `deepseek-v4-flash` emitted **zero**
+`DESCRIBE` statements with the section present *or* absent — a direct answer where the
+aggregate had none.
+
+### The guidance gate (CI)
+
+`tests/check_guidance_prov.py` runs on any guidance change (`.github/workflows/guidance-gate.yml`)
+and enforces four things:
+
+1. **Every `##`/`###` section carries a well-formed `prov`** with `issue`, `models`, `added`,
+   `cell`, `tier`. New guidance cannot merge without naming its model and its cell.
+2. **`tier=` is spelled correctly.** `select_tiers()` defaults an unrecognised tier to
+   `core`, so `tier=exta` would silently un-do a demotion and keep shipping to prod.
+3. **The assembled `query` description stays under `QUERY_DESC_CEILING`.** A ratchet, not a
+   target — raising it is a one-line diff a reviewer can question. Say in the PR what earned
+   the space.
+4. **A *deferred* guidance-SQL exemption cites an issue.** `FRAGMENTS` holds two kinds of
+   entry and only one is debt: something that can never bind (a bare clause, a CTE over an
+   undefined relation) is exempt forever, while a "not yet mapped" deferral is a real
+   runnable query waiting on placeholder mappings and must name a tracking issue.
+
+That last one is #394's lesson, and the most transferable thing in this section. The
+AOI-clip recipe sat in `FRAGMENTS` as *"those AOI geoparquets are not mapped"* — an honest
+deferral — and shipped with the wrong geometry column name and degrees divided by 1609.344.
+Two guards were nominally over that block, a benchmark cell and the SQL harness, and both
+had been opted out of. **An exemption with a good reason is indistinguishable from coverage
+until someone checks.**
+
+Note what each guard can and cannot do, because they are complementary and neither is
+sufficient: **binding** catches a moved column, a renamed function, a path that no longer
+resolves. It cannot catch `/1609.344`, which is valid SQL that is simply wrong — that needs
+a **trap cell** with a gold value. `cell=none` is deliberately *not* gated: it is the audit
+signal, and banning it would push authors to invent a cell reference rather than write a cell.
+
 ---
 
 ## Validating guidance changes (headless model-suite test)

--- a/tests/check_guidance_prov.py
+++ b/tests/check_guidance_prov.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Stage 4 of #384: gate the guidance files so provenance and size can't re-accrete.
+
+Three checks, each guarding a failure this repo has actually shipped:
+
+1. **Every section carries a well-formed `prov` line.** `h3-guide.md` and
+   `query-optimization.md` are injected verbatim into the `query` tool description on
+   every call, so a rule with no recorded motivation is unvalidated weight nobody can
+   later argue about. The audit that produced this gate found eight sections whose
+   provenance had to be reconstructed from closed issues and git blame; that is the cost
+   of letting one merge without it. `q-opt §9` also shipped *post-policy* with no cell, so
+   the discipline was leaking in the present, not only the past.
+
+2. **A `tier=extra` demotion is spelled correctly.** `select_tiers()` treats an
+   unrecognised tier as `core` (the safe default), which means a typo — `tier=exta` — is
+   silently a no-op rather than an error. The flag would appear to do nothing and the
+   section would keep shipping to prod.
+
+3. **The assembled `query` description stays under a committed ceiling.** #293/#384 exist
+   because it grew unnoticed. The ceiling is a ratchet, not a target: raising it is a
+   one-line diff a reviewer can see and question, which is the whole point.
+
+4. **A deferred guidance-SQL exemption names a tracking issue.** #394 is the case: the
+   AOI-clip recipe sat in the harness's `FRAGMENTS` list as "those AOI geoparquets are not
+   mapped" — an honest deferral — and shipped with the wrong geometry column name and
+   degrees divided by 1609.344. Binding alone would have caught the first defect on day
+   one. Two guards were nominally over that block and both had been opted out of, so **an
+   exemption with a good reason is indistinguishable from coverage until someone checks.**
+   Entries that can never bind (a bare clause, a CTE over an undefined relation) are not
+   debt and are left alone; a *deferral* is, and must carry a `#NNN`.
+
+Deliberately NOT checked: `cell=none`. It is the audit *signal*, not a violation — the
+consumer sweep behind #384 found that of 5,524 ch flagged `cell=none`, only ~683 ch was a
+clean demotion candidate and the rest was load-bearing but unguarded. A CI rule banning
+`cell=none` would push authors to invent a cell reference rather than write a cell.
+
+Runs in CI on any guidance change, and locally:
+    python tests/check_guidance_prov.py
+"""
+import os
+import re
+import sys
+
+GUIDES = ("h3-guide.md", "query-optimization.md")
+REQUIRED_FIELDS = ("issue", "models", "added", "cell", "tier")
+VALID_TIERS = ("core", "extra")
+
+# The ceiling is the ratchet. Set from the measured v0.8.19 payload (40,476 ch) with ~5%
+# headroom so ordinary wording fixes don't trip it, but a new section does. Raising this
+# should come with a sentence in the PR saying what earned the space.
+QUERY_DESC_CEILING = 42_500
+
+HEADING = re.compile(r"^(#{2,6})[ \t]+(\S.*)$")
+PROV = re.compile(r"^[ \t]*<!--[ \t]*prov:(.*?)-->[ \t]*$")
+FIELD = re.compile(r"\b([a-z_]+)=(\S+)")
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _prov_for_heading(lines, i):
+    """The prov payload for the heading at `lines[i]`, or None if the next content line
+    is not a prov comment. Only the first non-blank line is considered, so provenance
+    cannot drift away from the heading it describes."""
+    for line in lines[i + 1:]:
+        if not line.strip():
+            continue
+        m = PROV.match(line)
+        return m.group(1).strip() if m else None
+    return None
+
+
+def check_prov(violations):
+    sections = 0
+    for name in GUIDES:
+        path = os.path.join(ROOT, name)
+        if not os.path.exists(path):
+            violations.append(f"{name}: missing — guidance file expected at repo root")
+            continue
+        lines = open(path).read().splitlines()
+        for i, line in enumerate(lines):
+            m = HEADING.match(line)
+            if not m:
+                continue
+            sections += 1
+            title = m.group(2).strip()
+            prov = _prov_for_heading(lines, i)
+            if prov is None:
+                violations.append(
+                    f"{name}:{i + 1}: section '{title[:60]}' has no `prov` line. Add "
+                    "`<!-- prov: issue=#N models=<which models failed> added=YYYY-MM-DD "
+                    "cell=<benchmark cell|none> tier=core|extra -->` directly under the heading.")
+                continue
+            fields = dict(FIELD.findall(prov))
+            missing = [f for f in REQUIRED_FIELDS if f not in fields]
+            if missing:
+                violations.append(
+                    f"{name}:{i + 1}: section '{title[:50]}' prov is missing "
+                    f"{', '.join(missing)}")
+            tier = fields.get("tier")
+            if tier is not None and tier not in VALID_TIERS:
+                # Silently a no-op otherwise: select_tiers() defaults anything it doesn't
+                # recognise to `core`, so a typo'd demotion still ships to prod.
+                violations.append(
+                    f"{name}:{i + 1}: section '{title[:50]}' has tier={tier!r}; "
+                    f"expected one of {VALID_TIERS}. An unrecognised tier is treated as "
+                    "`core`, so a typo silently un-does the demotion.")
+    return sections
+
+
+def check_budget(violations):
+    """Assemble the description the way the server does and hold it under the ceiling."""
+    sys.path.insert(0, ROOT)
+    try:
+        import server  # noqa: F401  (import side-effect: builds the description)
+    except Exception as e:  # pragma: no cover - import failure is its own signal
+        violations.append(f"could not import server.py to measure the description: {e}")
+        return None
+    try:
+        desc = server.mcp._tool_manager._tools["query"].description
+    except Exception as e:
+        violations.append(f"could not read the assembled `query` description: {e}")
+        return None
+    if len(desc) > QUERY_DESC_CEILING:
+        violations.append(
+            f"assembled `query` description is {len(desc):,} ch, over the "
+            f"{QUERY_DESC_CEILING:,} ch ceiling by {len(desc) - QUERY_DESC_CEILING:,}. "
+            "Either tighten the guidance or raise QUERY_DESC_CEILING in this file and say "
+            "in the PR what earned the space.")
+    return len(desc)
+
+
+# Language that marks a FRAGMENTS entry as *deferred* rather than *not a statement*. A
+# deferral is debt: the SQL is real and runnable, and only the placeholder mappings are
+# missing. Those must name an issue so the exemption has an owner (#402).
+DEFERRAL_PHRASES = ("not yet mapped", "not mapped", "todo", "for now", "pending")
+ISSUE_REF = re.compile(r"#\d+")
+
+
+def check_deferred_fragments(violations):
+    fixture = os.path.join(ROOT, "tests", "guidance_sql", "fixture.py")
+    if not os.path.exists(fixture):
+        return 0
+    sys.path.insert(0, os.path.dirname(fixture))
+    try:
+        import fixture as fx
+    except Exception as e:  # pragma: no cover
+        violations.append(f"could not import the guidance-SQL fixture: {e}")
+        return 0
+    deferred = 0
+    for key, reason in sorted(getattr(fx, "FRAGMENTS", {}).items()):
+        low = str(reason).lower()
+        if not any(p in low for p in DEFERRAL_PHRASES):
+            continue  # can never bind — not debt, exempt forever
+        deferred += 1
+        if not ISSUE_REF.search(str(reason)):
+            violations.append(
+                f"guidance_sql/fixture.py: FRAGMENTS[{key!r}] is a deferral "
+                f"({reason!s:.60}…) with no issue reference. A deferred exemption is debt: "
+                "either promote it to EXECUTABLE with mappings, or cite the issue tracking "
+                "it (#402) so it has an owner.")
+    return deferred
+
+
+def main():
+    violations = []
+    sections = check_prov(violations)
+    deferred = check_deferred_fragments(violations)
+    size = check_budget(violations)
+    if violations:
+        print(f"❌ guidance gate: {len(violations)} problem(s)", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+    headroom = QUERY_DESC_CEILING - size if size is not None else 0
+    print(f"✅ guidance gate: {sections} sections all carry a well-formed prov line; "
+          f"{deferred} deferred SQL exemption(s) all cite an issue; "
+          f"`query` description {size:,} ch of {QUERY_DESC_CEILING:,} ceiling "
+          f"({headroom:,} ch headroom)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/guidance_sql/fixture.py
+++ b/tests/guidance_sql/fixture.py
@@ -17,6 +17,17 @@ see. It is not a result-value check (that is the model gate's job).
 
 Datasets/paths verified 2026-08-11. To grow coverage, promote a FRAGMENT whose
 reason is "not yet mapped" to EXECUTABLE with real mappings and confirm it runs.
+
+Two kinds of FRAGMENT, and only one is debt:
+  * NOT A STATEMENT — a bare clause, a CTE over an undefined relation, a write-path
+    COPY, a deliberate parse-error illustration. Can never bind; exempt forever.
+  * DEFERRED ("not yet mapped") — a real runnable query waiting on placeholder
+    mappings. This IS debt and must cite a tracking issue, so the deferral has an
+    owner. #394 is why: the AOI-clip recipe sat here as "those AOI geoparquets are
+    not mapped" and shipped with a wrong geometry column name and degrees divided by
+    1609.344. Binding alone would have caught the first on day one. An exemption with
+    a good reason is indistinguishable from coverage until someone checks.
+    tests/check_guidance_prov.py enforces the citation.
 """
 
 # One CA partition present in every dataset used below (verified).
@@ -121,7 +132,7 @@ FRAGMENTS = {
     "h3-guide.md:523cd143ac": "two-query block; the per-group form needs a literal `state` column not present in a clean mapping",
     "h3-guide.md:21d7da17ad": "incomplete — `FROM ...` ellipsis (illustrative approx-area shortcut)",
     "h3-guide.md:da9876be19": "incomplete — `FROM ...` ellipsis (great-circle distance illustration)",
-    "h3-guide.md:39e204c12b": "GEBCO x geomorphology h6 join; two co-indexed datasets not yet mapped",
+    "h3-guide.md:39e204c12b": "GEBCO x geomorphology h6 join; two co-indexed datasets not yet mapped (#402)",
     "h3-guide.md:e258e8fec8": "bare JOIN clauses over undefined dataset_a/b, wdpa/gfw (resolution-conversion idiom)",
     "h3-guide.md:598ddf3355": "needs dataset-specific columns (_cng_fid, amount, state_id); no representative mapping",
     "h3-guide.md:e2dfe983ec": "CTE fragment referencing an undefined `flat_funding` relation",
@@ -132,12 +143,12 @@ FRAGMENTS = {
     "h3-guide.md:ae094c7f8c": "COPY to a write path with a `SELECT ...` ellipsis (export idiom)",
     # --- query-optimization.md ---
     "query-optimization.md:2f7793ba77": "bare JOIN clause (include-h0-in-join idiom)",
-    "query-optimization.md:a941d3b637": "regions x padus x carbon 3-way; regions/padus hex paths not yet mapped",
+    "query-optimization.md:a941d3b637": "regions x padus x carbon 3-way; regions/padus hex paths not yet mapped (#402)",
     "query-optimization.md:0681d81d61": "references an undefined `scope` CTE (join-before-aggregate illustration)",
-    "query-optimization.md:48c32ed53a": "`<bucket>/<dataset>` with `_cng_fid` and `data_00.parquet`; dataset not yet mapped",
+    "query-optimization.md:48c32ed53a": "`<bucket>/<dataset>` with `_cng_fid` and `data_00.parquet`; dataset not yet mapped (#402)",
     "query-optimization.md:e103e0c492": "`read_parquet('…')` ellipsis placeholder (DESCRIBE-to-find-a-column idiom)",
     "query-optimization.md:b344ccbf7e": "bare WHERE clause (fuzzy text match)",
     "query-optimization.md:557a390cc8": "bare WHERE clause (exact text match)",
     "query-optimization.md:b63ace2673": "bare WHERE clauses incl. a deliberate parse-error illustration; not executable",
-    "query-optimization.md:29b78ebc22": "generic `value`/`lc_class` columns with sentinel exclusion; dataset not yet mapped",
+    "query-optimization.md:29b78ebc22": "generic `value`/`lc_class` columns with sentinel exclusion; dataset not yet mapped (#402)",
 }


### PR DESCRIPTION
Stage 4 of #384 — the piece the issue calls "the only thing that stops re-accretion."

`tests/check_guidance_prov.py`, wired up as `.github/workflows/guidance-gate.yml` on any
guidance change. Four checks, each guarding something this repo has actually shipped:

| # | check | the failure it guards |
|---|---|---|
| 1 | every `##`/`###` section has a well-formed `prov` (issue, models, added, cell, tier) | the audit had to reconstruct provenance for 8 sections from closed issues and git blame — then q-opt §9 shipped *post-policy* with no cell |
| 2 | `tier=` is spelled correctly | `select_tiers()` defaults an unrecognised tier to `core`, so `tier=exta` **silently un-does a demotion** and keeps shipping to prod |
| 3 | assembled `query` description under `QUERY_DESC_CEILING` | #293/#384 exist because it grew unnoticed |
| 4 | a **deferred** guidance-SQL exemption cites a tracking issue | #394 — see below |

All 27 sections pass today. Ceiling set to **42,500 ch** against the measured **40,476**
(2,024 headroom, ~5%) — a ratchet, not a target; raising it is a one-line diff a reviewer can
question.

### Check 4 is the transferable one

`FRAGMENTS` holds two kinds of entry and only one is debt:

- **not a statement** — a bare clause, a CTE over an undefined relation, a write-path `COPY`,
  a deliberate parse-error illustration. Can never bind; exempt forever, untouched by this.
- **deferred** ("not yet mapped") — a *real runnable query* waiting on placeholder mappings.
  That is debt and must name an owner.

#394 was exactly the second kind. The AOI-clip recipe sat there as *"those AOI geoparquets
are not mapped"* — an honest, plausible deferral — and shipped with the wrong geometry column
name and `ST_Length` (degrees) divided by 1609.344. Binding alone would have caught the first
defect on day one. Two guards were nominally over that block, a benchmark cell and this
harness, and **both had been opted out of.** An exemption with a good reason is
indistinguishable from coverage until someone checks.

The four current deferrals now cite #402, which tracks promoting them.

### Verified to fail, not merely to pass

Each check exercised against a deliberate violation — one problem reported, exit 1, every
time:

| injected | result |
|---|---|
| a section with no `prov` | `h3-guide.md:496: section 'Sneaky new rule' has no prov line…` |
| `tier=exta` | `…has tier='exta'; expected one of ('core','extra'). An unrecognised tier is treated as core, so a typo silently un-does the demotion.` |
| padding past the ceiling | `assembled query description is 43,988 ch, over the 42,500 ch ceiling by 1,488` |
| an issue ref stripped from a deferral | `FRAGMENTS['h3-guide.md:39e204c12b'] is a deferral … with no issue reference` |

### Deliberately not gated: `cell=none`

It is the audit *signal*, not a violation. The consumer sweep found only ~683 of 5,524
flagged ch was a clean demotion candidate; the rest was load-bearing but unguarded. A rule
banning `cell=none` would push authors to invent a cell reference rather than write a cell.

### Also recorded in AGENTS.md

That an efficiency demotion should be graded on **the behaviour it targets**, not turn count.
At 2 trials the per-cell `tool_calls` delta was −0.52 with stdev 4.43, so the −6% total meant
nothing — while counting `DESCRIBE` statements gave a clean zero-vs-zero answer. And that the
two guards are complementary: binding catches a moved column; only a trap cell catches
`/1609.344`, which is valid SQL that is simply wrong.

427 passed; guidance-SQL harness 12 executed / 21 fragments / 0 failures.
