### PR TITLE
k8s(prod): promote v0.8.21 (guidance-SQL coverage; q-opt §7 placeholder)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.20@sha256:a522c253c47f01403c2f59f3d9842fbadbcb01b009365247ae78ef00ebec8843
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.21@sha256:562b27b6181c57355d2a83a853ae2f0ca434e2e2ab03e2b83ddeee6888c90de3
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes **v0.8.21** (`16c9ff6`), shipping #402 via #408.

`k8s/deployment.yaml` only — per #406/#407 the dev manifest digest lags the cluster by
design and is not bumped here.

## What ships

The harness change is test-only. The single prompt-artifact change is one token in
`query-optimization.md` §7: `SUM(value)` → `SUM(<value>)`, because no dataset in the
catalog declares a column named `value`, so that block could never have bound as written.
Always-on payload 40,963 → **40,969 ch** (+6) against the 42,500 ceiling.

## Gate (AGENTS.md)

Dev ran `:main@sha256:cd700522` = `16c9ff6` on both endpoint-backing pods, serving a
40,969 ch `query` description containing `SUM(<value>)` — sampled four times across pods.
All 110 MCP references in the Job logs point at dev, none at production.

`regression` tier, NRP `deepseek-v4-flash`, 7 apps / 41 questions / **82 cells** × 2
trials — `results/2026-08-18-regression-think`:

- **The targeted risk did not materialise.** Zero occurrences of `<value>` or any
  placeholder in emitted SQL across all 7 logs; zero binder/parser errors naming one;
  zero transcript errors; zero timeouts.
- **`sum-amount-safe`** — the cell guarding the edited section — matched gold on every
  component, both cells × both trials: `tpl-boulder-funders` $321.2M / $6.3M / $4.9M /
  $3.1M; `tplca-cd16-funders` $36,108,100 with Prop40 $11.75M, Prop12 $7.608M, PropTax
  $6.15M, LWCF $5.638M.
- **Zero mechanically-graded failures** (13 auto-pass, 69 `needs-judge`, 0 fail). car-19
  **21.2** (gold 21.1), car-23 **22.5** (22.7), car-28 **27.5** (27.0), car-31
  **1.7/1.74** (1.74).

## One cell scored 1/2, and it is not this change

`car-23` trial 1 asked which dataset was meant rather than answering. **Pre-existing model
variance** — the same model did the same thing on 2026-08-11 and 2026-08-16, and the
ambiguity it raises (two catalog layers both documenting "channelized connectivity") has
nothing to do with the no-data section edited here. Filed as
boettiger-lab/geo-agent-benchmark#51 with evidence that both readings give 22.35%, so the
cell should stay `mode: answer` rather than become a `clarify-` cell.

## #366 caveat, stated rather than assumed

Release **rebuilds** instead of retagging, so `:v0.8.21` is `sha256:562b27b6` while the
digest dev actually gated is `sha256:cd700522` — different bytes from the same commit
`16c9ff6`. That is #366's open sliver. Byte-identity of the served `query` description is
therefore **verified after rollout**, not inferred from the shared commit.

Rollout and verification (`kubectl apply` + `rollout restart`, then digest convergence
across all 6 endpoint-backing pods, `/version` sampled repeatedly, and a prod-vs-dev
description diff) recorded in a comment below.