### PR TITLE
k8s(prod): promote v0.8.22 (DOUBLE rendering)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.21@sha256:562b27b6181c57355d2a83a853ae2f0ca434e2e2ab03e2b83ddeee6888c90de3
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.22@sha256:10052de08be75ca09fe2b0f10970eea1b5c1058713cf3f13d9d6ec4d473f5cd4
         imagePullPolicy: IfNotPresent
         env:
         - name: STAC_CATALOG_URL


### PR DESCRIPTION
Promotes **v0.8.22** (`c7120a3`), shipping #410 via #411. `k8s/deployment.yaml` only.

## What ships

`query` rendered `DOUBLE` columns at six significant figures — a 26-million-acre total arrived
as `2.64715e+07`, a dollar sum as `3.212e+08`. Plus a NULL double printing the literal `nan`,
which made NULL and a genuine NaN indistinguishable — the distinction q-opt §7 asks models to
act on.

No guidance text changed, so the `query` description must stay byte-identical at 40,969 ch.

## Gate

Dev @ `main@c7120a3` (`:main` `sha256:48e57d0e`, both endpoint pods converged, fix confirmed
live). `regression` tier, NRP `deepseek-v4-flash`, 7 apps / **82 cells** × 2 trials, against
this morning's `reg-402` control on the same tier, model and endpoint. All **140** MCP
references in the job logs point at dev, none at production.

**The change is visible in a model's own answer**, which is the whole argument for it:

| cell | before | after |
|---|---|---|
| `ca-gap12-acres` | "26,471,**500** acres" — the 6-sig-fig artifact | "**26,471,459** acres" — the layer's true sum |

**No baseline regression:** car-19 21.2/21.2 and car-28 27.5/27.5 unchanged; car-23 improved
to 22.5/22.5 (both trials answered rather than one clarifying — the variance tracked in
geo-agent-benchmark#51). **Zero** answers contain `e+NN` notation in either run, so the longer
numbers introduced no new failure mode.

## Two timeouts that the control did not have — and they are not this change

`car-31-ace-wetland-presence` and `wet-top10-hydrobasins-composite`. Both wetlands cells, both
the in-progress NWI rebuild: car-31's transcript shows `HTTP GET error reading
's3://public-wetlands/nwi-v2/hex/…'`, with 22 tool calls spent retrying `h0=*`, `**/*.parquet`
and `h0=0` before giving up.

Stated plainly: those two cells are **unevaluable on any build right now**, so "the gate
passed" means it passed on everything it could measure. Prod already serves the same wetlands
gap — promoting neither causes nor worsens it.

## #366 caveat

Release rebuilds rather than retags, so `:v0.8.22` is `sha256:10052de0` while dev gated
`sha256:48e57d0e` — same commit `c7120a3`, different bytes. Byte-identity of the served
description is **verified after rollout**, not inferred. Rollout record to follow in a comment.