### PR TITLE
fix(#330): say the tiles are not on the map yet, and name the handoff

### DIFF
--- a/server.py
+++ b/server.py
@@ -582,6 +582,7 @@ from tiles.pyramid import (
     build_hex_tiles,
     cached_result_dict,
     render_recipe,
+    _DISPLAY_HANDOFF_NOTE,
     _rollup_note,
     lock_is_stale,
     read_existing_metadata,
@@ -789,13 +790,14 @@ def register_hex_tiles(
       the extrusions; the returned `layer` is a `fill-extrusion` layer.
 
     Returns a dict with `status` ∈ {"done", "running", "failed"}:
-    - status="done" (cache hit or fast build): includes the render recipe —
-      `source` (pass to map.addSource) and `layer` (pass to map.addLayer),
-      both ready to use as-is with a default viridis color ramp. Also
-      `value_columns` and `value_stats` ({<col>: {"by_res": {"<res>":
-      {"min","max","mean"}}, "suggested_scale": "linear"|"log"}}) if you want
-      to customize the palette or honor the log-scale hint, plus `hash`,
-      `bounds`, `feature_count_finest`.
+    - status="done" (cache hit or fast build): the tiles exist. They are NOT
+      on the map yet — display them by calling your client's map-display tool
+      (`add_hex_tile_layer` in the geo-agent apps) with `tile_url` copied
+      verbatim from `tile_url_template`, plus a `value_column`. `next_step` in
+      the response says the same thing. Also `value_columns` and `value_stats`
+      ({<col>: {"by_res": {"<res>": {"min","max","mean"}}, "suggested_scale":
+      "linear"|"log"}}) if you want to customize the palette or honor the
+      log-scale hint, plus `hash`, `bounds`, `feature_count_finest`.
     - status="running": being built in the background. You get `hash` and
       `tile_url_template`. Call `get_hex_tile_status(hash, wait_seconds=30)`
       to poll — it long-polls server-side, so one call returns either the
@@ -805,7 +807,8 @@ def register_hex_tiles(
     - status="failed": build raised an error inline. `error` has the message.
       Safe to re-submit with adjusted parameters.
 
-    MapLibre usage (identical regardless of format — render what you got):
+    If your client has no map-display tool and you are driving MapLibre
+    directly, `source` and `layer` are paste-ready with a viridis ramp:
         map.addSource(id, result.source);
         map.addLayer({id: ..., source: id, ...result.layer});
 
@@ -988,6 +991,11 @@ def _done_response(base: dict, meta: dict) -> dict:
     note = _rollup_note(meta.get("agg", ""))
     if note:
         result["rollup_note"] = note
+    # The async-poll path reaches "done" here rather than through pyramid.py's
+    # builders, and it is the common one for big builds — the note has to be on
+    # every done response or the handoff advice is missing exactly when the
+    # build took long enough for the model to lose the thread (#330).
+    result["next_step"] = _DISPLAY_HANDOFF_NOTE
     return result
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1302,6 +1302,57 @@ class TestGetHexTileStatus:
         assert status["status"] == "done"
         assert "rollup_note" in status and "lower bound" in status["rollup_note"]
 
+    def test_done_response_names_the_display_handoff(self, isolated_jobs, monkeypatch):
+        """Every done response must say the tiles are not yet on the map (#330).
+
+        The failure this guards: on a `status:"done"` register the model reads
+        the paste-ready recipe, concludes the map is updated, narrates success
+        and never calls the client's display tool — ~50% of hex requests on
+        qwen against the real apps. Nothing else in the payload contradicts
+        that reading, and this text is what it sees at the deciding moment.
+        """
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        sub = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        assert sub["status"] == "done"
+        for field in ("next_step",):
+            assert field in sub, sub.keys()
+        assert "NOT on the map" in sub["next_step"]
+        assert "add_hex_tile_layer" in sub["next_step"]
+        assert "tile_url_template" in sub["next_step"]
+
+    def test_poll_path_also_names_the_display_handoff(self, isolated_jobs, monkeypatch):
+        """The async-poll done response reaches "done" through a different
+        builder, and it is the common path for big builds — #331 is the
+        precedent for a note landing on one path and not the other."""
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        sub = server.register_hex_tiles(
+            sql="SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 1.0 AS val",
+            agg="AVG",
+        )
+        status = server.get_hex_tile_status(hash=sub["hash"])
+        assert status["status"] == "done"
+        assert "next_step" in status
+        assert "add_hex_tile_layer" in status["next_step"]
+
+    def test_cache_hit_names_the_display_handoff(self, isolated_jobs, monkeypatch):
+        """The cache-hit path is the one #330 actually observed failing, and it
+        is the one no benchmark cell exercises — every register in the matrix
+        runs so far returned "running"."""
+        import server
+        monkeypatch.setattr(server, "_BUILD_INLINE_WAIT_SECONDS", 30.0)
+        sql = "SELECT h3_latlng_to_cell(37.8, -122.3, 5) AS h5, 2.0 AS val"
+        first = server.register_hex_tiles(sql=sql, agg="AVG")
+        assert first["status"] == "done"
+        second = server.register_hex_tiles(sql=sql, agg="AVG")
+        assert second.get("cache_hit") is True, second.keys()
+        assert "next_step" in second
+        assert "add_hex_tile_layer" in second["next_step"]
+
     def test_non_count_distinct_status_has_no_rollup_note(self, isolated_jobs, monkeypatch):
         # Exact aggs (AVG here) must NOT carry the caveat — it's specific to
         # the non-composable COUNT_DISTINCT rollup.

--- a/tiles/pyramid.py
+++ b/tiles/pyramid.py
@@ -287,6 +287,25 @@ _COUNT_DISTINCT_ROLLUP_NOTE = (
 )
 
 
+# Building tiles is not displaying them (#330). The done payload carries a
+# paste-ready MapLibre recipe, and weak models read that plus `status: "done"`
+# as "the map is updated", narrate success and never hand off — observed at
+# ~50% on qwen against the real apps. Nothing else in the response says the
+# layer is not on the map yet, and this text is read at exactly the moment that
+# decision is made, so it states the required next action first.
+#
+# The client tool is named because the generic phrasing is what failed: a model
+# that cannot identify which tool to call stops. Deployments without it are
+# still served — the MapLibre recipe remains, and is offered as the fallback.
+_DISPLAY_HANDOFF_NOTE = (
+    "Tiles are built, but they are NOT on the map yet. To display them, call "
+    "your client's map-display tool (`add_hex_tile_layer` in the geo-agent "
+    "apps) with `tile_url` copied verbatim from `tile_url_template` above, "
+    "plus a `value_column` from `value_columns`. If your client has no such "
+    "tool, `source` and `layer` are a paste-ready MapLibre recipe."
+)
+
+
 def _rollup_note(agg: str) -> str | None:
     """Human-facing caveat about rollup fidelity for aggs whose coarse levels
     are not exact. None when the agg is exact at every level."""
@@ -451,6 +470,7 @@ def cached_result_dict(plan: dict, cached: dict) -> dict:
     note = _rollup_note(cached.get("agg", ""))
     if note:
         result["rollup_note"] = note
+    result["next_step"] = _DISPLAY_HANDOFF_NOTE
     result.update(render_recipe(cached, plan["tile_url_template"]))
     return result
 
@@ -678,6 +698,7 @@ def build_hex_tiles(con: duckdb.DuckDBPyConnection, plan: dict) -> dict:
     note = _rollup_note(agg)
     if note:
         result["rollup_note"] = note
+    result["next_step"] = _DISPLAY_HANDOFF_NOTE
     result.update(render_recipe(metadata, plan["tile_url_template"]))
     return result
 


### PR DESCRIPTION
Refs #330. **Not yet model-validated** — see the validation section, which is the part
worth arguing with.

## What the model actually sees

I reproduced the failing condition before changing anything, per #330's own instruction to
ground-truth first: registered the same SQL twice on dev to force a cache hit. The payload
at the deciding moment is a complete `source` + `layer` MapLibre recipe, `cache_hit: true`,
`status: "done"` — and **nothing anywhere saying the layer is not yet displayed**.

`add_hex_tile_layer` appears **nowhere** in the docstring, the payload, or any guidance
file. `_done_response`'s own comment reads: *"Includes the paste-ready render recipe … so
the agent renders the result without further branching."*

Given that, "the map is updated, I'll narrate success" is the **reasonable** reading. The
model is not being careless; it is being told the output is terminal.

## Change

A `next_step` field on the done payload — following the existing `rollup_note` precedent,
so the required action is stated exactly where the decision is made:

> Tiles are built, but they are NOT on the map yet. To display them, call your client's
> map-display tool (`add_hex_tile_layer` in the geo-agent apps) with `tile_url` copied
> verbatim from `tile_url_template` above, plus a `value_column` from `value_columns`. If
> your client has no such tool, `source` and `layer` are a paste-ready MapLibre recipe.

The docstring now leads with the handoff instead of the recipe, and the "render what you
got" MapLibre block is reframed as the no-display-tool fallback.

**On all three done paths**, not one: `cached_result_dict`, the inline-build result, and
`server._done_response` (async poll). #331 is the precedent for a note reaching some paths
and not others.

**Naming the client tool** is a real coupling decision. Generic phrasing is close to what
the docstring already implied, and a model that cannot identify which tool to call stops —
which is the failure. Deployments without that tool are still served: the MapLibre recipe
remains and is now the explicit fallback rather than the headline.

**Cost:** +195 chars on a 6,473-char always-on description. (I first measured this as a
*reduction* by comparing a stripped docstring against a served description — it is an
increase.)

## Tests

Three, one per done path — including the **cache-hit path that no benchmark cell
exercises**. All three fail without the change. Full suite **437 passed**.

## Validation — what the matrix can and cannot show

Per AGENTS.md this needs the dev model suite. Being precise about what that will prove:

- **No-regression: testable.** The three `bio-hexmap-*` cells (geo-agent-benchmark#27) are
  in the `regression` tier and grade the handoff mechanically. They passed 6/6 before this
  change.
- **The fix on the poll path: partly testable.** Those cells register → poll → hand off, and
  `_done_response` is on that path, so they will see `next_step`.
- **The fix on the cache-hit path: NOT testable.** Every register in every matrix run so far
  has returned `status:"running"` — the branch #330 actually observed failing has never been
  exercised. Confirmed by geo-agent-benchmark#24's closing note; it needs a cell whose SQL
  hash is pre-warmed in setup, which is benchmark-side work.

So a green run here means "no regression, and the poll path carries the advice". It does
**not** mean the observed ~50% failure is fixed. I would not claim #330 closed on a green
matrix alone, and the honest close condition is a pre-warmed cache-hit cell.

Related caveat from the benchmark side: those traps have never fired in anger — all
observations to date are passes, so their discrimination is unproven.

## Not included

#330 step 3, improving the `could not resolve color-scale metadata` error text. That is
client-side (geo-agent), and belongs in that repo.