### PR TITLE
fix(#413): retag releases instead of rebuilding them

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,13 @@
 name: Build Docker image
 
+# Build once, on main. A release does NOT build (#413): it adds a `:vX.Y.Z` tag to the
+# manifest that `main` already produced and dev already gated, so prod runs the exact
+# bytes that were validated instead of a same-commit rebuild that differs. Release
+# identity moved to the Deployment's APP_VERSION env, which is what made this possible —
+# it used to be a build arg, and that alone forced a rebuild per release.
 on:
   push:
     branches: [main]
-    tags: ['v*']
   schedule:
     - cron: '0 6 * * 1'  # Mondays 06:00 UTC — refresh base image + unpinned deps
   workflow_dispatch:
@@ -45,13 +49,10 @@ jobs:
           repo=ghcr.io/boettiger-lab/mcp-data-server
           case "${{ github.event_name }}" in
             push)
-              if [ "${{ github.ref_type }}" = "tag" ]; then
-                # Release tag (vX.Y.Z): immutable version tag + immutable sha.
-                tags="$repo:${{ github.ref_name }}"$'\n'"$repo:${{ github.sha }}"
-              else
-                # Push to main: moving dev tag + immutable sha.
-                tags="$repo:main"$'\n'"$repo:${{ github.sha }}"
-              fi
+              # Push to main: moving dev tag + immutable sha. Tags no longer trigger
+              # this workflow (#413), so there is no release-build branch here — a
+              # release retags one of these digests.
+              tags="$repo:main"$'\n'"$repo:${{ github.sha }}"
               ;;
             *)
               # schedule / workflow_dispatch: dep+base refresh. Move ONLY the dev
@@ -66,12 +67,12 @@ jobs:
               fi
               ;;
           esac
