### PR TITLE
guidance(#396): ST_Transform / *_Spheroid are not broken — they want lat/lon

### DIFF
--- a/h3-guide.md
+++ b/h3-guide.md
@@ -424,11 +424,23 @@ JOIN read_parquet('<aoi_geoparquet>') rg ON rg._cng_fid = c.aoi_fid
 GROUP BY rg.<aoi_name> ORDER BY miles DESC;
 ```
 
-**`ST_Length` returns degrees, not metres,** because these GeoParquets store lon/lat. Dividing
-by `1609.344` is off by ~5 orders of magnitude, and the usual repairs are unavailable here:
-`ST_Transform` returns `POINT (inf inf)` and every `*_Spheroid` function returns `nan`. The
-ratio above is the way through — both lengths carry the same wrong unit, so it cancels, and
-`length_miles` supplies the real scale. Same idea as the fractional-overlay recipe below.
+**`ST_Length` returns degrees, not metres,** because these GeoParquets store lon/lat — so
+dividing by `1609.344` is off by ~5 orders of magnitude. The ratio above sidesteps units
+entirely: both lengths carry the same wrong unit, it cancels, and `length_miles` supplies the
+real scale. Same idea as the fractional-overlay recipe below, and it needs no CRS choice.
+
+**If you need a true length in metres, flip the axes first.** `ST_Length_Spheroid`,
+`ST_Distance_Spheroid` and `ST_Transform` all read the first ordinate as **latitude**, the
+opposite of how these files store it; passing lon/lat gives `nan` or `POINT (inf inf)` rather
+than an error. `ST_FlipCoordinates` is the fix:
+
+```sql
+SELECT ROUND(SUM(ST_Length_Spheroid(ST_FlipCoordinates(<line_geom>))) / 1609.344, 1) AS miles
+FROM read_parquet('<line_geoparquet>');
+```
+
+Both routes agree — on federal trails clipped to a county, 1,177.4 mi geodesic against
+1,177.9 mi by the ratio (0.04%).
 
 **Read each geometry column name off the schema** (`DESCRIBE`, or the STAC `table:columns`) —
 it is `geom` on the census layers, `geometry` on trails and seafloor-geomorphology, and

--- a/tests/guidance_sql/fixture.py
+++ b/tests/guidance_sql/fixture.py
@@ -108,6 +108,14 @@ EXECUTABLE = {
         "<aoi_geom>": "geom",
         "<aoi_name>": "NAMELSAD",
     },
+    # geodesic length via flip + spheroid (#396). ST_Length_Spheroid reads the first
+    #   ordinate as LATITUDE, the opposite of how these files store it, and returns nan
+    #   rather than erroring on lon/lat input — which is exactly how the guide came to
+    #   claim the function was broken. Binding this keeps the claim honest.
+    "h3-guide.md:a0dab29752": {
+        "<line_geoparquet>": TRAILS_GPQ,
+        "<line_geom>": "geometry",
+    },
     # presence-only over res-10 land children (#355): mean of a 0/1 flag, never
     #   promoted to the res-8 parent. ACE feature x NWI wetlands, no GAP column.
     "h3-guide.md:da766d501c": {


### PR DESCRIPTION
**I went to file the upstream report you asked for, searched duckdb-spatial first, and found
the bug was mine.** #396 is closed as not-a-bug; nothing was filed upstream.

`ST_Length_Spheroid`, `ST_Distance_Spheroid` and `ST_Transform` all read the **first ordinate
as latitude** — the opposite of how our GeoParquets store it. Fed lon/lat they return `nan` /
`POINT (inf inf)` **rather than erroring**, so "the function is broken" and "your coordinates
are on the wrong axis" produce byte-identical evidence. I read the first and never tested the
second.

Upstream had already answered it twice:

- **duckdb-spatial#526** — closed by the reporter: *"duckdb-spatial expects coordinates to be
  passed as x=lat/y=lon to work with `*_Spheroid` functions."*
- **duckdb-spatial#211** — `ST_Transform` infinity, same convention.

Verified on prod (v0.8.19):

| call | result |
|---|---|
| `ST_Length_Spheroid('LINESTRING(-120 37, -120 38)')` | `nan` |
| `ST_Length_Spheroid(ST_FlipCoordinates(same))` | **110,987 m** — 1° latitude, correct |
| `ST_Transform(ST_Point(-120,37),'EPSG:4326','EPSG:5070')` | `POINT (inf inf)` |
| `ST_Transform(ST_FlipCoordinates(same), …)` | **`POINT (-2093434.36 1816511.55)`** |

`PROJ_DATA` — the other cause in #211 — is set locally but makes no difference.

### What this PR changes

The false sentence shipped in #395 and is live in v0.8.18/v0.8.19:

> ~~the usual repairs are unavailable here: `ST_Transform` returns `POINT (inf inf)` and every
> `*_Spheroid` function returns `nan`~~

It now teaches the flip and gives the working form:

```sql
SELECT ROUND(SUM(ST_Length_Spheroid(ST_FlipCoordinates(<line_geom>))) / 1609.344, 1) AS miles
FROM read_parquet('<line_geoparquet>');
```

The ratio recipe **stays the default**, but on its own merits — no CRS choice, no flip, reuses
the feature's own `length_miles` — rather than because the alternatives supposedly fail.

**The new snippet is registered `EXECUTABLE`, not exempted as a fragment.** Having got this
claim wrong once, it should be bound on every CI run rather than trusted: **13 executed, 21
fragments, 0 failures.** That is check 4 of the gate we just landed doing its job on its author.

### Nothing downstream moves — and one worry is cleared

| | |
|---|---|
| Siskiyou gold, exact geodesic | **1,177.4 mi** vs shipped **1,177.9** (0.04%) — third independent confirmation |
| trails `length_miles` accuracy | 1,438.2 geodesic vs 1,438.6 stated (**0.03%**) |

That second row retires a side worry I had recorded earlier: `length_miles` looked ~21% off the
geodesic length. That gap *was* the broken lon/lat spheroid call, not a data problem.

### The lesson

`nan` and `inf` are not error messages. Both functions returned a value for garbage input, so
the two hypotheses looked the same. **One sanity check against a known answer — 1° of latitude
is ~111 km — separates them in a single query,** and is a lot cheaper than an upstream issue.

`427 passed`; guidance gate green at 40,963 ch of the 42,500 ceiling.
