### PR TITLE
chore: ship .mcp.json so Claude Code gets duckdb-geo like the other editors

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "duckdb-geo": {
+      "type": "http",
+      "url": "https://duckdb-mcp.nrp-nautilus.io/mcp"
+    }
+  }
+}


### PR DESCRIPTION
The repo already configures `duckdb-geo` for **VS Code** (`.vscode/mcp.json`) and **Roo**
(`.roo/mcp.json`), both at `https://duckdb-mcp.nrp-nautilus.io/mcp`. Claude Code reads
`.mcp.json` at the repo root, which did not exist — confirmed by `~/.claude.json` showing
`mcpServers: []` for this project.

So a Claude Code session here has **no `duckdb-geo` tool** and falls back to hand-rolled
JSON-RPC over HTTP or a local in-process DuckDB.

## Why that fallback is not harmless

I hit it today. Working on this repo means answering questions about what the *deployed
server* returns, and a local DuckDB is a different thing — it does not exercise the tool
description, the result rendering (#361/#387/#410), the per-connection preamble (#378), or
the pod memory limit (#270).

Concretely: I computed a replacement gold value for a benchmark cell in a local DuckDB. It
was right — verified afterwards through the server, same 2.74 — but I only checked *because
it was questioned*. An agent can compute a number that is correct and still not reproducible
through the product, and for a gold value or a guidance example that is the only form that
matters.

Same endpoint and same shape as the two existing configs, so this adds no new trust decision
beyond the one this repo already makes. Takes effect on session restart / server approval.