-          # Version stamp baked into the image: the tag on release builds, else "main".
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            app_version="${{ github.ref_name }}"
-          else
-            app_version="main"
-          fi
+          # The image's own stamp is always "main" now: it is built from main and
+          # released by retag, so it cannot know its release name. `k8s/deployment.yaml`
+          # supplies the real one via APP_VERSION env, and CI checks the two agree
+          # (tests/check_k8s_image_pins.py). GIT_SHA below stays accurate through a
+          # retag — it is the commit this image was built from.
+          app_version="main"
           {
             echo "tags<<EOF"
             echo "$tags"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Publish GitHub Release
 # When a vX.Y.Z tag is pushed, publish a matching GitHub Release with
 # auto-generated notes (the merged-PR list since the previous tag) so the
 # Releases page reflects what's actually shipped. See issue #221.
-# docker.yml builds the image for the same tag in parallel; this only creates
-# the Release entry.
+# This only creates the Release entry. It does NOT build an image: since #413 a
+# release names the digest dev already gated (retag-release.yml) rather than
+# rebuilding the commit, so docker.yml no longer runs on tags.
 on:
   push:
     tags: ['v*']

--- a/.github/workflows/retag-release.yml
+++ b/.github/workflows/retag-release.yml
@@ -1,0 +1,79 @@
+name: Release (retag, no rebuild)
+
+# Names an existing manifest as a release (#413). This deliberately does NOT build:
+# a release ships the exact bytes dev gated, and a rebuild of the same commit is not
+# the same bytes (on v0.8.16, 6 of 10 layers differed, and an unpinned pandas could
+# have silently reverted the fix that release was shipping).
+#
+# You supply the digest explicitly rather than letting this resolve `:main` itself.
+# That is the point: `:main` moves on every merge, so "whatever main is now" is not
+# the same claim as "the artifact dev validated". Read it off the running dev pod:
+#
+#   kubectl -n biodiversity get pods -l app=dev-duckdb-mcp \
+#     -o jsonpath='{.items[0].status.containerStatuses[0].imageID}'
+#
+# Then set the SAME digest and version in k8s/deployment.yaml (image: + APP_VERSION
+# env); tests/check_k8s_image_pins.py fails the build if those two disagree.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. v0.8.23'
+        required: true
+      digest:
+        description: 'Digest to name (sha256:...) — the one dev gated'
+        required: true
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Validate inputs
+        run: |
+          echo "${{ inputs.version }}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "::error::version must look like v1.2.3"; exit 1; }
+          echo "${{ inputs.digest }}" | grep -Eq '^sha256:[0-9a-f]{64}$' \
+            || { echo "::error::digest must be sha256:<64 hex>"; exit 1; }
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Refuse to re-point an existing release tag
+        run: |
+          repo=ghcr.io/boettiger-lab/mcp-data-server
+          if docker buildx imagetools inspect "$repo:${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::$repo:${{ inputs.version }} already exists — release tags are immutable"
+            exit 1
+          fi
+
+      - name: Retag
+        run: |
+          repo=ghcr.io/boettiger-lab/mcp-data-server
+          docker buildx imagetools create -t "$repo:${{ inputs.version }}" "$repo@${{ inputs.digest }}"
+
+      - name: Verify the tag resolves to the requested digest
+        run: |
+          repo=ghcr.io/boettiger-lab/mcp-data-server
+          got=$(docker buildx imagetools inspect "$repo:${{ inputs.version }}" --format '{{.Manifest.Digest}}')
+          echo "requested: ${{ inputs.digest }}"
+          echo "resolved:  $got"
+          [ "$got" = "${{ inputs.digest }}" ] \
+            || { echo "::error::tag resolved to a different digest"; exit 1; }
+          {
+            echo "### Released \`${{ inputs.version }}\`"
+            echo ""
+            echo "Named existing digest \`${{ inputs.digest }}\` — no rebuild."
+            echo ""
+            echo "Next: set both \`image:\` and the \`APP_VERSION\` env to this version"
+            echo "in \`k8s/deployment.yaml\`, then apply and restart."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,19 +136,50 @@ know what dev serves. (`k8s-image-pin.yml` checks the pin *is* a digest, not tha
 current.) Prod is the opposite: its digest is committed in `k8s/deployment.yaml` and is
 authoritative, because prod is promoted deliberately per release.
 
-**Tag a release → redeploy prod (promote by digest):**
-1. `git tag vX.Y.Z && git push origin vX.Y.Z`, then wait for `docker.yml` to build `:vX.Y.Z`.
-2. Read the digest from the build run's job summary, or:
-   `docker buildx imagetools inspect ghcr.io/boettiger-lab/mcp-data-server:vX.Y.Z --format '{{.Manifest.Digest}}'`
-3. Set `image: ghcr.io/boettiger-lab/mcp-data-server:vX.Y.Z@sha256:<digest>` in
-   `k8s/deployment.yaml` (separate commit).
+**Release → promote prod. Retag, never rebuild (#413).**
+
+A release ships the artifact dev gated, not a fresh build of the same commit. `docker.yml`
+does not run on tags; a release only adds a name to a manifest that already exists.
+
+1. Take the digest dev validated — the `:main` digest at the gated commit:
+   ```bash
+   kubectl -n biodiversity get pods -l app=dev-duckdb-mcp \
+     -o jsonpath='{.items[0].status.containerStatuses[0].imageID}'
+   ```
+2. Name that manifest as the release (no build). Use the workflow, not a local
+   `docker` — this box has no docker CLI, and CI already holds the registry credential:
+   ```bash
+   gh workflow run retag-release.yml -f version=vX.Y.Z -f digest=sha256:<digest>
+   ```
+   It refuses to re-point an existing release tag, and verifies the tag resolves to the
+   digest you asked for. `git tag vX.Y.Z` for the source record too — it just no longer
+   triggers a build.
+3. In `k8s/deployment.yaml`, set **both** (one commit):
+   - `image: …:vX.Y.Z@sha256:<the same digest>`
+   - the `APP_VERSION` env to `vX.Y.Z`
 4. `kubectl apply -f k8s/deployment.yaml`
 5. `kubectl rollout restart deployment/duckdb-mcp -n biodiversity`
 
+**Why APP_VERSION lives in the manifest.** It used to be a build arg, so stamping a release
+name meant rebuilding — and a rebuild of the same commit is not the same bytes (on v0.8.16,
+6 of 10 layers differed, and an unpinned pandas could have silently reverted the fix that
+release was shipping). `server.py` reads the stamp from the environment, so the Deployment
+overrides the image's own `"main"`. The image stays identity-free and immutable; the release
+name is deploy-time metadata. `GIT_SHA` is *not* overridden — it is the commit the image was
+built from and survives a retag intact.
+
+The two now have to agree, so `tests/check_k8s_image_pins.py` fails the build if the
+`:vX.Y.Z` in `image:` and the `APP_VERSION` env differ, or if a release-pinned Deployment
+omits the env entirely (`/version` would then report `main` in production).
+
 prod pins an immutable `:vX.Y.Z@sha256:…` (tag for humans, digest enforced — if they ever
-disagree, the digest wins). **Never apply prod while the manifest points at an image CI
-hasn't built yet** — the rollout stalls on `ImagePullBackOff`. `kubectl apply` must precede
-`rollout restart`; a git push alone does not update the cluster.
+disagree, the digest wins). **Never apply prod while the manifest points at an image that
+does not exist in the registry** — the rollout stalls on `ImagePullBackOff`. `kubectl apply`
+must precede `rollout restart`; a git push alone does not update the cluster.
+
+**What this buys.** Prod's digest now *equals* dev's, so "prod runs what was validated" is
+structural. The served-artifact diff (comparing prod's `query` description against dev's)
+drops from a required safety net to a spot check.
 
 **No `docker` CLI (e.g. a JupyterLab session)?** `imagetools inspect` needs it, and the
 GHCR packages API needs a `read:packages` token most of our `gh` logins don't carry. An

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,6 +26,15 @@ spec:
         image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.22@sha256:10052de08be75ca09fe2b0f10970eea1b5c1058713cf3f13d9d6ec4d473f5cd4
         imagePullPolicy: IfNotPresent
         env:
+        # Release identity is supplied HERE, not baked into the image (#413). The
+        # image is built once from `main` and a release only adds a tag to that
+        # existing manifest — so its own ENV still says "main", and this overrides
+        # it. Keep this in step with the `:vX.Y.Z` in `image:` above; CI enforces
+        # that they match (tests/check_k8s_image_pins.py). GIT_SHA is NOT overridden:
+        # the image's own value is the commit it was built from, which stays correct
+        # through a retag.
+        - name: APP_VERSION
+          value: "v0.8.22"
         - name: STAC_CATALOG_URL
           value: "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
         - name: MCP_PUBLIC_BASE_URL

--- a/tests/check_k8s_image_pins.py
+++ b/tests/check_k8s_image_pins.py
@@ -12,6 +12,18 @@ throwaway test endpoint where cross-pod skew cannot arise) opts out with a
 `# ci-image-pin: allow-mutable — <reason>` comment on the image line or the line
 directly above it. The exception is then greppable and justified in-tree.
 
+Second check (#413): a Deployment pinned to a `:vX.Y.Z` tag must also set an
+`APP_VERSION` env var equal to that tag. Release identity is now supplied at deploy
+time rather than baked into the image — a release adds a tag to the *existing* `main`
+manifest instead of rebuilding, so the image's own `ENV APP_VERSION` still reads
+"main" and the Deployment must override it. Two places now have to agree, so this
+checks they do; otherwise `/version` would quietly report the wrong release and the
+audit trail this whole scheme exists for would be worthless. Files pinned to a moving
+tag (`:main`, dev) are exempt — they have no release identity to state.
+
+Assumes one Deployment of this repo's image per k8s/*.yaml file, which holds today
+and keeps this check dependency-free.
+
 Runs in CI on any k8s/*.yaml change, and locally: `python tests/check_k8s_image_pins.py`.
 """
 import glob
@@ -22,14 +34,36 @@ import sys
 REPO_IMAGE = "ghcr.io/boettiger-lab/mcp-data-server"
 IMAGE_LINE = re.compile(r"^\s*image:\s*(\S+)")
 ALLOW_MUTABLE = "ci-image-pin: allow-mutable"
+VERSION_TAG = re.compile(r":(v\d+\.\d+\.\d+)@sha256:")
+APP_VERSION_ENV = re.compile(
+    r"^\s*-\s*name:\s*APP_VERSION\s*$\n\s*value:\s*[\"']?(\S+?)[\"']?\s*$", re.M
+)
 
 
 def main():
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     violations = []
     checked = allowed = 0
+    stamped = 0
     for path in sorted(glob.glob(os.path.join(root, "k8s", "*.yaml"))):
-        lines = open(path).read().splitlines()
+        text = open(path).read()
+        lines = text.splitlines()
+        rel = os.path.relpath(path, root)
+        # #413: a release-pinned Deployment must state the same version in APP_VERSION.
+        for tag in set(VERSION_TAG.findall(text)):
+            env = APP_VERSION_ENV.search(text)
+            if env is None:
+                violations.append(
+                    f"{rel}: pinned to {tag} but sets no APP_VERSION env — /version would "
+                    f"report the image's own stamp ('main' after a retag), not the release"
+                )
+            elif env.group(1) != tag:
+                violations.append(
+                    f"{rel}: image tag {tag} != APP_VERSION {env.group(1)} — /version would "
+                    f"misreport the running release"
+                )
+            else:
+                stamped += 1
         for i, line in enumerate(lines):
             m = IMAGE_LINE.match(line)
             if not m:
@@ -50,17 +84,17 @@ def main():
             if any(ALLOW_MUTABLE in w for w in window):
                 allowed += 1
                 continue
-            rel = os.path.relpath(path, root)
             violations.append(f"{rel}:{i + 1}: not digest-pinned -> {ref}")
 
     if violations:
-        print("k8s image-pin check FAILED — pin these by @sha256: (see AGENTS.md rollout, #366):")
+        print("k8s image-pin check FAILED (see AGENTS.md rollout; #366 digest pinning, #413 release stamp):")
         for v in violations:
             print(f"  ✗ {v}")
         return 1
     print(
         f"k8s image-pin check OK — {checked} repo image reference(s): "
-        f"{checked - allowed} digest-pinned, {allowed} explicit allow-mutable"
+        f"{checked - allowed} digest-pinned, {allowed} explicit allow-mutable; "
+        f"{stamped} release pin(s) with a matching APP_VERSION"
     )
     return 0
 


### PR DESCRIPTION
Fixes #413.

## The problem

Prod has never provably run the bytes dev gated. A release tag triggered a **second build of
an already-validated commit**, and a rebuild is not bit-identical:

| release | dev gated | prod got |
|---|---|---|
| v0.8.21 | `cd700522…` | `562b27b6…` |
| v0.8.22 | `48e57d0e…` | `10052de0…` |

#366 measured it harder on v0.8.16: **6 of 10 layers differed**. Both promotions this week
were only safe because I diffed the served tool description against dev by hand — that manual
check was the compensating control, and it does not scale. It catches guidance drift; it would
not catch a different DuckDB patch release.

## The cause was one line of build config

`APP_VERSION` was a **build arg** baked into the image, so stamping a release name *required*
building a new image. #366's closing comment read decoupling it as a significant prerequisite.
It isn't: **`server.py:36` already reads the stamp from `os.environ`**, and a Kubernetes `env:`
overrides an image `ENV`. Release identity becomes deploy-time metadata; the image stays
identity-free and immutable.

## Changes

| file | change |
|---|---|
| `k8s/deployment.yaml` | `APP_VERSION` env beside the digest pin — both move in one commit |
| `docker.yml` | no longer builds on `v*`; the image always stamps itself `main` |
| `retag-release.yml` | **new** — `workflow_dispatch` retag: names an existing digest, refuses to re-point an existing release tag, verifies what it produced |
| `check_k8s_image_pins.py` | fails if `:vX.Y.Z` and `APP_VERSION` disagree, or a release pin omits the env |
| `AGENTS.md` | release runbook rewritten around retag-not-rebuild |

`GIT_SHA` is deliberately **not** overridden — it is the commit the image was built from and
stays correct through a retag.

## The new footgun, and its guard

Two places now have to agree. So the pin checker enforces it, and I verified it catches both
shapes rather than assuming:

```
image tag v0.8.22 != APP_VERSION v0.8.21 — /version would misreport the running release
pinned to v0.8.22 but sets no APP_VERSION env — /version would report the image's own
  stamp ('main' after a retag), not the release
```

Good state passes: *"4 repo image reference(s): 3 digest-pinned, 1 explicit allow-mutable;
1 release pin(s) with a matching APP_VERSION"*.

## Why the retag is a workflow, not a documented command

There is no `docker` CLI on the box this repo is operated from, so a `docker buildx imagetools
create` line in AGENTS.md would be a step nobody here can run — which is how runbooks rot. The
workflow also holds the registry credential already.

## Correction worth flagging

My first commit **overwrote** `.github/workflows/release.yml`, the GitHub Release publisher
from #221, instead of adding a new file. Restored, and my workflow moved to
`retag-release.yml`. Its stale comment (*"docker.yml builds the image for the same tag in
parallel"*) is updated, since that is exactly what this PR ends.

## Blast radius

**Inert until the next release.** The manifest states `v0.8.22`, which is what prod already
runs, so applying it changes nothing observable. The mechanism gets exercised on the next
promotion — where the image will say `main` and `/version` must still report the release. That
is the check to watch, and I'd rather it be watched than assumed.

Full suite: 434 passed.