### PR TITLE
fix(#410): render DOUBLE at full magnitude, and a NULL double as blank not `nan`

### DIFF
--- a/server.py
+++ b/server.py
@@ -445,9 +445,30 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
             # missing cell (the IUCN size-stratified assets have NULL finer
             # h-columns, so this is live). It also stops a NULL date printing as
             # the literal `nan`, which reads as a value.
+            # Floats need the same treatment for the same reason, but the fix is NOT
+            # the same (#410). tabulate's default `floatfmt` is `g` — six significant
+            # figures — so a 26-million-acre total printed `2.64715e+07` and a dollar
+            # sum `3.212e+08`. `ROUND()` does not help: this is the display layer, so
+            # the obvious model-side workaround fails. Two traps here:
+            #   * A VARCHAR cast alone is NOT enough. Unlike a wide int, a float string
+            #     is re-parsed by tabulate and re-formatted straight back to
+            #     `1.95736e+07`, so the cast must be paired with `disable_numparse` for
+            #     exactly those columns. (Whole-table `disable_numparse` would undo the
+            #     wide-int alignment above; a `colalign` tuple with `None` holes drops
+            #     the padding entirely.)
+            #   * `%.10g` rather than a plain cast, because a raw DOUBLE cast exposes
+            #     representation noise — `1.74` becomes `1.7400000000000002`, and 1.74
+            #     is a live gold value. DECIMAL casts exactly instead, since it is
+            #     exact in DuckDB and only becomes lossy at the pandas boundary.
+            # The cost is that these columns render left-aligned. Accepted: this table
+            # is consumed by a model, so precision matters and alignment does not.
+            # It also restores the NULL-vs-NaN distinction — both printed `nan` before,
+            # while `query-optimization.md` §7 tells models to filter the NaN sentinel.
+            # A NULL is now blank and a real NaN still says `nan`.
             WIDE_INTS = ("BIGINT", "UBIGINT", "HUGEINT", "UHUGEINT")  # > 2^53
             rendered = []
-            for c, t in zip(result.columns, result.dtypes):
+            no_numparse = []  # column indices tabulate must not re-parse (#410)
+            for i, (c, t) in enumerate(zip(result.columns, result.dtypes)):
                 tu, q = str(t).upper(), f'"{c}"'
                 if tu == "DATE":
                     expr = f"strftime({q}, '%Y-%m-%d')"
@@ -455,6 +476,12 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
                     expr = f"strftime({q}, '%Y-%m-%d %H:%M:%S')"
                 elif tu in WIDE_INTS:
                     expr = f"CAST({q} AS VARCHAR)"
+                elif tu in ("DOUBLE", "FLOAT"):
+                    expr = f"printf('%.10g', {q})"
+                    no_numparse.append(i)
+                elif tu.startswith("DECIMAL"):
+                    expr = f"CAST({q} AS VARCHAR)"
+                    no_numparse.append(i)
                 else:
                     rendered.append(None)
                     continue
@@ -467,7 +494,7 @@ def query(sql_query: str, s3_key: str = None, s3_secret: str = None, s3_endpoint
             df = result.limit(51).df()
             if df.empty: return "No results found."
             truncated = len(df) > 50
-            md = df.head(50).to_markdown(index=False)
+            md = df.head(50).to_markdown(index=False, disable_numparse=no_numparse)
             if truncated:
                 md += (
                     "\n\n⚠️ Showing the first 50 rows only — this is a preview, not the"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -325,6 +325,67 @@ class TestQueryFunction:
         assert "-577762574070710271" in result
         assert "18446744073709551614" in result
 
+    def test_query_double_renders_full_magnitude(self):
+        """A DOUBLE must not be cut to six significant figures (#410).
+
+        tabulate's default floatfmt is `g`, so a 26-million-acre total rendered
+        `2.64715e+07` and a dollar sum `3.212e+08`. Acreages, areas and dollar
+        totals are almost all DOUBLE, so this hit most answers this server gives.
+        """
+        result = query("SELECT 19573561.06::DOUBLE AS acres, 321200000.0::DOUBLE AS dollars")
+        assert "19573561.06" in result and "321200000" in result
+        assert "1.95736e+07" not in result and "3.212e+08" not in result
+        assert "e+0" not in result
+
+    def test_query_round_does_not_mask_the_display_layer(self):
+        """ROUND() was not a workaround — the loss was in rendering, not the value
+        (#410). Worth pinning: it is the fix a model would reach for."""
+        result = query("SELECT ROUND(19573561.06::DOUBLE, 2) AS rounded")
+        assert "19573561.06" in result and "1.95736e+07" not in result
+
+    def test_query_null_double_is_blank_and_real_nan_is_not(self):
+        """A NULL double renders blank; a genuine NaN still says `nan` (#410).
+
+        Both printed `nan` before, which is the one distinction that must survive
+        here: `query-optimization.md` §7 tells models to filter the NaN sentinel
+        before aggregating, and they cannot filter what they cannot see.
+        """
+        result = query(
+            "SELECT v FROM (VALUES (1.5::DOUBLE), (NULL::DOUBLE), ('NaN'::DOUBLE)) t(v)"
+        )
+        lines = [l for l in result.splitlines() if l.startswith("|") and "---" not in l]
+        assert sum("nan" in l for l in lines) == 1, result
+        assert any(l.strip("| ").strip() == "" for l in lines[1:]), result
+
+    def test_query_double_does_not_expose_float_noise(self):
+        """`%.10g`, not a raw cast: a plain VARCHAR cast renders 1.74 as
+        `1.7400000000000002` (#410). 1.74 is a live gold value (car-31)."""
+        result = query("SELECT (1.74::DOUBLE + 0.0)::DOUBLE AS pct, (1.0/3.0)::DOUBLE AS third")
+        assert "1.7400000000000002" not in result
+        assert "1.74" in result and "0.3333333333" in result
+
+    def test_query_small_floats_survive(self):
+        """A fixed-decimal format would flatten small values to 0.00 — they must
+        keep their magnitude (#410)."""
+        result = query("SELECT 1e-7::DOUBLE AS tiny")
+        assert "1e-07" in result and "0.00" not in result
+
+    def test_query_decimal_renders_exactly(self):
+        """DECIMAL is exact in DuckDB and only lossy at the pandas boundary, so it
+        casts rather than going through %.10g (#410)."""
+        result = query("SELECT 123456789.1234567890::DECIMAL(38,10) AS d")
+        assert "123456789.123456789" in result
+        assert "1.23457e+08" not in result
+
+    def test_query_wide_int_still_exact_beside_a_double(self):
+        """#410 disables tabulate number-parsing per column. The wide-int columns
+        must NOT be included, or #387 regresses."""
+        result = query(
+            "SELECT 613762179077668863::UBIGINT AS h8, 19573561.06::DOUBLE AS acres"
+        )
+        assert "613762179077668863" in result and "e+17" not in result
+        assert "19573561.06" in result
+
 
 class TestResourceFunctions:
     """Test MCP resource functions."""


### PR DESCRIPTION
Fixes #410.

## Before / after

```
-- SELECT 19573561.06::DOUBLE AS acres, 321200000.0::DOUBLE AS dollars, 19573561::BIGINT AS n

before:  |       acres |   dollars |         n |
         | 1.95736e+07 | 3.212e+08 |  19573561 |

after:   | acres       | dollars   |         n |
         | 19573561.06 | 321200000 |  19573561 |
```

Acreages, areas and dollar totals are almost all `DOUBLE`, so six significant figures hit
most answers this server gives. `ROUND()` was not a workaround — the loss is in the display
layer, which is why the fix a model would reach for did nothing.

**Second defect, same site:** a NULL double printed the literal `nan`, so NULL and a genuine
NaN were indistinguishable. That matters more than it looks: `query-optimization.md` §7 tells
models to filter the NaN sentinel before aggregating, and they cannot filter what they cannot
see. A NULL is now blank; a real NaN still says `nan`.

## The fix is not the one I first proposed, and the difference is the point

I originally recommended the #387 VARCHAR-cast treatment. **It does not work** — corrected on
the issue with measurements. Unlike a wide int, a float string is re-parsed by tabulate and
re-formatted straight back to `1.95736e+07`; wide ints only survive because they re-parse to an
exact `int`. So the cast must be paired with `disable_numparse` for exactly those column
indices. Rejected alternatives, all measured under the pinned `pandas==3.0.5`:

- **whole-table `disable_numparse=True`** — undoes #387's wide-int alignment.
- **`colalign` with `None` holes** — drops the padding entirely.
- **`to_markdown(floatfmt=".10g")`** — right-aligned and correct on precision, but leaves the
  NULL→`nan` half unfixed, and `missingval` cannot help because pandas collapses `None` and
  `float('nan')` in a float64 column.
- **plain `CAST(col AS VARCHAR)`** — exposes representation noise: `1.74` becomes
  `1.7400000000000002`, and 1.74 is a live gold value (car-31). Hence `%.10g`.

`DECIMAL` casts exactly instead of going through `%.10g`, since it is exact in DuckDB and only
becomes lossy at the pandas boundary.

**Cost:** these columns render left-aligned. Accepted — this table is consumed by a model, so
precision matters and alignment does not. Called out in the code comment so it reads as a
decision rather than an oversight.

## Tests

7 new, **6 of which fail without the change** (verified by stashing the fix). The seventh
(`test_query_small_floats_survive`) passes today and pins against a `,.2f`-style fix, which
would flatten `1e-7` to `0.00`. One test specifically guards #387 from regressing, since this
change turns off number-parsing per column and including a wide-int column would break it.

Full suite: **434 passed**.

## ⚠️ The guidance-SQL job will be red, and it is not this PR

`h3-guide.md:da766d501c` fails on `s3://public-wetlands/nwi-v2/hex/…` returning 404. The NWI
layer is being rebuilt right now by the maintainers; the fixture path is deliberately left
alone. Reproduces on `main` without this branch.

## Validation

Not a prompt artifact, but it changes text models read and quote back — the same class as #387
and #361, both of which were gated on dev. Needs a `regression` run before prod, watching cells
whose gold is a formatted number.