### PR TITLE
k8s(prod): promote v0.8.23 (register_hex_tiles display handoff)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     values: ["us-west"]
       containers:
       - name: server
-        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.22@sha256:10052de08be75ca09fe2b0f10970eea1b5c1058713cf3f13d9d6ec4d473f5cd4
+        image: ghcr.io/boettiger-lab/mcp-data-server:v0.8.23@sha256:ddc8fe69a382ff6ef09624f0e861c1a7cf465007ca1c8500ea288fab6cc4fc31
         imagePullPolicy: IfNotPresent
         env:
         # Release identity is supplied HERE, not baked into the image (#413). The
@@ -34,7 +34,7 @@ spec:
         # the image's own value is the commit it was built from, which stays correct
         # through a retag.
         - name: APP_VERSION
-          value: "v0.8.22"
+          value: "v0.8.23"
         - name: STAC_CATALOG_URL
           value: "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
         - name: MCP_PUBLIC_BASE_URL


### PR DESCRIPTION
Ships #330 via #416. **First release through the retag path (#413)** — and it delivers the
thing #366 tracked for weeks:

```
dev pods   sha256:ddc8fe69…
:main      sha256:ddc8fe69…
:v0.8.23   sha256:ddc8fe69…
```

**Prod pins the exact artifact the gate scored.** v0.8.21 and v0.8.22 each shipped a digest
dev never ran, because a release tag rebuilt the commit; both were only safe because I diffed
the served description by hand. That manual check is no longer the safety net.

`docker.yml` **did not fire on this tag** — confirmed, the last two builds are both `main`
pushes. `APP_VERSION` now comes from the Deployment, which is what made the rebuild
unnecessary; `check_k8s_image_pins.py` enforces that it matches the image tag.

## What ships

`register_hex_tiles` framed its output as a paste-ready MapLibre recipe and never named the
client tool that displays it. A weak model read `status:"done"`, concluded the map was
updated, narrated success and stopped — ~50% of hex requests on qwen. Every done response now
carries `next_step`.

## Gate

Dev @ `main@5f5cf42`. Regression tier, 7 apps / 82 cells / 2 trials (deepseek-v4-flash,
qwen3-small), then 3 trials on the biodiversity slice adding `z-ai/glm-5.2`.

| production model | hex-map cells |
|---|---|
| `deepseek-v4-flash` | 3/3 pass |
| `z-ai/glm-5.2` | 3/3 pass |

**10/10 trials across three models** called `add_hex_tile_layer` with a `tile_url` matching a
returned template — zero narrate-and-stop, zero fabricated URLs.

Delivery of the new field verified by result-length against the reg-410 control: done payloads
**1992 → 2366** median, distributions non-overlapping.

## The one gating failure was a grader defect, not a regression

`equals_result_field` compared against only the **first** `register_hex_tiles` result, so a
model that refined its SQL and re-registered was failed for handing off the correct (second)
URL. Diagnosed in `grade.py`, reported, fixed upstream (geo-agent-benchmark#66, which also
found a second instance in `_result_truncated`). Re-grading 209 cells flipped exactly the two
affected trials and nothing else.

`qwen3-small` fails that cell genuinely (`agg=MAX`, 3/3) — the canary working, and per the
gating rule not a ship blocker.

## Does NOT close #330

Every register in every run returned `"running"`, so the **cache-hit path the issue actually
reported has never been exercised**. Shipping improves the poll path; the originally-observed
failure remains unverified. Closing needs a cell whose SQL hash is pre-warmed in setup, which
is benchmark-side and shouldn't be written until the warm path is shown reproducible.