### PR TITLE
k8s(prod): promote v0.8.20 (axis-order correction)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.19@sha256:f38f2d8c1630aaeae7fc5aed40e575c7583b87ff247cfa874954efabcca79e65
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.20@sha256:a522c253c47f01403c2f59f3d9842fbadbcb01b009365247ae78ef00ebec8843
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL

--- a/k8s/dev-deployment.yaml
+++ b/k8s/dev-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         # dev's ≥2 replicas exist to catch. Bump this digest on redeploy (see
         # AGENTS.md → Rollout workflow). The tag prefix is for humans; the digest
         # is enforced. See issue #341.
-        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:16abf693eb28cd0652c4eac52e6751f45b7c9e29ea42af444c30ee4a2169b843
+        image: ghcr.io/boettiger-lab/mcp-data-server:main@sha256:dd626e6f0830ed0423016ab1356b3118a94205ede25ae2f725ae161bdc324ea6
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Two commits: the dev pin that was applied during the gate but never committed, then the prod
promotion.

Ships #404 — the correction to #395's false claim that `ST_Transform` and the `*_Spheroid`
family are broken on this server. **Prod has been serving that false statement since v0.8.18.**

### Gate

Regression tier on dev, NRP `deepseek-v4-flash`, 4 apps, 27 cells, 2 trials, against control
`2026-08-16-g394-dev-regression`. This change earns the gate twice over: it is a prompt
artifact, and it is itself a correction of a low-risk-looking text edit.

- **27/27 cells grade-identical.**
- **The specific new risk did not materialise.** Naming `*_Spheroid` in the guidance could have
  tempted models into calling it on lon/lat and taking a silent `nan` for an answer. Measured:
  **zero** `*_Spheroid` / `ST_Transform` calls in either condition. The flip rule protects a
  model that reaches for them; it doesn't push anyone toward them.

| cell | result | gold |
|---|---|---|
| `tplca-trail-miles-siskiyou` | **1,177.9 mi** (both trials) | 1,177.9 |
| `car-28-headwater-streams` | 27.5% (both) | 27.0 ±1.5 |
| `bosl-nearest-fishing-jarvis` | ~156 km | 154, accept 150–160 |
| `bosl-pri-eez-area` | 1,969,000 km² | 1,968,896 |

Always-on payload **50,420 → 50,907 ch** (+487); `tier=extra` sections stay excluded.

### Rollout

All 6 endpoint-backing pods on `sha256:a522c25…`; `/version` → `v0.8.20 @ 1e91b6c`, sampled
three times. Prod and dev now serve byte-identical descriptions, with the false claim gone and
the working `ST_Length_Spheroid(ST_FlipCoordinates(…))` form present.

### One operational finding worth keeping

**No `main` image build fired for #404's merge.** The last `main` build was `0801b330` (#403);
merging `1e91b6c` produced only the `v0.8.20` tag build — probably a dropped push webhook
during the GitHub API 503s at the time. Since dev tracks `:main`, rolling dev to it would have
deployed the *previous* build and I would have gated the wrong image. Caught by comparing
`head_sha` across `docker.yml` runs instead of trusting the tag, then fixed with a
`workflow_dispatch` on main.

**A merge does not guarantee an image — check the run, not the branch.**

Related: `/version` read `0801b330` once mid-rollout, a stale hit on a not-yet-replaced pod.
Sampling three times is cheap insurance and is what the runbook's "endpoints are
authoritative" note is really about.

Also visible again here: `v0.8.20`'s digest differs from the dev build of the same commit —
#366.
